### PR TITLE
perf(console): quiet auto-refresh — no full-panel flicker on dashboard/performance/traffic

### DIFF
--- a/console/src/components/charts/error-by-model-chart.tsx
+++ b/console/src/components/charts/error-by-model-chart.tsx
@@ -70,9 +70,9 @@ export function ErrorByModelChart({ models }: Props) {
           }}
         />
         <Legend wrapperStyle={{ fontSize: "12px" }} />
-        <Bar dataKey="4xx" stackId="err" fill="#f59e0b" radius={0} barSize={20} />
-        <Bar dataKey="429" stackId="err" fill="#ef4444" radius={0} barSize={20} />
-        <Bar dataKey="5xx" stackId="err" fill="#dc2626" radius={[0, 4, 4, 0]} barSize={20} />
+        <Bar dataKey="4xx" stackId="err" fill="#f59e0b" radius={0} barSize={20} isAnimationActive={false} />
+        <Bar dataKey="429" stackId="err" fill="#ef4444" radius={0} barSize={20} isAnimationActive={false} />
+        <Bar dataKey="5xx" stackId="err" fill="#dc2626" radius={[0, 4, 4, 0]} barSize={20} isAnimationActive={false} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/console/src/components/charts/latency-overview-chart.tsx
+++ b/console/src/components/charts/latency-overview-chart.tsx
@@ -90,6 +90,7 @@ export function LatencyOverviewChart({ data }: Props) {
             strokeWidth={2}
             dot={false}
             connectNulls
+            isAnimationActive={false}
           />
         ))}
       </LineChart>

--- a/console/src/components/charts/model-breakdown-chart.tsx
+++ b/console/src/components/charts/model-breakdown-chart.tsx
@@ -67,7 +67,7 @@ export function ModelBreakdownChart({ models }: Props) {
             fontSize: "12px",
           }}
         />
-        <Bar dataKey="requests" fill="#3b82f6" radius={[0, 4, 4, 0]} barSize={20} />
+        <Bar dataKey="requests" fill="#3b82f6" radius={[0, 4, 4, 0]} barSize={20} isAnimationActive={false} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/console/src/components/charts/model-donut-chart.tsx
+++ b/console/src/components/charts/model-donut-chart.tsx
@@ -58,6 +58,7 @@ export function ModelDonutChart({ models, height = 240 }: Props) {
           }
           labelLine={{ strokeWidth: 1 }}
           style={{ fontSize: "11px" }}
+          isAnimationActive={false}
         >
           {data.map((_, i) => (
             <Cell key={i} fill={COLORS[i % COLORS.length]} />

--- a/console/src/components/charts/request-volume-chart.tsx
+++ b/console/src/components/charts/request-volume-chart.tsx
@@ -93,6 +93,7 @@ export function RequestVolumeChart({ data }: Props) {
             fill={SERIES_COLORS[i % SERIES_COLORS.length]}
             stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
             fillOpacity={0.4}
+            isAnimationActive={false}
           />
         ))}
       </AreaChart>

--- a/console/src/components/charts/stacked-bar-chart.tsx
+++ b/console/src/components/charts/stacked-bar-chart.tsx
@@ -92,6 +92,7 @@ export function StackedBarChart({ data, field, height = 240, yFormatter = format
             dataKey={group}
             stackId="1"
             fill={GROUP_COLORS[i % GROUP_COLORS.length]}
+            isAnimationActive={false}
           />
         ))}
       </BarChart>

--- a/console/src/components/charts/timeseries-line-chart.tsx
+++ b/console/src/components/charts/timeseries-line-chart.tsx
@@ -107,6 +107,7 @@ export function TimeseriesLineChart({
               strokeWidth={2}
               dot={false}
               connectNulls
+              isAnimationActive={false}
             />
           ) : (
             <Line
@@ -118,6 +119,7 @@ export function TimeseriesLineChart({
               strokeWidth={2}
               dot={false}
               connectNulls
+              isAnimationActive={false}
             />
           ),
         )}

--- a/console/src/hooks/use-finish-reason-timeseries.ts
+++ b/console/src/hooks/use-finish-reason-timeseries.ts
@@ -48,5 +48,6 @@ export function useFinishReasonTimeseries(opts?: { granularity?: string }) {
         ...fp,
       }),
     meta: { preset },
+    placeholderData: (prev) => prev,
   })
 }

--- a/console/src/hooks/use-metrics.ts
+++ b/console/src/hooks/use-metrics.ts
@@ -12,6 +12,7 @@ export function useMetricsSummary() {
   return useQuery({
     queryKey: ["metrics-summary", { start, end, ...fp }],
     queryFn: () => apiFetch<MetricsSummary>("/api/metrics/summary", { start, end, ...fp }),
+    placeholderData: (prev) => prev,
   })
 }
 
@@ -49,6 +50,7 @@ export function useTimeseries(
       }),
     // Include preset in dep tracking for reactivity
     meta: { preset },
+    placeholderData: (prev) => prev,
   })
 }
 
@@ -60,5 +62,6 @@ export function useModels() {
   return useQuery({
     queryKey: ["models", { start, end, ...fp }],
     queryFn: () => apiFetch<ModelsData>("/api/metrics/models", { start, end, ...fp }),
+    placeholderData: (prev) => prev,
   })
 }

--- a/console/src/pages/errors.tsx
+++ b/console/src/pages/errors.tsx
@@ -123,9 +123,9 @@ function ErrorByModelCountChart({ models }: { models: MetricsModelRow[] }) {
           }}
         />
         <Legend wrapperStyle={{ fontSize: "12px" }} />
-        <Bar dataKey="4xx" stackId="err" fill="#f59e0b" barSize={20} />
-        <Bar dataKey="429" stackId="err" fill="#ef4444" barSize={20} />
-        <Bar dataKey="5xx" stackId="err" fill="#dc2626" radius={[0, 4, 4, 0]} barSize={20} />
+        <Bar dataKey="4xx" stackId="err" fill="#f59e0b" barSize={20} isAnimationActive={false} />
+        <Bar dataKey="429" stackId="err" fill="#ef4444" barSize={20} isAnimationActive={false} />
+        <Bar dataKey="5xx" stackId="err" fill="#dc2626" radius={[0, 4, 4, 0]} barSize={20} isAnimationActive={false} />
       </BarChart>
     </ResponsiveContainer>
   )


### PR DESCRIPTION
## Summary

Auto-refresh ticks caused the entire dashboard / performance / traffic
panels to flash on every interval. Surgical fix in two layers, 10 files,
+17 lines — no changes to the toolbar store, `useAutoRefresh`, or URL
sync.

## What was happening

Each refresh tick called `setPreset(currentPreset)`, which advances the
store's `start`/`end` to a new now-window. Every metrics hook embeds
`{ start, end, ...filters }` in its React Query `queryKey`, so each tick
spawned a new key with no cached prev — `data` went to `undefined`,
`isLoading` flipped to `true`, the page-level `<Loader2>` early-return
covered everything, charts entered their "No data available" branch and
unmounted, then remounted with Recharts' default 1500 ms in-animation.
Net: ~120 ms of perceived flicker on every tick, all 4 charts redrawing
from scratch.

## Fix — two layers

1. **`placeholderData: (prev) => prev`** on `useMetricsSummary`,
   `useTimeseries`, `useModels`, and `useFinishReasonTimeseries` (the
   four hooks that lacked it). With this in place, queryKey changes
   trigger a *background* refetch but consumers see `data === prev` and
   `isLoading === false`. Charts stay mounted; the toolbar's `RefreshCw`
   spinner is the single visible feedback that a refetch is in flight
   (Grafana model). `useLlmCalls`, `useAgentTurns`, and
   `useHttpExchanges` already had this.

2. **`isAnimationActive={false}`** on every `<Area>` / `<Line>` /
   `<Bar>` / `<Pie>` in the seven shared chart components and the inline
   chart in `errors.tsx`. Recharts' default 1500 ms enter-animation is
   what was perceived as the visible jitter when data updated.

Out of scope (deliberately): the toolbar store rewrite, a `useWindow`
selector, URL-sync tick subscription pruning, and `React.memo` on chart
shells. Each of those is a hygiene win, not a smoothness win — the two
layers above eliminate the user-visible flicker on their own.

## Test plan

- [x] `npm run build` — passes (`tsc -b && vite build`, no type errors).
- [x] Bundle inspection: 21× `isAnimationActive:!1` and 14×
      `placeholderData` references in the minified output.
- [x] Mocked smoothness suite (Playwright, 6 ticks × 5 s,
      `/private/tmp/tokenscope_pw/refresh_smoothness_v2.mjs`): all three
      routes pass with **`maxBoxDelta = 0.0 px`**, no Loader2 / no
      "No data available" after first paint, refresh fires every tick.
- [x] Live smoothness check (5 ticks × 5 s, real backend at
      `wuneng:4500`): no Loader2 / no "No data available" reappearance
      across dashboard, performance, traffic.
- [ ] Eyeball in a real browser at refresh = 5 s, 10 s, 30 s on
      dashboard / performance / traffic — only the toolbar spinner
      pulses; charts and KPIs are stationary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)