### PR TITLE
feat(ts-llm): tiktoken fallback estimator for missing-usage rows

### DIFF
--- a/console/src/components/llm-call-detail/summary-cards.tsx
+++ b/console/src/components/llm-call-detail/summary-cards.tsx
@@ -37,19 +37,33 @@ export function SummaryCards({ detail }: Props) {
           {formatMs(detail.e2e_latency_ms)}
         </div>
       </SummaryCard>
-      <SummaryCard label="Tokens">
-        <div className="flex items-center gap-3 tabular-nums">
+      <SummaryCard label={detail.tokens_estimated ? "Tokens (estimated)" : "Tokens"}>
+        <div
+          className="flex items-center gap-3 tabular-nums"
+          title={
+            detail.tokens_estimated
+              ? "Estimated by tokenizer (cl100k) — server returned no usage block"
+              : undefined
+          }
+        >
           <span className="flex flex-col">
             <span className="text-[10px] text-muted-foreground">in</span>
-            <span>{formatNumber(detail.input_tokens)}</span>
+            <span className={detail.tokens_estimated ? "text-amber-700 dark:text-amber-400" : ""}>
+              {detail.tokens_estimated ? "~" : ""}
+              {formatNumber(detail.input_tokens)}
+            </span>
           </span>
           <span className="flex flex-col">
             <span className="text-[10px] text-muted-foreground">out</span>
-            <span>{formatNumber(detail.output_tokens)}</span>
+            <span className={detail.tokens_estimated ? "text-amber-700 dark:text-amber-400" : ""}>
+              {detail.tokens_estimated ? "~" : ""}
+              {formatNumber(detail.output_tokens)}
+            </span>
           </span>
         </div>
         <div className="text-xs tabular-nums text-muted-foreground">
-          total: {formatNumber(detail.total_tokens)}
+          total: {detail.tokens_estimated ? "~" : ""}
+          {formatNumber(detail.total_tokens)}
         </div>
       </SummaryCard>
     </div>

--- a/console/src/components/turn-detail/call-card.tsx
+++ b/console/src/components/turn-detail/call-card.tsx
@@ -79,8 +79,22 @@ export function CallCard({
           )}>
             {speed === "error" && "✗ "}{formatMs(call.e2e_latency_ms)}
           </span>
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-            {formatNumber(call.input_tokens)}↑ {formatNumber(call.output_tokens)}↓
+          <span
+            className={cn(
+              "shrink-0 text-xs tabular-nums",
+              call.tokens_estimated
+                ? "text-amber-700 dark:text-amber-400"
+                : "text-muted-foreground",
+            )}
+            title={
+              call.tokens_estimated
+                ? "Estimated by tokenizer (cl100k) — server returned no usage block"
+                : undefined
+            }
+          >
+            {call.tokens_estimated ? "~" : ""}
+            {formatNumber(call.input_tokens)}↑ {call.tokens_estimated ? "~" : ""}
+            {formatNumber(call.output_tokens)}↓
           </span>
           {expanded ? <ChevronDown className="size-4 text-muted-foreground" /> : <ChevronRight className="size-4 text-muted-foreground" />}
         </div>

--- a/console/src/pages/llm-calls.tsx
+++ b/console/src/pages/llm-calls.tsx
@@ -84,10 +84,29 @@ function CellValue({ item, column }: { item: LlmCallListItem; column: SortKey })
     case "e2e_latency_ms":
       return <span className="tabular-nums">{formatMs(item.e2e_latency_ms)}</span>
     case "input_tokens":
-      return <span className="tabular-nums">{formatNumber(item.input_tokens)}</span>
+      return <TokenCell value={item.input_tokens} estimated={item.tokens_estimated} />
     case "output_tokens":
-      return <span className="tabular-nums">{formatNumber(item.output_tokens)}</span>
+      return <TokenCell value={item.output_tokens} estimated={item.tokens_estimated} />
   }
+}
+
+/**
+ * In/Out token cell. Prefixes the value with `~` and shows a tooltip when the
+ * row's tokens were filled in by the fallback tiktoken estimator (server
+ * returned no `usage` block — typical for LiteLLM proxy traffic).
+ */
+function TokenCell({ value, estimated }: { value: number | null; estimated?: boolean }) {
+  if (!estimated) {
+    return <span className="tabular-nums">{formatNumber(value)}</span>
+  }
+  return (
+    <span
+      className="tabular-nums text-amber-700 dark:text-amber-400"
+      title="Estimated by tokenizer — server returned no usage block"
+    >
+      ~{formatNumber(value)}
+    </span>
+  )
 }
 
 export function LlmCallsPage() {

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -21,6 +21,12 @@ export interface LlmCallListItem {
   e2e_latency_ms: number | null
   input_tokens: number | null
   output_tokens: number | null
+  /**
+   * True when input/output tokens came from the fallback tiktoken estimator
+   * instead of a wire-side `usage` block. Surfaces a `~` prefix on tokens
+   * columns. Optional because old API builds may not include it.
+   */
+  tokens_estimated?: boolean
   client_ip: string
   server_ip: string
   server_port: number
@@ -145,6 +151,8 @@ export interface AgentTurnCallItem {
   e2e_latency_ms: number | null
   input_tokens: number | null
   output_tokens: number | null
+  /** See LlmCallListItem.tokens_estimated. */
+  tokens_estimated?: boolean
   request_path: string
   client_ip: string
   client_port: number
@@ -176,6 +184,8 @@ export interface LlmCallDetail {
   input_tokens: number | null
   output_tokens: number | null
   total_tokens: number | null
+  /** See LlmCallListItem.tokens_estimated. */
+  tokens_estimated?: boolean
   ttft_ms: number | null
   e2e_latency_ms: number | null
   response_id: string | null

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -395,6 +395,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +467,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -859,6 +885,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1926,7 +1963,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -1946,7 +1983,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2269,6 +2306,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2696,6 +2739,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiktoken-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,9 +3115,11 @@ name = "ts-llm"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "regex",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "tokio",
  "tracing",
  "ts-common",

--- a/server/app/tokenscope/Cargo.toml
+++ b/server/app/tokenscope/Cargo.toml
@@ -27,6 +27,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 time.workspace = true
 axum.workspace = true
+duckdb.workspace = true
 rust-embed = { workspace = true, optional = true }
 mime_guess = { workspace = true, optional = true }
 

--- a/server/app/tokenscope/src/cmd/backfill_tokens.rs
+++ b/server/app/tokenscope/src/cmd/backfill_tokens.rs
@@ -1,0 +1,506 @@
+//! `tokenscope backfill-tokens` — fill in missing per-call token counts on
+//! historical rows by re-tokenizing their request/response bodies via the
+//! same wire-api walkers + tiktoken cl100k estimator the live processor
+//! uses for fresh traffic.
+//!
+//! Affects rows where:
+//!   * status_code is 2xx (or NULL — we still try, status filtering handled
+//!     defensively per row)
+//!   * input_tokens IS NULL OR input_tokens = 0
+//!   * AND output_tokens IS NULL OR output_tokens = 0
+//!   * response_body IS NOT NULL AND length > 0
+//!
+//! Idempotent — a re-run finds no zero-token rows and exits with a no-op
+//! summary. Refuses to run if the live tokenscope daemon holds the DB lock.
+//!
+//! Exit codes:
+//!   0 — success (rows updated, or zero rows to update)
+//!   1 — db open / IO / SQL error
+//!   2 — invalid arguments
+//!
+//! Logging:
+//!   INFO  — start banner, end summary
+//!   DEBUG (`-v`) — per-row "estimated call_id=… in=N out=M" line
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use clap::Args;
+use duckdb::Connection;
+use serde_json::Value;
+
+use ts_llm::token_estimator::{CL100kEstimator, TokenEstimator};
+use ts_llm::wire_apis as wa;
+
+#[derive(Debug, Args)]
+pub struct BackfillTokensArgs {
+    /// DuckDB file to scan. If omitted, falls back to `XDG_DATA_HOME` /
+    /// `~/.local/share/tokenscope/data/tokenscope.duckdb`.
+    #[arg(long)]
+    pub db_path: Option<PathBuf>,
+
+    /// Don't write — just log what would be updated.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Cap the number of rows touched (after filtering). Useful for
+    /// progressively rolling out on a large database. 0 means no cap.
+    #[arg(long, default_value_t = 0)]
+    pub limit: u64,
+
+    /// Skip the safety backup (`tokenscope.duckdb.pre_backfill_tokens_backup`).
+    /// Default: take a one-time backup if not already present.
+    #[arg(long)]
+    pub skip_backup: bool,
+}
+
+pub fn run(args: &BackfillTokensArgs) -> i32 {
+    let db_path = match resolve_db_path(args.db_path.as_deref()) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!("could not resolve db path: {e}");
+            return 2;
+        }
+    };
+    if !db_path.exists() {
+        tracing::error!("db file does not exist: {}", db_path.display());
+        return 1;
+    }
+
+    if !args.dry_run && !args.skip_backup {
+        if let Err(e) = ensure_backup(&db_path) {
+            tracing::error!("backup failed: {e}");
+            return 1;
+        }
+    }
+
+    let conn = match Connection::open(&db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                "failed to open {}: {e}\n\
+                 Hint: stop the live tokenscope daemon first — DuckDB \
+                 takes an exclusive lock while the writer is open.",
+                db_path.display()
+            );
+            return 1;
+        }
+    };
+
+    let estimator: Arc<dyn TokenEstimator> = Arc::new(CL100kEstimator::new());
+
+    let limit_clause = if args.limit > 0 {
+        format!(" LIMIT {}", args.limit)
+    } else {
+        String::new()
+    };
+    let select_sql = format!(
+        "SELECT id, wire_api, status_code, request_body, response_body \
+         FROM llm_calls \
+         WHERE COALESCE(input_tokens, 0) = 0 \
+           AND COALESCE(output_tokens, 0) = 0 \
+           AND response_body IS NOT NULL \
+           AND length(response_body) > 0\
+         ORDER BY request_time ASC{limit_clause}"
+    );
+    tracing::info!(
+        "backfill-tokens: scanning {}{}",
+        db_path.display(),
+        if args.dry_run { " (dry-run)" } else { "" }
+    );
+
+    let mut stmt = match conn.prepare(&select_sql) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to prepare select: {e}");
+            return 1;
+        }
+    };
+
+    let rows = match stmt.query_map([], |row| {
+        let id: String = row.get(0)?;
+        let wire_api: String = row.get(1)?;
+        let status: Option<u16> = row.get(2)?;
+        let req_body: Option<String> = row.get(3)?;
+        let resp_body: Option<String> = row.get(4)?;
+        Ok((id, wire_api, status, req_body, resp_body))
+    }) {
+        Ok(it) => it,
+        Err(e) => {
+            tracing::error!("failed to execute select: {e}");
+            return 1;
+        }
+    };
+
+    let mut scanned: u64 = 0;
+    let mut updated: u64 = 0;
+    let mut skipped_status: u64 = 0;
+    let mut skipped_no_body: u64 = 0;
+    let mut skipped_estimate_zero: u64 = 0;
+    let mut skipped_unknown_wire: u64 = 0;
+
+    let mut update_stmt = match conn.prepare(
+        "UPDATE llm_calls SET input_tokens = ?, output_tokens = ?, total_tokens = ? WHERE id = ?",
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("failed to prepare update: {e}");
+            return 1;
+        }
+    };
+
+    let row_iter: Vec<_> = rows.filter_map(|r| r.ok()).collect();
+    for (id, wire_api, status, req_body, resp_body) in row_iter {
+        scanned += 1;
+        // Defensive status filter: live processor only estimates on 2xx,
+        // mirror that here so a 5xx error body's noise doesn't get a count.
+        if let Some(s) = status {
+            if !(200..300).contains(&s) {
+                skipped_status += 1;
+                continue;
+            }
+        }
+        let resp_body_str = match resp_body {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                skipped_no_body += 1;
+                continue;
+            }
+        };
+        let resp_json: Value = match serde_json::from_str(&resp_body_str) {
+            Ok(v) => v,
+            Err(_) => {
+                skipped_no_body += 1;
+                continue;
+            }
+        };
+        let req_json: Value = req_body
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or(Value::Null);
+
+        let (est_in, est_out) = match wire_api.as_str() {
+            wa::OPENAI_CHAT => (
+                wa::openai::chat::estimate_input_tokens(&req_json, estimator.as_ref()),
+                wa::openai::chat::estimate_output_tokens(&resp_json, estimator.as_ref()),
+            ),
+            wa::OPENAI_RESPONSES => (
+                wa::openai::responses::estimate_input_tokens(&req_json, estimator.as_ref()),
+                wa::openai::responses::estimate_output_tokens(&resp_json, estimator.as_ref()),
+            ),
+            wa::ANTHROPIC => (
+                wa::anthropic::estimate_input_tokens(&req_json, estimator.as_ref()),
+                wa::anthropic::estimate_output_tokens(&resp_json, estimator.as_ref()),
+            ),
+            other => {
+                tracing::debug!("unknown wire_api={other} on call_id={id}; skipping");
+                skipped_unknown_wire += 1;
+                continue;
+            }
+        };
+
+        if est_in == 0 && est_out == 0 {
+            skipped_estimate_zero += 1;
+            continue;
+        }
+
+        tracing::debug!(
+            call_id = %id,
+            wire_api = %wire_api,
+            in_tokens = est_in,
+            out_tokens = est_out,
+            "would update tokens"
+        );
+
+        if !args.dry_run {
+            let total = est_in.saturating_add(est_out);
+            if let Err(e) = update_stmt.execute(duckdb::params![est_in, est_out, total, id]) {
+                tracing::error!(call_id = %id, "update failed: {e}");
+                continue;
+            }
+        }
+        updated += 1;
+    }
+
+    drop(update_stmt);
+    drop(stmt);
+    if !args.dry_run {
+        if let Err(e) = conn.execute("CHECKPOINT", []) {
+            tracing::warn!("CHECKPOINT failed (changes still committed via WAL): {e}");
+        }
+    }
+
+    tracing::info!(
+        scanned,
+        updated,
+        skipped_status,
+        skipped_no_body,
+        skipped_estimate_zero,
+        skipped_unknown_wire,
+        dry_run = args.dry_run,
+        "backfill-tokens done"
+    );
+    0
+}
+
+fn resolve_db_path(arg: Option<&Path>) -> Result<PathBuf, String> {
+    if let Some(p) = arg {
+        return Ok(p.to_path_buf());
+    }
+    let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
+    Ok(PathBuf::from(home).join(".local/share/tokenscope/data/tokenscope.duckdb"))
+}
+
+fn ensure_backup(db_path: &Path) -> Result<(), String> {
+    let mut backup = db_path.to_path_buf();
+    let new_ext = match db_path.extension() {
+        Some(ext) => format!("{}.pre_backfill_tokens_backup", ext.to_string_lossy()),
+        None => "pre_backfill_tokens_backup".to_string(),
+    };
+    backup.set_extension(new_ext);
+    if backup.exists() {
+        tracing::info!(
+            "backup already present at {} (skipping)",
+            backup.display()
+        );
+        return Ok(());
+    }
+    tracing::info!("backing up {} -> {}", db_path.display(), backup.display());
+    std::fs::copy(db_path, &backup).map_err(|e| format!("copy failed: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use duckdb::Connection;
+    use tempfile::tempdir;
+
+    /// Bootstrap a temp DuckDB matching the production llm_calls schema
+    /// (only the columns we actually read/write — minimal but matching
+    /// types). Returns (path, conn).
+    fn make_temp_db(dir: &std::path::Path) -> (PathBuf, Connection) {
+        let db = dir.join("test.duckdb");
+        let c = Connection::open(&db).expect("open");
+        c.execute_batch(
+            "CREATE TABLE llm_calls (
+                id VARCHAR PRIMARY KEY,
+                source_id VARCHAR DEFAULT '',
+                client_ip VARCHAR DEFAULT '',
+                client_port USMALLINT DEFAULT 0,
+                server_ip VARCHAR DEFAULT '',
+                server_port USMALLINT DEFAULT 0,
+                request_time TIMESTAMP DEFAULT now(),
+                wire_api VARCHAR,
+                model VARCHAR DEFAULT '',
+                api_type VARCHAR DEFAULT 'chat',
+                is_stream BOOLEAN DEFAULT false,
+                request_path VARCHAR DEFAULT '',
+                status_code USMALLINT,
+                input_tokens UINTEGER,
+                output_tokens UINTEGER,
+                total_tokens UINTEGER,
+                request_body VARCHAR,
+                response_body VARCHAR
+            );",
+        )
+        .unwrap();
+        (db, c)
+    }
+
+    fn insert(
+        c: &Connection,
+        id: &str,
+        wire_api: &str,
+        status: u16,
+        req: &str,
+        resp: &str,
+        in_t: Option<u32>,
+        out_t: Option<u32>,
+    ) {
+        c.execute(
+            "INSERT INTO llm_calls (id, wire_api, status_code, request_body, response_body, input_tokens, output_tokens) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            duckdb::params![id, wire_api, status, req, resp, in_t, out_t],
+        )
+        .unwrap();
+    }
+
+    fn token_pair(c: &Connection, id: &str) -> (Option<u32>, Option<u32>) {
+        c.query_row(
+            "SELECT input_tokens, output_tokens FROM llm_calls WHERE id = ?",
+            duckdb::params![id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn backfill_updates_zero_token_rows_and_leaves_wire_rows_alone() {
+        let dir = tempdir().unwrap();
+        let (db_path, conn) = make_temp_db(dir.path());
+
+        // 5 zero rows (LiteLLM-shape — no usage in response).
+        for i in 0..5 {
+            insert(
+                &conn,
+                &format!("zero-{i}"),
+                "openai-chat",
+                200,
+                &format!(
+                    r#"{{"model":"exp_model","messages":[{{"role":"user","content":"q{i}"}}]}}"#
+                ),
+                &format!(
+                    r#"{{"choices":[{{"message":{{"role":"assistant","content":"answer {i} with some longer text so the estimator returns something non-trivial"}}}}]}}"#
+                ),
+                Some(0),
+                Some(0),
+            );
+        }
+        // 5 wire-usage rows that must NOT be modified.
+        for i in 0..5 {
+            insert(
+                &conn,
+                &format!("wire-{i}"),
+                "openai-chat",
+                200,
+                &format!(
+                    r#"{{"model":"gpt-4","messages":[{{"role":"user","content":"q{i}"}}]}}"#
+                ),
+                &format!(
+                    r#"{{"choices":[{{"message":{{"role":"assistant","content":"answer {i}"}}}}],"usage":{{"prompt_tokens":7,"completion_tokens":4,"total_tokens":11}}}}"#
+                ),
+                Some(7),
+                Some(4),
+            );
+        }
+        drop(conn);
+
+        let args = BackfillTokensArgs {
+            db_path: Some(db_path.clone()),
+            dry_run: false,
+            limit: 0,
+            skip_backup: true,
+        };
+        let code = run(&args);
+        assert_eq!(code, 0);
+
+        // Verify zero rows now have tokens > 0.
+        let conn = Connection::open(&db_path).unwrap();
+        for i in 0..5 {
+            let (it, ot) = token_pair(&conn, &format!("zero-{i}"));
+            assert!(it.unwrap_or(0) > 0, "zero-{i} input not estimated");
+            assert!(ot.unwrap_or(0) > 0, "zero-{i} output not estimated");
+        }
+        // Wire rows untouched.
+        for i in 0..5 {
+            let (it, ot) = token_pair(&conn, &format!("wire-{i}"));
+            assert_eq!(it, Some(7), "wire-{i} input mutated");
+            assert_eq!(ot, Some(4), "wire-{i} output mutated");
+        }
+        drop(conn);
+
+        // Re-run is idempotent (touches 0 rows).
+        let code2 = run(&args);
+        assert_eq!(code2, 0);
+        let conn = Connection::open(&db_path).unwrap();
+        for i in 0..5 {
+            let (it1, ot1) = token_pair(&conn, &format!("zero-{i}"));
+            assert!(it1.unwrap_or(0) > 0); // still > 0
+            assert!(ot1.unwrap_or(0) > 0);
+        }
+    }
+
+    #[test]
+    fn dry_run_makes_no_changes() {
+        let dir = tempdir().unwrap();
+        let (db_path, conn) = make_temp_db(dir.path());
+        insert(
+            &conn,
+            "x",
+            "openai-chat",
+            200,
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+            r#"{"choices":[{"message":{"role":"assistant","content":"longer answer here"}}]}"#,
+            Some(0),
+            Some(0),
+        );
+        drop(conn);
+
+        let args = BackfillTokensArgs {
+            db_path: Some(db_path.clone()),
+            dry_run: true,
+            limit: 0,
+            skip_backup: true,
+        };
+        let code = run(&args);
+        assert_eq!(code, 0);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let (it, ot) = token_pair(&conn, "x");
+        assert_eq!(it, Some(0));
+        assert_eq!(ot, Some(0));
+    }
+
+    #[test]
+    fn skips_unknown_wire_api() {
+        let dir = tempdir().unwrap();
+        let (db_path, conn) = make_temp_db(dir.path());
+        insert(
+            &conn,
+            "weird",
+            "made-up-wire",
+            200,
+            r#"{}"#,
+            r#"{"some":"body"}"#,
+            Some(0),
+            Some(0),
+        );
+        drop(conn);
+
+        let args = BackfillTokensArgs {
+            db_path: Some(db_path.clone()),
+            dry_run: false,
+            limit: 0,
+            skip_backup: true,
+        };
+        let code = run(&args);
+        assert_eq!(code, 0);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let (it, ot) = token_pair(&conn, "weird");
+        assert_eq!(it, Some(0));
+        assert_eq!(ot, Some(0));
+    }
+
+    #[test]
+    fn skips_non_2xx_status() {
+        let dir = tempdir().unwrap();
+        let (db_path, conn) = make_temp_db(dir.path());
+        insert(
+            &conn,
+            "err",
+            "openai-chat",
+            500,
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+            r#"{"error":{"message":"oops"}}"#,
+            Some(0),
+            Some(0),
+        );
+        drop(conn);
+
+        let args = BackfillTokensArgs {
+            db_path: Some(db_path.clone()),
+            dry_run: false,
+            limit: 0,
+            skip_backup: true,
+        };
+        let code = run(&args);
+        assert_eq!(code, 0);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let (it, ot) = token_pair(&conn, "err");
+        assert_eq!(it, Some(0));
+        assert_eq!(ot, Some(0));
+    }
+}

--- a/server/app/tokenscope/src/cmd/mod.rs
+++ b/server/app/tokenscope/src/cmd/mod.rs
@@ -2,5 +2,6 @@
 //! capture pipeline and lives in `main.rs`; everything here is for
 //! diagnostic / pre-flight subcommands that exit before any pipeline spawn.
 
+pub mod backfill_tokens;
 pub mod doctor;
 pub mod validate;

--- a/server/app/tokenscope/src/main.rs
+++ b/server/app/tokenscope/src/main.rs
@@ -131,6 +131,10 @@ enum Command {
     },
     /// Run pre-flight diagnostics (config, capture privileges, storage, API port, console).
     Doctor(cmd::doctor::DoctorArgs),
+    /// Re-tokenize historical rows whose `usage` block was missing on the wire,
+    /// filling in input_tokens / output_tokens / total_tokens via cl100k.
+    /// Stop the live tokenscope daemon first — DuckDB takes an exclusive lock.
+    BackfillTokens(cmd::backfill_tokens::BackfillTokensArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -197,6 +201,11 @@ async fn main() {
         }
         Some(Command::Doctor(args)) => {
             let code = cmd::doctor::run(cli.config.as_deref(), &args).await;
+            std::process::exit(code);
+        }
+        Some(Command::BackfillTokens(args)) => {
+            init_logger(&cli.color, cli.verbose);
+            let code = cmd::backfill_tokens::run(&args);
             std::process::exit(code);
         }
         None => {

--- a/server/ts-common/src/internal_metrics.rs
+++ b/server/ts-common/src/internal_metrics.rs
@@ -180,6 +180,7 @@ define_metrics! {
     LlmGenericToolIdCanonicalized  => { kind: Counter, group: Llm, short: "generic_tool_id_canonicalized"   },
     LlmGenericSessionIdSynthFailed => { kind: Counter, group: Llm, short: "generic_session_id_synth_failed" },
     LlmHeartbeatsReceived          => { kind: Counter, group: Llm, short: "llm_heartbeats_received"      },
+    LlmTokensEstimated             => { kind: Counter, group: Llm, short: "tokens_estimated"            },
 
     // -- Turn tracking --
     // `turn_heartbeats_dropped` is bumped at the LLM stage's try_send site

--- a/server/ts-llm/Cargo.toml
+++ b/server/ts-llm/Cargo.toml
@@ -14,3 +14,5 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+tiktoken-rs = "0.11"
+regex = "1"

--- a/server/ts-llm/src/lib.rs
+++ b/server/ts-llm/src/lib.rs
@@ -4,6 +4,7 @@ pub mod parsed_json;
 pub mod processor;
 pub mod profile;
 pub mod stage;
+pub mod token_estimator;
 pub mod wire_api_registry;
 pub mod wire_apis;
 
@@ -12,4 +13,8 @@ pub use parsed_json::ParsedJson;
 pub use processor::build_agent_call_info;
 pub use profile::{AgentProfile, AgentProfileRegistry, SessionIdExtraction};
 pub use stage::spawn_llm_stage;
+pub use token_estimator::{
+    collect_anthropic_assistant_text, collect_chat_assistant_text,
+    collect_responses_output_text, extract_think_blocks, CL100kEstimator, TokenEstimator,
+};
 pub use wire_api_registry::WireApiRegistry;

--- a/server/ts-llm/src/processor.rs
+++ b/server/ts-llm/src/processor.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::model::{AgentCallInfo, ApiType, LlmCall, LlmCallStart, LlmEvent};
 use crate::parsed_json::ParsedJson;
 use crate::profile::{parse_bodies, AgentProfileRegistry, CallCtx};
+use crate::token_estimator::{CL100kEstimator, TokenEstimator};
 use crate::wire_api_registry::WireApiRegistry;
 
 /// Processes `HttpJoinerEvent`s and extracts `LlmCall` records. Stateless —
@@ -17,6 +18,9 @@ pub struct LlmProcessor {
     wire_apis: Arc<WireApiRegistry>,
     registry: Arc<AgentProfileRegistry>,
     metrics: MetricsWorker,
+    /// Fallback tokenizer used when the wire response omits `usage`. Held as
+    /// `Arc<dyn>` so tests can inject a deterministic stub.
+    estimator: Arc<dyn TokenEstimator>,
 }
 
 impl LlmProcessor {
@@ -25,10 +29,26 @@ impl LlmProcessor {
         registry: Arc<AgentProfileRegistry>,
         metrics: MetricsWorker,
     ) -> Self {
+        Self::with_estimator(
+            wire_apis,
+            registry,
+            metrics,
+            Arc::new(CL100kEstimator::new()),
+        )
+    }
+
+    /// Same as `new` but accepts a custom estimator. Used by tests.
+    pub fn with_estimator(
+        wire_apis: Arc<WireApiRegistry>,
+        registry: Arc<AgentProfileRegistry>,
+        metrics: MetricsWorker,
+        estimator: Arc<dyn TokenEstimator>,
+    ) -> Self {
         Self {
             wire_apis,
             registry,
             metrics,
+            estimator,
         }
     }
 
@@ -91,13 +111,85 @@ impl LlmProcessor {
         // assembled across events; non-SSE binds it to `response.body` and
         // lazy-parses on first read. Either way, downstream readers get the
         // canonical Value via `resp_body_cache.get()`.
-        let (resp_info, resp_body_cache) = if !sse_events.is_empty() {
+        let (mut resp_info, resp_body_cache) = if !sse_events.is_empty() {
             extractor.extract_sse(&sse_events)
         } else {
             let cache = ParsedJson::from_bytes(response.body.clone());
             let info = extractor.extract_response(&response, &cache);
             (info, cache)
         };
+
+        // Fallback estimator: when the wire response omitted `usage` (LiteLLM
+        // proxy + similar upstreams) and the response was a real completion,
+        // tokenize the request and assembled response bodies via tiktoken
+        // (cl100k_base) and patch the counts. The DEBUG log lets `-v` users
+        // see exactly which calls were estimated. Bumps the
+        // `LlmTokensEstimated` metric so the share is visible in /metrics.
+        if response.status >= 200
+            && response.status < 300
+            && resp_info.input_tokens.unwrap_or(0) == 0
+            && resp_info.output_tokens.unwrap_or(0) == 0
+        {
+            if let Some(body_str) = resp_info.response_body.as_deref() {
+                if let Ok(resp_json) = serde_json::from_str::<Value>(body_str) {
+                    let req_json: Value = std::str::from_utf8(&request.body)
+                        .ok()
+                        .and_then(|s| serde_json::from_str(s).ok())
+                        .unwrap_or(Value::Null);
+                    let est_in;
+                    let est_out;
+                    match extractor.name() {
+                        crate::wire_apis::OPENAI_CHAT => {
+                            est_in = crate::wire_apis::openai::chat::estimate_input_tokens(
+                                &req_json,
+                                self.estimator.as_ref(),
+                            );
+                            est_out = crate::wire_apis::openai::chat::estimate_output_tokens(
+                                &resp_json,
+                                self.estimator.as_ref(),
+                            );
+                        }
+                        crate::wire_apis::OPENAI_RESPONSES => {
+                            est_in = crate::wire_apis::openai::responses::estimate_input_tokens(
+                                &req_json,
+                                self.estimator.as_ref(),
+                            );
+                            est_out = crate::wire_apis::openai::responses::estimate_output_tokens(
+                                &resp_json,
+                                self.estimator.as_ref(),
+                            );
+                        }
+                        crate::wire_apis::ANTHROPIC => {
+                            est_in = crate::wire_apis::anthropic::estimate_input_tokens(
+                                &req_json,
+                                self.estimator.as_ref(),
+                            );
+                            est_out = crate::wire_apis::anthropic::estimate_output_tokens(
+                                &resp_json,
+                                self.estimator.as_ref(),
+                            );
+                        }
+                        _ => {
+                            est_in = 0;
+                            est_out = 0;
+                        }
+                    }
+                    if est_in > 0 || est_out > 0 {
+                        resp_info.input_tokens = Some(est_in);
+                        resp_info.output_tokens = Some(est_out);
+                        resp_info.total_tokens = Some(est_in.saturating_add(est_out));
+                        self.metrics.counter(Metric::LlmTokensEstimated).inc();
+                        tracing::debug!(
+                            wire_api = extractor.name(),
+                            model = %resp_info.model.as_deref().unwrap_or("unknown"),
+                            input_tokens = est_in,
+                            output_tokens = est_out,
+                            "estimated tokens (no usage in wire payload)"
+                        );
+                    }
+                }
+            }
+        }
 
         let model = resp_info.model.unwrap_or(req_info.model);
 
@@ -280,6 +372,7 @@ mod tests {
                 Metric::LlmGenericToolIdCanonicalized,
                 Metric::LlmGenericSessionIdSynthFailed,
                 Metric::LlmHeartbeatsReceived,
+                Metric::LlmTokensEstimated,
             ],
         );
         let _svc = sys.start();
@@ -388,6 +481,88 @@ mod tests {
         };
         let events = proc.process(HttpJoinerEvent::Request(Arc::new(req)));
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn exchange_no_usage_triggers_estimator_chat() {
+        // Regression: LiteLLM-proxy + similar upstreams omit `usage`. The
+        // live processor must fall back to the tiktoken estimator and write
+        // non-zero input/output tokens, otherwise the row shows as 0/0 in
+        // the console.
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics());
+        let req_body = json!({
+            "model":"exp_model",
+            "messages":[
+                {"role":"system","content":"You are helpful"},
+                {"role":"user","content":"What is the capital of France?"}
+            ]
+        });
+        let req = openai_request(&req_body);
+        // Note: NO `usage` field on the response — the bug we're fixing.
+        let resp_body = json!({
+            "id":"chatcmpl-noUsage",
+            "model":"exp_model",
+            "choices":[{
+                "index":0,
+                "message":{"role":"assistant","content":"The capital of France is Paris."},
+                "finish_reason":"stop"
+            }]
+        });
+        let (request, response) = exchange_parts(req, Bytes::from(resp_body.to_string()), false);
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-noUsage".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: vec![],
+        });
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                let it = call
+                    .input_tokens
+                    .expect("input_tokens populated by estimator");
+                let ot = call
+                    .output_tokens
+                    .expect("output_tokens populated by estimator");
+                assert!(it > 0, "estimator should produce >0 input tokens");
+                assert!(ot > 0, "estimator should produce >0 output tokens");
+                assert_eq!(call.total_tokens, Some(it + ot));
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    #[test]
+    fn exchange_with_usage_does_not_run_estimator() {
+        // Negative case: when the wire usage is present, the estimator must
+        // NOT run — assertable by checking the tokens equal the wire values
+        // exactly (estimator would replace them).
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics());
+        let req_body = json!({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]});
+        let req = openai_request(&req_body);
+        let resp_body = json!({
+            "id":"chatcmpl-withUsage",
+            "model":"gpt-4",
+            "choices":[{"index":0,"message":{"role":"assistant","content":"a much longer answer than the input prompt to ensure clear divergence between estimator output and wire usage values"},"finish_reason":"stop"}],
+            "usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+        });
+        let (request, response) = exchange_parts(req, Bytes::from(resp_body.to_string()), false);
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-withUsage".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: vec![],
+        });
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                assert_eq!(call.input_tokens, Some(1));
+                assert_eq!(call.output_tokens, Some(1));
+                assert_eq!(call.total_tokens, Some(2));
+            }
+            _ => panic!("expected Complete"),
+        }
     }
 
     #[test]

--- a/server/ts-llm/src/stage.rs
+++ b/server/ts-llm/src/stage.rs
@@ -73,6 +73,7 @@ pub fn spawn_llm_stage(
                 Metric::LlmGenericToolIdCanonicalized,
                 Metric::LlmGenericSessionIdSynthFailed,
                 Metric::LlmHeartbeatsReceived,
+                Metric::LlmTokensEstimated,
                 Metric::MetricsHeartbeatsDropped,
                 Metric::TurnHeartbeatsDropped,
             ],

--- a/server/ts-llm/src/token_estimator.rs
+++ b/server/ts-llm/src/token_estimator.rs
@@ -1,0 +1,491 @@
+//! Fallback token estimator for LLM calls whose response payload omits the
+//! `usage` field (LiteLLM proxy + assorted self-hosted backends do this).
+//!
+//! Built around the `cl100k_base` BPE table from `tiktoken-rs`. cl100k is the
+//! tokenizer for OpenAI's GPT-4 / GPT-4o / GPT-3.5 family; for non-OpenAI
+//! models proxied through OpenAI-shaped APIs (Qwen / GLM / DeepSeek behind
+//! LiteLLM) the count drifts roughly +/-15-25%. For Anthropic the drift is
+//! similar — Anthropic's tokenizer is not public. The number is meant to be
+//! "good enough for capacity planning and rough cost estimates"; never
+//! authoritative.
+//!
+//! Estimates produced by this module are always rounded to `u32`. Zero-text
+//! inputs return zero. Concurrency: `CL100kEstimator` is `Send + Sync`; load
+//! it once per process.
+//!
+//! # Reasoning-token compatibility
+//!
+//! Reasoning text is emitted by different servers under different field names
+//! and shapes; the estimator must count it once regardless of channel:
+//!
+//! * `message.reasoning_content` — DeepSeek-R1 / Qwen3 native shape.
+//! * `message.reasoning` — vLLM 0.17+ rename on the patched B300 image.
+//!   Servers emit one OR the other; some emit both with identical payload.
+//! * `<think>...</think>` blocks embedded inside `message.content` when
+//!   `--reasoning-parser` was off on the server.
+//! * Anthropic `content[*].type == "thinking"` extended-thinking blocks.
+//! * OpenAI Responses `output[*].type == "reasoning"` blocks (with
+//!   `summary[*].text` / inner `content[*].text`).
+//!
+//! `collect_chat_assistant_text` handles the OpenAI Chat shape with
+//! deduplication by exact-string equality. The Anthropic / Responses shapes
+//! are walked by their respective wire-api walkers, but both delegate the
+//! `<think>...</think>` extraction back here via `extract_think_blocks`.
+
+use std::sync::Arc;
+
+use regex::Regex;
+use serde_json::Value;
+use tiktoken_rs::{cl100k_base, CoreBPE};
+
+/// Counts tokens in arbitrary text. Implementations must be deterministic and
+/// thread-safe.
+pub trait TokenEstimator: Send + Sync {
+    fn count_text(&self, text: &str) -> u32;
+}
+
+/// Production estimator using `tiktoken-rs::cl100k_base`. Construction loads
+/// the bundled BPE table (~4MB binary). Construct once per process and share.
+pub struct CL100kEstimator {
+    bpe: CoreBPE,
+}
+
+impl CL100kEstimator {
+    pub fn new() -> Self {
+        Self {
+            bpe: cl100k_base().expect("tiktoken-rs cl100k_base bundled BPE must load"),
+        }
+    }
+
+    pub fn shared() -> Arc<dyn TokenEstimator> {
+        Arc::new(Self::new())
+    }
+}
+
+impl Default for CL100kEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenEstimator for CL100kEstimator {
+    fn count_text(&self, text: &str) -> u32 {
+        if text.is_empty() {
+            return 0;
+        }
+        // `encode_with_special_tokens` is the tiktoken behavior used by the
+        // OpenAI client libraries when computing prompt token budget; it
+        // matches what the server would have counted (modulo cross-model
+        // drift documented at module level).
+        self.bpe.encode_with_special_tokens(text).len() as u32
+    }
+}
+
+/// Strip every `<think>...</think>` block from `content` and return them as a
+/// `Vec<String>`. Returns the cleaned content as the second tuple element.
+/// Multiline blocks are supported. The returned think-block strings are the
+/// inner contents — without the surrounding tags.
+pub fn extract_think_blocks(content: &str) -> (Vec<String>, String) {
+    // Compile once. The regex is small; `OnceLock` would micro-optimize but
+    // adds noise. `(?s)` makes `.` match newlines.
+    static PATTERN: &str = r"(?s)<think>(.*?)</think>";
+    let re = Regex::new(PATTERN).expect("static think regex");
+    let mut blocks: Vec<String> = Vec::new();
+    let mut cleaned = String::with_capacity(content.len());
+    let mut last_end = 0;
+    for caps in re.captures_iter(content) {
+        let whole = caps.get(0).expect("regex capture 0");
+        let inner = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        cleaned.push_str(&content[last_end..whole.start()]);
+        blocks.push(inner.to_string());
+        last_end = whole.end();
+    }
+    cleaned.push_str(&content[last_end..]);
+    (blocks, cleaned)
+}
+
+fn push_unique(frags: &mut Vec<String>, s: String) {
+    if !s.is_empty() && !frags.iter().any(|f| f == &s) {
+        frags.push(s);
+    }
+}
+
+/// Concatenate every distinct piece of assistant-emitted text on an
+/// OpenAI-Chat-shaped `message` object: reasoning_content, reasoning,
+/// content (with `<think>` blocks separated and stripped), and serialized
+/// tool_calls. Deduplicates by exact-string equality so the same trace
+/// emitted via both `reasoning_content` and `reasoning` is counted once.
+pub fn collect_chat_assistant_text(message: &Value) -> String {
+    let mut frags: Vec<String> = Vec::new();
+
+    if let Some(s) = message.get("reasoning_content").and_then(|v| v.as_str()) {
+        push_unique(&mut frags, s.to_string());
+    }
+    if let Some(s) = message.get("reasoning").and_then(|v| v.as_str()) {
+        push_unique(&mut frags, s.to_string());
+    }
+    if let Some(c) = message.get("content").and_then(|v| v.as_str()) {
+        let (think_blocks, rest) = extract_think_blocks(c);
+        for tb in think_blocks {
+            push_unique(&mut frags, tb);
+        }
+        push_unique(&mut frags, rest);
+    } else if let Some(arr) = message.get("content").and_then(|v| v.as_array()) {
+        // OpenAI multipart content (text + image_url etc.). Pull only text parts.
+        for part in arr {
+            if let Some(kind) = part.get("type").and_then(|v| v.as_str()) {
+                if kind == "text" || kind == "input_text" || kind == "output_text" {
+                    if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                        let (tb, rest) = extract_think_blocks(t);
+                        for b in tb {
+                            push_unique(&mut frags, b);
+                        }
+                        push_unique(&mut frags, rest);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(tcs) = message.get("tool_calls").and_then(|v| v.as_array()) {
+        for tc in tcs {
+            if let Ok(s) = serde_json::to_string(tc) {
+                push_unique(&mut frags, s);
+            }
+        }
+    }
+
+    frags.join("\n")
+}
+
+/// Concatenate distinct text on an Anthropic-shaped assistant message. The
+/// Anthropic shape is `content: [{type: "text"|"thinking"|"tool_use", ...}]`.
+/// `thinking` blocks carry their text under `.thinking`; `text` under `.text`;
+/// `tool_use` is JSON-serialized whole. `<think>` substrings inside text
+/// blocks are also extracted (defensive — Anthropic shouldn't emit them but
+/// some bridged proxies do).
+pub fn collect_anthropic_assistant_text(message: &Value) -> String {
+    let mut frags: Vec<String> = Vec::new();
+
+    let blocks = message.get("content").and_then(|v| v.as_array());
+    if let Some(blocks) = blocks {
+        for blk in blocks {
+            let kind = blk.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            match kind {
+                "thinking" => {
+                    if let Some(t) = blk.get("thinking").and_then(|v| v.as_str()) {
+                        push_unique(&mut frags, t.to_string());
+                    }
+                }
+                "text" => {
+                    if let Some(t) = blk.get("text").and_then(|v| v.as_str()) {
+                        let (tb, rest) = extract_think_blocks(t);
+                        for b in tb {
+                            push_unique(&mut frags, b);
+                        }
+                        push_unique(&mut frags, rest);
+                    }
+                }
+                "tool_use" => {
+                    if let Ok(s) = serde_json::to_string(blk) {
+                        push_unique(&mut frags, s);
+                    }
+                }
+                _ => {}
+            }
+        }
+    } else if let Some(s) = message.get("content").and_then(|v| v.as_str()) {
+        let (tb, rest) = extract_think_blocks(s);
+        for b in tb {
+            push_unique(&mut frags, b);
+        }
+        push_unique(&mut frags, rest);
+    }
+
+    frags.join("\n")
+}
+
+/// Concatenate distinct text on an OpenAI Responses-shaped output. The
+/// Responses shape is `output: [{type: "message"|"reasoning"|...}]`. A
+/// `reasoning` item may carry `summary[*].text` and/or inner `content[*].text`.
+/// A `message` item carries `content: [{type: "output_text", text}]`.
+pub fn collect_responses_output_text(output: &Value) -> String {
+    let mut frags: Vec<String> = Vec::new();
+
+    let items = match output.as_array() {
+        Some(a) => a,
+        None => return String::new(),
+    };
+
+    for item in items {
+        let kind = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match kind {
+            "reasoning" => {
+                if let Some(summary) = item.get("summary").and_then(|v| v.as_array()) {
+                    for s in summary {
+                        if let Some(t) = s.get("text").and_then(|v| v.as_str()) {
+                            push_unique(&mut frags, t.to_string());
+                        }
+                    }
+                }
+                if let Some(inner) = item.get("content").and_then(|v| v.as_array()) {
+                    for c in inner {
+                        if let Some(t) = c.get("text").and_then(|v| v.as_str()) {
+                            push_unique(&mut frags, t.to_string());
+                        }
+                    }
+                }
+            }
+            "message" => {
+                if let Some(content) = item.get("content").and_then(|v| v.as_array()) {
+                    for c in content {
+                        let ck = c.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        if ck == "output_text" || ck == "input_text" || ck == "text" {
+                            if let Some(t) = c.get("text").and_then(|v| v.as_str()) {
+                                let (tb, rest) = extract_think_blocks(t);
+                                for b in tb {
+                                    push_unique(&mut frags, b);
+                                }
+                                push_unique(&mut frags, rest);
+                            }
+                        }
+                    }
+                }
+            }
+            "function_call" | "tool_call" => {
+                if let Ok(s) = serde_json::to_string(item) {
+                    push_unique(&mut frags, s);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    frags.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn est() -> CL100kEstimator {
+        CL100kEstimator::new()
+    }
+
+    #[test]
+    fn count_text_zero_on_empty() {
+        assert_eq!(est().count_text(""), 0);
+    }
+
+    #[test]
+    fn count_text_positive_and_stable() {
+        let e = est();
+        let a = e.count_text("Hello world");
+        let b = e.count_text("Hello world");
+        assert!(a > 0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn count_text_in_known_range() {
+        // "Hello world" tokenizes to 2 in cl100k_base.
+        assert_eq!(est().count_text("Hello world"), 2);
+    }
+
+    #[test]
+    fn extract_think_blocks_single() {
+        let (blocks, rest) = extract_think_blocks("<think>plan</think>answer");
+        assert_eq!(blocks, vec!["plan".to_string()]);
+        assert_eq!(rest, "answer");
+    }
+
+    #[test]
+    fn extract_think_blocks_multiple_and_multiline() {
+        let s = "<think>step\n1</think>mid<think>step\n2</think>end";
+        let (blocks, rest) = extract_think_blocks(s);
+        assert_eq!(blocks, vec!["step\n1".to_string(), "step\n2".to_string()]);
+        assert_eq!(rest, "midend");
+    }
+
+    #[test]
+    fn extract_think_blocks_none() {
+        let (blocks, rest) = extract_think_blocks("plain answer");
+        assert!(blocks.is_empty());
+        assert_eq!(rest, "plain answer");
+    }
+
+    #[test]
+    fn chat_collect_reasoning_content_only() {
+        let m = json!({"role":"assistant","reasoning_content":"thoughts","content":""});
+        let text = collect_chat_assistant_text(&m);
+        assert!(text.contains("thoughts"));
+    }
+
+    #[test]
+    fn chat_collect_reasoning_field_only() {
+        // vLLM 0.17+ rename: payload arrives under `reasoning` not `reasoning_content`.
+        let m = json!({"role":"assistant","reasoning":"thoughts","content":""});
+        let text = collect_chat_assistant_text(&m);
+        assert!(text.contains("thoughts"));
+    }
+
+    #[test]
+    fn chat_collect_dedupes_reasoning_content_eq_reasoning() {
+        // Server emits the SAME trace under both keys (some bridged proxies do).
+        let m = json!({
+            "role":"assistant",
+            "reasoning_content":"long trace here",
+            "reasoning":"long trace here",
+            "content":"final answer"
+        });
+        let text = collect_chat_assistant_text(&m);
+        // "long trace here" must appear exactly once.
+        assert_eq!(text.matches("long trace here").count(), 1);
+        assert!(text.contains("final answer"));
+    }
+
+    #[test]
+    fn chat_collect_extracts_think_block_from_content() {
+        let m = json!({
+            "role":"assistant",
+            "content":"<think>Let me reason</think>The answer is 42."
+        });
+        let text = collect_chat_assistant_text(&m);
+        assert!(text.contains("Let me reason"));
+        assert!(text.contains("The answer is 42."));
+        // Tag itself must be stripped.
+        assert!(!text.contains("<think>"));
+    }
+
+    #[test]
+    fn chat_collect_dedupes_think_against_reasoning_field() {
+        let m = json!({
+            "role":"assistant",
+            "reasoning":"Let me reason",
+            "content":"<think>Let me reason</think>final"
+        });
+        let text = collect_chat_assistant_text(&m);
+        assert_eq!(text.matches("Let me reason").count(), 1);
+    }
+
+    #[test]
+    fn chat_collect_includes_tool_calls() {
+        let m = json!({
+            "role":"assistant",
+            "content":null,
+            "tool_calls":[{
+                "id":"call_abc",
+                "type":"function",
+                "function":{"name":"do_thing","arguments":"{\"k\":\"v\"}"}
+            }]
+        });
+        let text = collect_chat_assistant_text(&m);
+        assert!(text.contains("do_thing"));
+        assert!(text.contains("call_abc"));
+    }
+
+    #[test]
+    fn chat_collect_multipart_content() {
+        let m = json!({
+            "role":"assistant",
+            "content":[
+                {"type":"text","text":"<think>x</think>hello"}
+            ]
+        });
+        let text = collect_chat_assistant_text(&m);
+        assert!(text.contains("x"));
+        assert!(text.contains("hello"));
+        assert!(!text.contains("<think>"));
+    }
+
+    #[test]
+    fn anthropic_collect_thinking_and_text() {
+        let m = json!({
+            "role":"assistant",
+            "content":[
+                {"type":"thinking","thinking":"step by step"},
+                {"type":"text","text":"final answer"}
+            ]
+        });
+        let text = collect_anthropic_assistant_text(&m);
+        assert!(text.contains("step by step"));
+        assert!(text.contains("final answer"));
+    }
+
+    #[test]
+    fn anthropic_collect_thinking_dedup_against_text_think_block() {
+        // Defensive: if a bridged proxy double-emits the trace as both a
+        // thinking block AND inline `<think>` inside a text block, count once.
+        let m = json!({
+            "role":"assistant",
+            "content":[
+                {"type":"thinking","thinking":"trace"},
+                {"type":"text","text":"<think>trace</think>answer"}
+            ]
+        });
+        let text = collect_anthropic_assistant_text(&m);
+        assert_eq!(text.matches("trace").count(), 1);
+        assert!(text.contains("answer"));
+    }
+
+    #[test]
+    fn anthropic_collect_tool_use() {
+        let m = json!({
+            "role":"assistant",
+            "content":[
+                {"type":"tool_use","id":"toolu_x","name":"foo","input":{"q":"v"}}
+            ]
+        });
+        let text = collect_anthropic_assistant_text(&m);
+        assert!(text.contains("toolu_x"));
+        assert!(text.contains("foo"));
+    }
+
+    #[test]
+    fn responses_collect_reasoning_summary_and_message() {
+        let output = json!([
+            {"type":"reasoning","summary":[{"type":"summary_text","text":"sum"}],
+             "content":[{"type":"reasoning_text","text":"deep"}]},
+            {"type":"message","content":[{"type":"output_text","text":"answer"}]}
+        ]);
+        let text = collect_responses_output_text(&output);
+        assert!(text.contains("sum"));
+        assert!(text.contains("deep"));
+        assert!(text.contains("answer"));
+    }
+
+    #[test]
+    fn responses_collect_dedupes_repeated_summary() {
+        let output = json!([
+            {"type":"reasoning","summary":[
+                {"text":"trace"},
+                {"text":"trace"}
+            ]},
+            {"type":"message","content":[{"type":"output_text","text":"ok"}]}
+        ]);
+        let text = collect_responses_output_text(&output);
+        assert_eq!(text.matches("trace").count(), 1);
+    }
+
+    #[test]
+    fn responses_collect_function_call() {
+        let output = json!([
+            {"type":"function_call","name":"do_it","arguments":"{}","call_id":"call_xyz"}
+        ]);
+        let text = collect_responses_output_text(&output);
+        assert!(text.contains("do_it"));
+        assert!(text.contains("call_xyz"));
+    }
+
+    #[test]
+    fn count_text_through_estimator_on_collected_text() {
+        let m = json!({
+            "role":"assistant",
+            "reasoning_content":"some thinking",
+            "content":"final"
+        });
+        let text = collect_chat_assistant_text(&m);
+        let n = est().count_text(&text);
+        assert!(n > 0);
+    }
+}

--- a/server/ts-llm/src/wire_apis/anthropic.rs
+++ b/server/ts-llm/src/wire_apis/anthropic.rs
@@ -675,6 +675,113 @@ pub fn extract_assistant_text_value(resp: &Value) -> Option<String> {
     }
 }
 
+// ─────────────────────────── Token estimation ─────────────────────────────
+
+use crate::token_estimator::{collect_anthropic_assistant_text, TokenEstimator};
+
+/// True iff the response body carried any Anthropic `usage` field with a
+/// non-zero count.
+pub fn usage_present(body: &Value) -> bool {
+    let u = match body.get("usage") {
+        Some(v) => v,
+        None => return false,
+    };
+    if !u.is_object() {
+        return false;
+    }
+    u.get("input_tokens")
+        .and_then(|v| v.as_u64())
+        .map(|n| n > 0)
+        .unwrap_or(false)
+        || u.get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n > 0)
+            .unwrap_or(false)
+}
+
+/// Walk an assistant-shaped Anthropic body (top-level `content[*]` blocks)
+/// and produce one concatenated, deduped string of all reasoning + text +
+/// serialized tool_use blocks.
+pub fn collected_response_text(body: &Value) -> String {
+    collect_anthropic_assistant_text(body)
+}
+
+/// Estimate input tokens for an Anthropic request. Walks `system` (string
+/// or `[{type:"text",text:...}]`), `messages[*]` (with role + content array
+/// or string), and `tools[*]` (each schema serialized whole).
+pub fn estimate_input_tokens(req: &Value, est: &dyn TokenEstimator) -> u32 {
+    let mut total: u32 = 0;
+
+    // system: string OR array of {type:"text",text:...}
+    if let Some(s) = req.get("system").and_then(|v| v.as_str()) {
+        total = total.saturating_add(est.count_text(s));
+    } else if let Some(arr) = req.get("system").and_then(|v| v.as_array()) {
+        for blk in arr {
+            if let Some(t) = blk.get("text").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(t));
+            }
+        }
+    }
+
+    if let Some(msgs) = req.get("messages").and_then(|v| v.as_array()) {
+        for m in msgs {
+            if let Some(role) = m.get("role").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(role));
+            }
+            if let Some(s) = m.get("content").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(s));
+            } else if let Some(arr) = m.get("content").and_then(|v| v.as_array()) {
+                for blk in arr {
+                    let kind = blk.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    match kind {
+                        "text" => {
+                            if let Some(t) = blk.get("text").and_then(|v| v.as_str()) {
+                                total = total.saturating_add(est.count_text(t));
+                            }
+                        }
+                        "thinking" => {
+                            if let Some(t) = blk.get("thinking").and_then(|v| v.as_str()) {
+                                total = total.saturating_add(est.count_text(t));
+                            }
+                        }
+                        "tool_use" | "tool_result" => {
+                            if let Ok(s) = serde_json::to_string(blk) {
+                                total = total.saturating_add(est.count_text(&s));
+                            }
+                        }
+                        _ => {
+                            // image / other modal blocks: skip — we don't tokenize binary.
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(tools) = req.get("tools").and_then(|v| v.as_array()) {
+        for t in tools {
+            if let Ok(s) = serde_json::to_string(t) {
+                total = total.saturating_add(est.count_text(&s));
+            }
+        }
+    }
+    if let Some(tc) = req.get("tool_choice") {
+        if let Ok(s) = serde_json::to_string(tc) {
+            total = total.saturating_add(est.count_text(&s));
+        }
+    }
+
+    total
+}
+
+/// Estimate output tokens for an Anthropic response body. Counts thinking +
+/// text + tool_use blocks; deduplicates think-block text against thinking
+/// blocks.
+pub fn estimate_output_tokens(resp: &Value, est: &dyn TokenEstimator) -> u32 {
+    let text = collected_response_text(resp);
+    est.count_text(&text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1011,5 +1118,122 @@ mod tests {
         ];
         let (info, _body) = extract_from_sse(&events);
         assert_eq!(info.response_id.as_deref(), Some("msg_stream_01"));
+    }
+}
+
+#[cfg(test)]
+mod estimator_tests {
+    use super::*;
+    use crate::token_estimator::CL100kEstimator;
+    use serde_json::json;
+
+    fn cl() -> CL100kEstimator {
+        CL100kEstimator::new()
+    }
+
+    #[test]
+    fn usage_present_true_when_set() {
+        let body = json!({"usage": {"input_tokens": 10, "output_tokens": 5}});
+        assert!(usage_present(&body));
+    }
+
+    #[test]
+    fn usage_present_false_when_missing_or_zero() {
+        assert!(!usage_present(&json!({})));
+        assert!(!usage_present(
+            &json!({"usage": {"input_tokens": 0, "output_tokens": 0}})
+        ));
+    }
+
+    #[test]
+    fn estimate_input_walks_string_system_messages_tools() {
+        let req = json!({
+            "system": "You are helpful",
+            "messages": [
+                {"role":"user","content":"Hello"}
+            ],
+            "tools": [
+                {"name":"calc","description":"adds","input_schema":{"type":"object"}}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        assert!(n > 5);
+    }
+
+    #[test]
+    fn estimate_input_walks_array_system() {
+        let req_arr = json!({
+            "system":[{"type":"text","text":"You are helpful"}],
+            "messages":[{"role":"user","content":"Hi"}]
+        });
+        let req_str = json!({
+            "system":"You are helpful",
+            "messages":[{"role":"user","content":"Hi"}]
+        });
+        // Both forms must yield the same input estimate.
+        assert_eq!(
+            estimate_input_tokens(&req_arr, &cl()),
+            estimate_input_tokens(&req_str, &cl())
+        );
+    }
+
+    #[test]
+    fn estimate_input_walks_message_array_content() {
+        let req = json!({
+            "system":"sys",
+            "messages":[
+                {"role":"user","content":[
+                    {"type":"text","text":"hello there"},
+                    {"type":"tool_result","tool_use_id":"toolu_x","content":"ok"}
+                ]}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        assert!(n > 3);
+    }
+
+    #[test]
+    fn estimate_output_thinking_plus_text_counted() {
+        let resp = json!({
+            "content":[
+                {"type":"thinking","thinking":"plan ahead"},
+                {"type":"text","text":"final answer"}
+            ]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        let plain = estimate_output_tokens(
+            &json!({"content":[{"type":"text","text":"final answer"}]}),
+            &cl(),
+        );
+        assert!(n > plain, "thinking block must count (got {n} vs plain {plain})");
+    }
+
+    #[test]
+    fn estimate_output_dedupes_thinking_against_inline_think_block() {
+        let resp = json!({
+            "content":[
+                {"type":"thinking","thinking":"trace"},
+                {"type":"text","text":"<think>trace</think>answer"}
+            ]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        // Compare against a response that omits the duplicate inline block.
+        let single = json!({
+            "content":[
+                {"type":"thinking","thinking":"trace"},
+                {"type":"text","text":"answer"}
+            ]
+        });
+        assert_eq!(n, estimate_output_tokens(&single, &cl()));
+    }
+
+    #[test]
+    fn estimate_output_includes_tool_use() {
+        let resp = json!({
+            "content":[
+                {"type":"tool_use","id":"toolu_x","name":"calc","input":{"a":1}}
+            ]
+        });
+        assert!(estimate_output_tokens(&resp, &cl()) > 0);
     }
 }

--- a/server/ts-llm/src/wire_apis/openai/chat.rs
+++ b/server/ts-llm/src/wire_apis/openai/chat.rs
@@ -518,6 +518,108 @@ pub fn extract_assistant_text_value(resp: &Value) -> Option<String> {
     }
 }
 
+// ─────────────────────────── Token estimation ─────────────────────────────
+//
+// Fallback estimators for when the response payload omits the `usage` field.
+// These walk the same body shapes as the parsers above and feed every
+// distinct piece of text through the supplied `TokenEstimator`. They exist
+// alongside (not on top of) the wire-usage parsing — the live processor only
+// invokes them when the wire `usage` block was absent.
+
+use crate::token_estimator::{collect_chat_assistant_text, TokenEstimator};
+
+/// True iff the response body carried any Chat-shape `usage` field. The API
+/// handler uses this against `response_body` to decide `tokens_estimated`.
+pub fn usage_present(body: &Value) -> bool {
+    let u = match body.get("usage") {
+        Some(v) => v,
+        None => return false,
+    };
+    if !u.is_object() {
+        return false;
+    }
+    u.get("prompt_tokens")
+        .and_then(|v| v.as_u64())
+        .map(|n| n > 0)
+        .unwrap_or(false)
+        || u.get("completion_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n > 0)
+            .unwrap_or(false)
+        || u.get("total_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n > 0)
+            .unwrap_or(false)
+}
+
+/// Walk the assistant message on choices[0].message and produce a single
+/// concatenated string with reasoning_content / reasoning / `<think>` /
+/// content / tool_calls all deduplicated. Returns empty if the response
+/// shape is unexpected.
+pub fn collected_response_text(body: &Value) -> String {
+    let msg = body
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"));
+    match msg {
+        Some(m) => collect_chat_assistant_text(m),
+        None => String::new(),
+    }
+}
+
+/// Estimate input tokens for an OpenAI Chat request body. Walks every
+/// message (system / user / assistant / tool roles) plus the `tools[*]`
+/// schema. Empty / wrong-shaped bodies return 0.
+pub fn estimate_input_tokens(req: &Value, est: &dyn TokenEstimator) -> u32 {
+    let mut total: u32 = 0;
+    if let Some(msgs) = req.get("messages").and_then(|v| v.as_array()) {
+        for m in msgs {
+            // role token (small but stable on the wire)
+            if let Some(role) = m.get("role").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(role));
+            }
+            // content: string or array
+            if let Some(s) = m.get("content").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(s));
+            } else if let Some(arr) = m.get("content").and_then(|v| v.as_array()) {
+                for part in arr {
+                    if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                        total = total.saturating_add(est.count_text(t));
+                    }
+                }
+            }
+            // assistant tool_calls (counts as the model output it would have
+            // generated had this been part of a fresh response)
+            if let Some(tcs) = m.get("tool_calls").and_then(|v| v.as_array()) {
+                for tc in tcs {
+                    if let Ok(s) = serde_json::to_string(tc) {
+                        total = total.saturating_add(est.count_text(&s));
+                    }
+                }
+            }
+            // tool result message: tool_call_id is small, content already covered.
+        }
+    }
+    if let Some(tools) = req.get("tools").and_then(|v| v.as_array()) {
+        for t in tools {
+            if let Ok(s) = serde_json::to_string(t) {
+                total = total.saturating_add(est.count_text(&s));
+            }
+        }
+    }
+    if let Some(s) = req.get("tool_choice").and_then(|v| v.as_str()) {
+        total = total.saturating_add(est.count_text(s));
+    }
+    total
+}
+
+/// Estimate output tokens for an OpenAI Chat response body. Counts all
+/// reasoning channels + content + tool_calls, deduplicated.
+pub fn estimate_output_tokens(resp: &Value, est: &dyn TokenEstimator) -> u32 {
+    let text = collected_response_text(resp);
+    est.count_text(&text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -780,6 +882,181 @@ mod tests {
         assert!(w.is_tool_use("tool_calls"));
         assert!(w.is_tool_use("function_call"));
         assert!(!w.is_tool_use("stop"));
+    }
+
+    // ─────────── Token estimator walker tests (Step 2) ───────────
+
+    use crate::token_estimator::CL100kEstimator;
+
+    fn cl() -> CL100kEstimator {
+        CL100kEstimator::new()
+    }
+
+    #[test]
+    fn usage_present_true_when_prompt_tokens_set() {
+        let body = json!({"usage": {"prompt_tokens": 10, "completion_tokens": 5}});
+        assert!(usage_present(&body));
+    }
+
+    #[test]
+    fn usage_present_false_when_missing() {
+        let body = json!({"choices":[]});
+        assert!(!usage_present(&body));
+    }
+
+    #[test]
+    fn usage_present_false_when_zero_only() {
+        // LiteLLM proxy sometimes emits an empty usage block with zeros.
+        // Treat zero-only as "no real wire usage" so the estimator still runs.
+        let body = json!({"usage": {"prompt_tokens": 0, "completion_tokens": 0}});
+        assert!(!usage_present(&body));
+    }
+
+    #[test]
+    fn estimate_input_walks_system_user_tools() {
+        let req = json!({
+            "messages": [
+                {"role":"system","content":"You are helpful"},
+                {"role":"user","content":"Hello"}
+            ],
+            "tools": [
+                {"type":"function","function":{"name":"calc","description":"adds two numbers","parameters":{}}}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        // Each piece independently is > 0; the sum must dominate the trivial
+        // (3-token) overhead of any individual fragment.
+        assert!(n > 5, "expected >5 tokens, got {n}");
+    }
+
+    #[test]
+    fn estimate_input_handles_array_content() {
+        let req = json!({
+            "messages": [
+                {"role":"user","content":[
+                    {"type":"text","text":"part one"},
+                    {"type":"text","text":"part two"}
+                ]}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        assert!(n >= 4, "expected >=4 tokens for two text parts, got {n}");
+    }
+
+    #[test]
+    fn estimate_output_text_only() {
+        let resp = json!({
+            "choices": [{
+                "index": 0,
+                "message": {"role":"assistant","content":"Hello world"},
+                "finish_reason":"stop"
+            }]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        assert_eq!(n, 2); // "Hello world" is 2 cl100k tokens
+    }
+
+    #[test]
+    fn estimate_output_includes_reasoning_content() {
+        let resp = json!({
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role":"assistant",
+                    "reasoning_content":"long internal trace abcdef",
+                    "content":"final"
+                },
+                "finish_reason":"stop"
+            }]
+        });
+        let with_reasoning = estimate_output_tokens(&resp, &cl());
+        let resp_no_reasoning = json!({
+            "choices": [{
+                "index":0,
+                "message":{"role":"assistant","content":"final"},
+                "finish_reason":"stop"
+            }]
+        });
+        let plain = estimate_output_tokens(&resp_no_reasoning, &cl());
+        assert!(
+            with_reasoning > plain,
+            "reasoning_content must inflate output count (got {with_reasoning} vs plain {plain})"
+        );
+    }
+
+    #[test]
+    fn estimate_output_dedupes_reasoning_field_against_reasoning_content() {
+        // Both fields carry SAME text. Counted once.
+        let resp_dup = json!({
+            "choices": [{
+                "index":0,
+                "message": {
+                    "role":"assistant",
+                    "reasoning_content":"trace text",
+                    "reasoning":"trace text",
+                    "content":"answer"
+                },
+                "finish_reason":"stop"
+            }]
+        });
+        let resp_single = json!({
+            "choices": [{
+                "index":0,
+                "message": {
+                    "role":"assistant",
+                    "reasoning_content":"trace text",
+                    "content":"answer"
+                },
+                "finish_reason":"stop"
+            }]
+        });
+        assert_eq!(
+            estimate_output_tokens(&resp_dup, &cl()),
+            estimate_output_tokens(&resp_single, &cl())
+        );
+    }
+
+    #[test]
+    fn estimate_output_extracts_think_blocks_from_content() {
+        let resp = json!({
+            "choices": [{
+                "index":0,
+                "message": {
+                    "role":"assistant",
+                    "content":"<think>plan ahead</think>final"
+                },
+                "finish_reason":"stop"
+            }]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        let plain = estimate_output_tokens(
+            &json!({"choices":[{"index":0,"message":{"role":"assistant","content":"final"},"finish_reason":"stop"}]}),
+            &cl(),
+        );
+        assert!(n > plain, "<think> tokens must be counted (got {n} vs plain {plain})");
+    }
+
+    #[test]
+    fn estimate_output_includes_tool_calls() {
+        let resp = json!({
+            "choices": [{
+                "index":0,
+                "message": {
+                    "role":"assistant",
+                    "content": null,
+                    "tool_calls":[{"id":"call_1","type":"function","function":{"name":"do","arguments":"{}"}}]
+                },
+                "finish_reason":"tool_calls"
+            }]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        assert!(n > 0, "tool_calls must contribute tokens");
+    }
+
+    #[test]
+    fn estimate_output_zero_on_unexpected_shape() {
+        let resp = json!({"foo":"bar"});
+        assert_eq!(estimate_output_tokens(&resp, &cl()), 0);
     }
 
     #[test]

--- a/server/ts-llm/src/wire_apis/openai/responses.rs
+++ b/server/ts-llm/src/wire_apis/openai/responses.rs
@@ -515,6 +515,106 @@ pub fn extract_assistant_text_value(resp: &Value) -> Option<String> {
     None
 }
 
+// ─────────────────────────── Token estimation ─────────────────────────────
+
+use crate::token_estimator::{collect_responses_output_text, TokenEstimator};
+
+/// True iff the response body carried any Responses-shape `usage` field.
+pub fn usage_present(body: &Value) -> bool {
+    let u = match body.get("usage") {
+        Some(v) => v,
+        None => return false,
+    };
+    if !u.is_object() {
+        return false;
+    }
+    u.get("input_tokens")
+        .and_then(|v| v.as_u64())
+        .map(|n| n > 0)
+        .unwrap_or(false)
+        || u.get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| n > 0)
+            .unwrap_or(false)
+}
+
+/// Walk the top-level `output[*]` array and produce one concatenated, deduped
+/// string of all reasoning summary + reasoning content + assistant message
+/// text + serialized function_call/tool_call payloads. Returns empty if
+/// `output` is missing or wrong-typed.
+pub fn collected_response_text(body: &Value) -> String {
+    if let Some(out) = body.get("output") {
+        return collect_responses_output_text(out);
+    }
+    String::new()
+}
+
+/// Estimate input tokens for an OpenAI Responses request. Walks
+/// `instructions` (system prompt), `input[*]` messages (with role + content
+/// array), and `tools[*]`.
+pub fn estimate_input_tokens(req: &Value, est: &dyn TokenEstimator) -> u32 {
+    let mut total: u32 = 0;
+
+    if let Some(s) = req.get("instructions").and_then(|v| v.as_str()) {
+        total = total.saturating_add(est.count_text(s));
+    }
+
+    if let Some(items) = req.get("input").and_then(|v| v.as_array()) {
+        for it in items {
+            // Items can be:
+            //   {role:"...", content:[{type:"input_text"|"output_text", text}]}
+            //   {type:"function_call_output", output:"..."}
+            //   {type:"function_call", name, arguments}
+            //   {type:"reasoning", ...}  (rare on input but possible if echoed)
+            if let Some(role) = it.get("role").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(role));
+            }
+            if let Some(content) = it.get("content").and_then(|v| v.as_array()) {
+                for c in content {
+                    if let Some(t) = c.get("text").and_then(|v| v.as_str()) {
+                        total = total.saturating_add(est.count_text(t));
+                    }
+                }
+            } else if let Some(s) = it.get("content").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(s));
+            }
+            // function_call_output: count `output` field
+            if let Some(out) = it.get("output").and_then(|v| v.as_str()) {
+                total = total.saturating_add(est.count_text(out));
+            }
+            // function_call: serialize whole
+            if it.get("type").and_then(|v| v.as_str()) == Some("function_call") {
+                if let Ok(s) = serde_json::to_string(it) {
+                    total = total.saturating_add(est.count_text(&s));
+                }
+            }
+        }
+    }
+
+    if let Some(tools) = req.get("tools").and_then(|v| v.as_array()) {
+        for t in tools {
+            if let Ok(s) = serde_json::to_string(t) {
+                total = total.saturating_add(est.count_text(&s));
+            }
+        }
+    }
+    if let Some(tc) = req.get("tool_choice") {
+        if let Ok(s) = serde_json::to_string(tc) {
+            total = total.saturating_add(est.count_text(&s));
+        }
+    }
+
+    total
+}
+
+/// Estimate output tokens for an OpenAI Responses response body. Counts
+/// reasoning summary + reasoning content + message text + tool/function
+/// call payloads, all deduplicated.
+pub fn estimate_output_tokens(resp: &Value, est: &dyn TokenEstimator) -> u32 {
+    let text = collected_response_text(resp);
+    est.count_text(&text)
+}
+
 #[cfg(test)]
 mod terminal_helper_tests {
     use super::*;
@@ -726,5 +826,113 @@ mod tests {
         let (info, _body) = extract_sse(&events);
         assert_eq!(info.model.as_deref(), Some("gpt-5"));
         assert_eq!(info.response_id.as_deref(), Some("resp_1"));
+    }
+}
+
+#[cfg(test)]
+mod estimator_tests {
+    use super::*;
+    use crate::token_estimator::CL100kEstimator;
+    use serde_json::json;
+
+    fn cl() -> CL100kEstimator {
+        CL100kEstimator::new()
+    }
+
+    #[test]
+    fn usage_present_true_when_set() {
+        let body = json!({"usage": {"input_tokens": 10, "output_tokens": 5}});
+        assert!(usage_present(&body));
+    }
+
+    #[test]
+    fn usage_present_false_when_missing_or_zero() {
+        assert!(!usage_present(&json!({})));
+        assert!(!usage_present(
+            &json!({"usage": {"input_tokens": 0, "output_tokens": 0}})
+        ));
+    }
+
+    #[test]
+    fn estimate_input_walks_instructions_and_input_messages() {
+        let req = json!({
+            "instructions":"You are helpful",
+            "input":[
+                {"role":"user","content":[
+                    {"type":"input_text","text":"Hello"}
+                ]}
+            ],
+            "tools":[
+                {"type":"function","name":"calc","description":"adds","parameters":{}}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        assert!(n > 5);
+    }
+
+    #[test]
+    fn estimate_input_function_call_output() {
+        let req = json!({
+            "input":[
+                {"type":"function_call_output","call_id":"call_x","output":"the result"}
+            ]
+        });
+        let n = estimate_input_tokens(&req, &cl());
+        assert!(n > 0);
+    }
+
+    #[test]
+    fn estimate_output_reasoning_summary_plus_message() {
+        let resp = json!({
+            "output":[
+                {"type":"reasoning","summary":[{"type":"summary_text","text":"thoughts"}]},
+                {"type":"message","content":[{"type":"output_text","text":"final"}]}
+            ]
+        });
+        let n = estimate_output_tokens(&resp, &cl());
+        let plain = estimate_output_tokens(
+            &json!({"output":[{"type":"message","content":[{"type":"output_text","text":"final"}]}]}),
+            &cl(),
+        );
+        assert!(n > plain, "reasoning summary must add tokens (got {n} vs plain {plain})");
+    }
+
+    #[test]
+    fn estimate_output_dedupes_reasoning_summary_text() {
+        let resp = json!({
+            "output":[
+                {"type":"reasoning","summary":[
+                    {"text":"trace"},
+                    {"text":"trace"}
+                ]},
+                {"type":"message","content":[{"type":"output_text","text":"ok"}]}
+            ]
+        });
+        let single = json!({
+            "output":[
+                {"type":"reasoning","summary":[{"text":"trace"}]},
+                {"type":"message","content":[{"type":"output_text","text":"ok"}]}
+            ]
+        });
+        assert_eq!(
+            estimate_output_tokens(&resp, &cl()),
+            estimate_output_tokens(&single, &cl())
+        );
+    }
+
+    #[test]
+    fn estimate_output_function_call_counted() {
+        let resp = json!({
+            "output":[
+                {"type":"function_call","name":"do","arguments":"{}","call_id":"call_y"}
+            ]
+        });
+        assert!(estimate_output_tokens(&resp, &cl()) > 0);
+    }
+
+    #[test]
+    fn estimate_output_zero_on_empty_or_unexpected() {
+        assert_eq!(estimate_output_tokens(&json!({}), &cl()), 0);
+        assert_eq!(estimate_output_tokens(&json!({"output":[]}), &cl()), 0);
     }
 }

--- a/server/ts-llm/tests/keepalive_estimator_integration.rs
+++ b/server/ts-llm/tests/keepalive_estimator_integration.rs
@@ -1,0 +1,150 @@
+//! End-to-end regression for the fallback token estimator.
+//!
+//! Replays the `keepalive_2sse_{client,server}.bin` fixtures (a real
+//! 27-POST agent session captured from a LiteLLM proxy that omits the wire
+//! `usage` field) through `HttpParser → HttpJoiner → LlmProcessor` and
+//! asserts that every resulting `LlmCall` has non-zero estimated tokens.
+//!
+//! Without the estimator wiring, those rows would land in the database as
+//! `input_tokens=NULL, output_tokens=NULL` and show as `-/-` in the
+//! console. The fixture has been verified via `grep` to contain neither
+//! `usage` nor `prompt_tokens` nor `completion_tokens` — every estimate
+//! produced here is a true fallback, not a fast path past the wire-usage
+//! parser.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+
+use ts_common::internal_metrics::{Metric, MetricsSystem};
+use ts_llm::model::LlmEvent;
+use ts_llm::processor::LlmProcessor;
+use ts_llm::profile::AgentProfileRegistry;
+use ts_llm::wire_apis::build_default_wire_api_registry;
+use ts_protocol::http::{HttpParser, ParseResult};
+use ts_protocol::joiner::HttpJoiner;
+use ts_protocol::model::HttpParseEvent;
+use ts_protocol::net::FlowKey;
+
+const CLIENT_BYTES: &[u8] =
+    include_bytes!("../../ts-protocol/tests/fixtures/keepalive_2sse_client.bin");
+const SERVER_BYTES: &[u8] =
+    include_bytes!("../../ts-protocol/tests/fixtures/keepalive_2sse_server.bin");
+
+#[test]
+fn keepalive_real_bytes_estimator_populates_tokens() {
+    let cip: IpAddr = "10.40.1.81".parse().unwrap();
+    let sip: IpAddr = "172.16.103.81".parse().unwrap();
+    let fk = FlowKey::new(String::new(), cip, 54754, sip, 4210);
+    let ca = (cip, 54754);
+    let sa = (sip, 4210);
+
+    // Stage 1: drive the HTTP parser with concatenated client + server bytes.
+    let mut parser = HttpParser::new();
+    let mut client_buf = BytesMut::from(CLIENT_BYTES);
+    let mut server_buf = BytesMut::from(SERVER_BYTES);
+    let mut http_events: Vec<HttpParseEvent> = Vec::new();
+    let result = parser.parse(
+        &mut client_buf,
+        &mut server_buf,
+        &fk,
+        ca,
+        sa,
+        0,
+        0,
+        0,
+        &mut http_events,
+    );
+    assert!(
+        matches!(result, ParseResult::Ok),
+        "parser must succeed; got {result:?}"
+    );
+
+    // Stage 2: feed those parse events through the joiner to get pairs.
+    let mut sys = MetricsSystem::new();
+    let joiner_w = sys.register_worker(
+        "joiner-test",
+        &[
+            Metric::HttpJoinerDone,
+            Metric::HttpJoinerUnpaired,
+            Metric::HttpJoinerExpired,
+            Metric::HttpJoinerPending,
+            Metric::JoinerHeartbeatsReceived,
+        ],
+    );
+    let _svc = sys.start();
+    let mut joiner = HttpJoiner::new(joiner_w);
+    let mut joiner_events = Vec::new();
+    for ev in http_events {
+        joiner_events.extend(joiner.process(ev));
+    }
+
+    // Stage 3: run through the LLM processor.
+    let mut sys2 = MetricsSystem::new();
+    let proc_w = sys2.register_worker(
+        "llm-test",
+        &[
+            Metric::WireDetected,
+            Metric::WireIgnored,
+            Metric::LlmCallsWithAgent,
+            Metric::LlmCallsWithoutAgent,
+            Metric::LlmGenericToolIdCanonicalized,
+            Metric::LlmGenericSessionIdSynthFailed,
+            Metric::LlmHeartbeatsReceived,
+            Metric::LlmTokensEstimated,
+        ],
+    );
+    let _svc2 = sys2.start();
+    let mut proc = LlmProcessor::new(
+        Arc::new(build_default_wire_api_registry()),
+        Arc::new(AgentProfileRegistry::new()),
+        proc_w,
+    );
+    let mut completes: Vec<Arc<ts_llm::model::LlmCall>> = Vec::new();
+    for ev in joiner_events {
+        for llm_event in proc.process(ev) {
+            if let LlmEvent::Complete { call, .. } = llm_event {
+                completes.push(call);
+            }
+        }
+    }
+
+    assert!(
+        !completes.is_empty(),
+        "fixture must yield at least one LlmCall (got 0)"
+    );
+
+    let mut zero_token_calls = 0;
+    for (i, call) in completes.iter().enumerate() {
+        let it = call.input_tokens.unwrap_or(0);
+        let ot = call.output_tokens.unwrap_or(0);
+        eprintln!(
+            "call#{i}: model={} wire_api={} status={:?} in={it} out={ot}",
+            call.model, call.wire_api, call.status_code
+        );
+        if it == 0 && ot == 0 {
+            zero_token_calls += 1;
+        }
+    }
+
+    assert_eq!(
+        zero_token_calls, 0,
+        "expected ALL calls to have non-zero estimated tokens; \
+         {zero_token_calls} of {} still showed (in=0,out=0)",
+        completes.len()
+    );
+
+    // At least one call should report a meaningfully large output (these are
+    // SSE responses with multi-line replies; tokenizer floor of 0 would be a
+    // dead estimator).
+    let max_out = completes
+        .iter()
+        .map(|c| c.output_tokens.unwrap_or(0))
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max_out >= 5,
+        "expected at least one call to estimate >=5 output tokens, got max={max_out}"
+    );
+}

--- a/server/ts-storage/src/duckdb.rs
+++ b/server/ts-storage/src/duckdb.rs
@@ -19,6 +19,99 @@ use crate::query::*;
 use crate::retention::{RetentionPolicy, RetentionReport};
 use crate::StorageBackend;
 
+/// Decide whether a row's `(input_tokens, output_tokens)` came from the
+/// fallback estimator vs the wire `usage` block. Returns true when the row
+/// has any tokens AND the response body either lacks a `usage` object or
+/// every numeric field inside `usage` is zero. Wire-api-agnostic — looks for
+/// any of the four canonical fields under `usage` (OpenAI Chat / Anthropic
+/// / OpenAI Responses all use one of these names).
+fn derive_tokens_estimated(
+    input_tokens: Option<u32>,
+    output_tokens: Option<u32>,
+    response_body: Option<&str>,
+) -> bool {
+    let in_tok = input_tokens.unwrap_or(0);
+    let out_tok = output_tokens.unwrap_or(0);
+    if in_tok == 0 && out_tok == 0 {
+        return false;
+    }
+    let body = match response_body {
+        Some(s) if !s.is_empty() => s,
+        _ => return true,
+    };
+    let v: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        _ => return true,
+    };
+    let usage = match v.get("usage") {
+        Some(u) if u.is_object() => u,
+        _ => return true,
+    };
+    for key in [
+        "prompt_tokens",
+        "completion_tokens",
+        "input_tokens",
+        "output_tokens",
+    ] {
+        if let Some(n) = usage.get(key).and_then(|v| v.as_u64()) {
+            if n > 0 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod derive_tokens_estimated_tests {
+    use super::derive_tokens_estimated;
+
+    #[test]
+    fn zero_tokens_returns_false() {
+        assert!(!derive_tokens_estimated(Some(0), Some(0), None));
+        assert!(!derive_tokens_estimated(None, None, Some(r#"{"x":1}"#)));
+    }
+
+    #[test]
+    fn no_body_with_tokens_returns_true() {
+        assert!(derive_tokens_estimated(Some(10), Some(5), None));
+        assert!(derive_tokens_estimated(Some(10), Some(5), Some("")));
+    }
+
+    #[test]
+    fn malformed_body_with_tokens_returns_true() {
+        assert!(derive_tokens_estimated(
+            Some(10),
+            Some(5),
+            Some("not json")
+        ));
+    }
+
+    #[test]
+    fn body_with_positive_usage_returns_false() {
+        let body = r#"{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        assert!(!derive_tokens_estimated(Some(10), Some(5), Some(body)));
+    }
+
+    #[test]
+    fn body_with_zero_usage_returns_true() {
+        let body = r#"{"usage":{"prompt_tokens":0,"completion_tokens":0}}"#;
+        assert!(derive_tokens_estimated(Some(10), Some(5), Some(body)));
+    }
+
+    #[test]
+    fn anthropic_shape_recognized() {
+        let body = r#"{"usage":{"input_tokens":7,"output_tokens":3}}"#;
+        assert!(!derive_tokens_estimated(Some(7), Some(3), Some(body)));
+    }
+
+    #[test]
+    fn body_missing_usage_block_returns_true() {
+        let body = r#"{"choices":[{"message":{"content":"hi"}}]}"#;
+        assert!(derive_tokens_estimated(Some(5), Some(2), Some(body)));
+    }
+}
+
 /// Default size of the read-connection pool. DuckDB serializes writes at the
 /// database layer anyway; extra read connections only help queries.
 const DEFAULT_READ_POOL_SIZE: usize = 4;
@@ -2088,7 +2181,7 @@ impl StorageBackend for DuckDbBackend {
             let items_sql = format!(
                 "SELECT id, source_id, epoch_ms(request_time), wire_api, model, status_code, is_stream, \
                  finish_reason, ttft_ms, e2e_latency_ms, input_tokens, output_tokens, \
-                 client_ip, server_ip, server_port, request_path \
+                 client_ip, server_ip, server_port, request_path, response_body \
                  FROM llm_calls WHERE {where_sql} \
                  ORDER BY {sort_by} {sort_order} \
                  LIMIT {limit} OFFSET {offset}"
@@ -2107,6 +2200,17 @@ impl StorageBackend for DuckDbBackend {
                 .next()
                 .map_err(|e| AppError::Storage(format!("row error: {e}")))?
             {
+                let input_tokens = row
+                    .get::<_, Option<u32>>(10)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                let output_tokens = row
+                    .get::<_, Option<u32>>(11)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                let response_body: Option<String> = row
+                    .get(16)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                let tokens_estimated =
+                    derive_tokens_estimated(input_tokens, output_tokens, response_body.as_deref());
                 items.push(CallListItem {
                     id: row
                         .get(0)
@@ -2138,12 +2242,9 @@ impl StorageBackend for DuckDbBackend {
                     e2e_latency_ms: row
                         .get::<_, Option<f64>>(9)
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    input_tokens: row
-                        .get::<_, Option<u32>>(10)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    output_tokens: row
-                        .get::<_, Option<u32>>(11)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+                    input_tokens,
+                    output_tokens,
+                    tokens_estimated,
                     client_ip: row
                         .get(12)
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
@@ -2194,6 +2295,11 @@ impl StorageBackend for DuckDbBackend {
             })?;
 
             let result = stmt.query_row(duckdb::params![id], |row| {
+                let input_tokens: Option<u32> = row.get(12)?;
+                let output_tokens: Option<u32> = row.get(13)?;
+                let response_body: Option<String> = row.get(23)?;
+                let tokens_estimated =
+                    derive_tokens_estimated(input_tokens, output_tokens, response_body.as_deref());
                 Ok(CallDetail {
                     id: row.get(0)?,
                     source_id: row.get(1)?,
@@ -2207,9 +2313,10 @@ impl StorageBackend for DuckDbBackend {
                     request_path: row.get(9)?,
                     status_code: row.get(10)?,
                     finish_reason: row.get(11)?,
-                    input_tokens: row.get(12)?,
-                    output_tokens: row.get(13)?,
+                    input_tokens,
+                    output_tokens,
                     total_tokens: row.get(14)?,
+                    tokens_estimated,
                     ttft_ms: row.get(15)?,
                     e2e_latency_ms: row.get(16)?,
                     response_id: row.get(17)?,
@@ -2218,7 +2325,7 @@ impl StorageBackend for DuckDbBackend {
                     server_ip: row.get(20)?,
                     server_port: row.get(21)?,
                     request_body: row.get(22)?,
-                    response_body: row.get(23)?,
+                    response_body,
                     request_headers: row.get(24)?,
                     response_headers: row.get(25)?,
                 })
@@ -2697,12 +2804,19 @@ impl StorageBackend for DuckDbBackend {
                     e2e_latency_ms: row
                         .get::<_, Option<f64>>(10)
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    input_tokens: row
-                        .get::<_, Option<u32>>(11)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    output_tokens: row
-                        .get::<_, Option<u32>>(12)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+                    input_tokens: {
+                        let v: Option<u32> = row
+                            .get(11)
+                            .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                        v
+                    },
+                    output_tokens: {
+                        let v: Option<u32> = row
+                            .get(12)
+                            .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                        v
+                    },
+                    tokens_estimated: false, // overwritten below once we read response_body
                     request_path: row
                         .get(13)
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
@@ -2731,6 +2845,13 @@ impl StorageBackend for DuckDbBackend {
                         .get::<_, Option<String>>(21)
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
                 });
+                // Now backfill tokens_estimated from the values just inserted.
+                let last = items.last_mut().expect("just pushed");
+                last.tokens_estimated = derive_tokens_estimated(
+                    last.input_tokens,
+                    last.output_tokens,
+                    last.response_body.as_deref(),
+                );
             }
 
             Ok(items)

--- a/server/ts-storage/src/query.rs
+++ b/server/ts-storage/src/query.rs
@@ -136,6 +136,11 @@ pub struct CallListItem {
     pub e2e_latency_ms: Option<f64>,
     pub input_tokens: Option<u32>,
     pub output_tokens: Option<u32>,
+    /// True when the row's tokens came from the fallback tiktoken estimator
+    /// rather than a wire-side `usage` block. Computed at read time from
+    /// `response_body`; not a stored column.
+    #[serde(default)]
+    pub tokens_estimated: bool,
     pub client_ip: String,
     pub server_ip: String,
     pub server_port: u16,
@@ -322,6 +327,10 @@ pub struct TurnCallItem {
     pub e2e_latency_ms: Option<f64>,
     pub input_tokens: Option<u32>,
     pub output_tokens: Option<u32>,
+    /// True when the row's tokens came from the fallback estimator. Mirrors
+    /// `CallListItem.tokens_estimated`.
+    #[serde(default)]
+    pub tokens_estimated: bool,
     pub request_path: String,
     pub client_ip: String,
     pub client_port: u16,
@@ -571,6 +580,10 @@ pub struct CallDetail {
     pub input_tokens: Option<u32>,
     pub output_tokens: Option<u32>,
     pub total_tokens: Option<u32>,
+    /// True when the row's tokens came from the fallback estimator. See
+    /// `CallListItem.tokens_estimated`.
+    #[serde(default)]
+    pub tokens_estimated: bool,
     pub ttft_ms: Option<f64>,
     pub e2e_latency_ms: Option<f64>,
     pub response_id: Option<String>,


### PR DESCRIPTION
## Summary

Fills in token counts for the ~15% of llm_calls where the wire `usage`
block is missing (LiteLLM proxy + similar upstreams). Three pieces:

1. **Live path estimator** — when status=2xx and both wire tokens are 0/None,
   re-tokenize request and assembled response bodies via tiktoken cl100k +
   per-wire-api walkers (covers OpenAI Chat, OpenAI Responses, Anthropic).
2. **Multi-format reasoning compatibility** — counts reasoning text once
   regardless of channel: `message.reasoning_content` (Qwen3 native),
   `message.reasoning` (vLLM 0.17+ rename), `<think>...</think>` blocks
   embedded in content, Anthropic `thinking` blocks, OpenAI Responses
   `reasoning` items with summary + content. Exact-string dedupe handles
   the common case where the server emits the same trace under multiple
   keys.
3. **Backfill subcommand** — `tokenscope backfill-tokens` re-tokenizes
   historical rows. `--dry-run` / `--limit` / `--skip-backup`; takes a
   one-time `.pre_backfill_tokens_backup` snapshot, refuses to run while
   the daemon holds the DuckDB lock; idempotent.

UI: list rows + detail summary card + agent-turn call card show `~` prefix
in amber with a tooltip when the row's tokens were estimated. The
`tokens_estimated` boolean is derived at API read time from
`response_body` — no schema change.

Verbose mode (`-v`) logs each estimation event:
`DEBUG estimated tokens (no usage in wire payload) wire_api=openai-chat in=39289 out=258 model=exp_model`.

## Live verification on wuneng

```
$ tokenscope backfill-tokens
INFO backfill-tokens done scanned=296 updated=275 skipped_status=21
     skipped_no_body=0 skipped_estimate_zero=0 skipped_unknown_wire=0

$ tokenscope backfill-tokens   # idempotency check
INFO backfill-tokens done scanned=21 updated=0 ...
```

After backfill: 1407 total calls, only the 21 non-2xx error rows still
show 0/0 tokens. exp_model rows: 338 total, 317 with tokens (all 200s).

## UI double-confirm (Playwright)

- exp_model list: `~2 / ~0`, `~92 / ~13` in amber w/ `~` prefix
- qwen36-27b list (wire usage present): `12 / 10`, `13.9K / 416` plain
- Detail panel summary card label switches to **Tokens (estimated)**;
  in/out/total all show `~` prefix in amber
- 405 error rows correctly show `— / —` (status-filtered out of estimator)

## Test plan

- [x] `cargo test --workspace` — 256 ts-llm + 7 ts-storage + 4 backfill
      tests + the rest of the suite all green
- [x] `tsc -b` clean for the console
- [x] End-to-end keepalive-bytes regression
      (`tests/keepalive_estimator_integration.rs`) replays a real
      LiteLLM-proxy capture through HttpParser → HttpJoiner → LlmProcessor
      and asserts every resulting LlmCall has non-zero estimated tokens
- [x] Live backfill on the wuneng db (275 updated, idempotent re-run)
- [x] API `/api/llm-calls/:id` returns `tokens_estimated: true` for a
      backfilled row (in=39289 / out=258), `false` for wire-usage rows
- [x] Playwright visual confirm of list + detail + comparison views

🤖 Generated with [Claude Code](https://claude.com/claude-code)