### PR TITLE
fix(ts-llm): only populate ttft_ms for streaming responses (TTFT no longer == E2E for non-stream)

### DIFF
--- a/server/ts-llm/src/processor.rs
+++ b/server/ts-llm/src/processor.rs
@@ -197,7 +197,14 @@ impl LlmProcessor {
         let response_time = response.first_byte_timestamp_us;
         let complete_time = response.complete_timestamp_us;
 
-        let ttft_ms = if response_time > request_time {
+        // TTFT (time to first token) is only meaningful for streaming
+        // responses — the wire `first_byte` then marks when the model
+        // started emitting tokens. Non-streaming servers buffer the full
+        // generation server-side and ship the complete JSON in one shot,
+        // so `first_byte ≈ complete_byte` and the metric collapses to E2E
+        // latency. Reporting that under the TTFT label was misleading and
+        // polluted the streaming-TTFT distributions on the dashboard.
+        let ttft_ms = if req_info.is_stream && response_time > request_time {
             Some((response_time - request_time) as f64 / 1000.0)
         } else {
             None
@@ -595,6 +602,162 @@ mod tests {
                 assert_eq!(call.total_tokens, Some(8));
                 assert_eq!(call.response_id.as_deref(), Some("chatcmpl-xyz"));
                 assert!(call.response_body.is_some());
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    #[test]
+    fn ttft_is_none_for_non_streaming_request() {
+        // For non-streaming requests, the wire `first_byte_timestamp_us`
+        // marks when the server starts shipping the JSON response — which
+        // only happens AFTER the model has finished generating. Reporting
+        // this gap as "TTFT" makes the metric collapse to E2E latency and
+        // pollutes the dashboard's TTFT percentiles. The processor must
+        // refuse to populate `ttft_ms` for non-streaming exchanges.
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics());
+        let req_body = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}]
+            // NOTE: no "stream": true field → is_stream=false
+        });
+        let req = openai_request(&req_body);
+        let resp_body = json!({
+            "id": "chatcmpl-nostream",
+            "model": "gpt-4",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        });
+        // exchange_parts() sets first_byte_timestamp_us = request_ts + 100_000 (i.e.
+        // 100 ms gap — enough for the old code path to compute ttft_ms = 100.0).
+        let (request, response) = exchange_parts(req, Bytes::from(resp_body.to_string()), false);
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-nostream".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: vec![],
+        });
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                assert!(!call.is_stream, "fixture should be non-streaming");
+                assert!(
+                    call.ttft_ms.is_none(),
+                    "ttft_ms must be None for non-streaming, got {:?}",
+                    call.ttft_ms,
+                );
+                // E2E latency stays meaningful regardless of streaming flag — it's
+                // (request_ts → complete_ts) which the wire genuinely measures.
+                assert!(
+                    call.e2e_latency_ms.is_some(),
+                    "e2e_latency_ms must remain populated for non-streaming",
+                );
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    #[test]
+    fn ttft_is_populated_for_streaming_request() {
+        // For streaming requests, the wire `first_byte_timestamp_us`
+        // marks the first SSE chunk — which corresponds to the moment
+        // the first generated token reaches the client. This IS the TTFT
+        // we want to expose.
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics());
+        let req_body = json!({
+            "model": "gpt-4",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let req = openai_request(&req_body);
+        let (request, response) = exchange_parts(req, Bytes::new(), true);
+        let sse = vec![
+            sse_event(
+                "",
+                r#"{"model":"gpt-4","choices":[{"index":0,"delta":{"content":"hi"}}]}"#,
+                1_150_000,
+            ),
+            sse_event(
+                "",
+                r#"{"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
+                1_200_000,
+            ),
+        ];
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-stream-ttft".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: sse,
+        });
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                assert!(call.is_stream, "fixture should be streaming");
+                let ttft = call
+                    .ttft_ms
+                    .expect("ttft_ms must be populated for streaming");
+                // exchange_parts() sets first_byte = request_ts + 100_000 us = +100 ms.
+                assert!(
+                    (ttft - 100.0).abs() < 1.0,
+                    "ttft_ms expected ~100.0, got {}",
+                    ttft,
+                );
+                let e2e = call
+                    .e2e_latency_ms
+                    .expect("e2e_latency_ms must be populated for streaming");
+                assert!(
+                    ttft <= e2e,
+                    "ttft ({}) must be <= e2e ({}) on a healthy stream",
+                    ttft,
+                    e2e,
+                );
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    #[test]
+    fn ttft_is_none_when_response_predates_request() {
+        // Defensive: a malformed capture where first_byte_timestamp_us
+        // somehow precedes request_ts (clock skew between capture points,
+        // out-of-order packet reassembly, etc.) must NOT produce a
+        // negative or wrap-around ttft. The original guard
+        // `response_time > request_time` already covered this; the gate
+        // we just added is `&&`-ed onto it, so we re-assert it holds.
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics());
+        let req_body = json!({
+            "model": "gpt-4",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let mut req = openai_request(&req_body);
+        // Bump the request timestamp PAST the response's first_byte timestamp
+        // produced by exchange_parts (= request_ts + 100_000). We push the
+        // request to t=2_000_000 so that first_byte_timestamp_us ends up
+        // 1_100_000 — earlier than the request.
+        req.timestamp_us = 1_000_000;
+        let (request, mut response) = exchange_parts(req, Bytes::new(), true);
+        // Now mutate the response so first_byte happens BEFORE request_ts.
+        response.first_byte_timestamp_us = 500_000;
+        let sse = vec![sse_event(
+            "",
+            r#"{"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
+            1_200_000,
+        )];
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-stream-skew".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: sse,
+        });
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                assert!(call.is_stream);
+                assert!(
+                    call.ttft_ms.is_none(),
+                    "ttft_ms must be None when response_time <= request_time",
+                );
             }
             _ => panic!("expected Complete"),
         }


### PR DESCRIPTION
## Summary

For non-streaming HTTP exchanges, the wire `first_byte_timestamp_us`
marks when the server starts shipping the JSON response — which only
happens *after* the model has finished generating the entire reply.
Reporting that gap as TTFT was wrong: it numerically collapses to E2E
latency, polluting the streaming-TTFT distributions on the dashboard /
performance / traffic pages.

## Evidence

Production data, last 1h on wuneng:4500 — same window split by `is_stream`:

| `is_stream` | n   | TTFT p50 | TTFT p95   | E2E p50  | E2E p95   | avg(TTFT/E2E) |
|-------------|-----|----------|------------|----------|-----------|---------------|
| `false`     | 24  | 2 703 ms | **21 200** | 2 703 ms | **21 200**| **0.9998**    |
| `true`      | 141 | 1 593 ms | 3 596      | 5 692    | 14 732    | 0.34          |

Non-streaming TTFT was identical to E2E to four decimal places — the
24 calls were single-handedly pulling the dashboard's TTFT p95 to
21.2 s, which read like a first-token regression but was just E2E for
batched responses.

## Fix

`server/ts-llm/src/processor.rs` `process_exchange` now gates `ttft_ms`
on `req_info.is_stream`:

```rust
let ttft_ms = if req_info.is_stream && response_time > request_time {
    Some((response_time - request_time) as f64 / 1000.0)
} else {
    None
};
```

`e2e_latency_ms` is unchanged — it remains `(complete_ts − request_ts)`
for both streaming and non-streaming.

The metrics bucket already filters `None` via
`if let Some(ttft) = call.ttft_ms` (`server/ts-metrics/src/bucket.rs:194`),
so streaming-only TTFT distributions are restored without touching the
aggregator. Display sites all degrade safely on null:

- `console/src/components/llm-call-detail/timeline-bar.tsx`:
  `(ttft_ms ?? 0) / e2e` → ratio = 0 → entire bar renders as "Gen"
  (the correct semantics for non-streaming).
- `summary-cards.tsx`, `llm-calls.tsx` table column: `formatMs(null)`
  → "—".
- `turn-detail/call-card.tsx` already labels its per-call value
  "TTFB" rather than "TTFT" and handles null.

## Migration

Existing DuckDB rows are not migrated: old non-streaming records keep
their (incorrect) `ttft_ms` values until they roll out of the retention
window. The change applies to all newly-captured calls.

## Tests

Three new unit tests in `processor::tests`:

- **`ttft_is_none_for_non_streaming_request`** — non-streaming exchange
  with `response_time > request_time` (the fixture's stock 100 ms gap)
  yields `ttft_ms = None`, while `e2e_latency_ms` stays populated.
  This is the regression repro.
- **`ttft_is_populated_for_streaming_request`** — streaming exchange
  yields `ttft_ms ≈ 100 ms` and `ttft_ms ≤ e2e_latency_ms`.
- **`ttft_is_none_when_response_predates_request`** — defensive: with
  the new `is_stream` gate `&&`-ed onto the existing
  `response_time > request_time` guard, clock-skew / out-of-order
  reassembly cannot produce a wrap-around negative TTFT.

## Test plan / regression

- [x] `cargo test -p ts-llm --release`: **311 passed, 0 failed**
      (3 new TTFT tests + 308 existing).
- [x] `cargo test -p ts-metrics --release`: 27 passed — confirms the
      bucket aggregator's `if let Some(ttft)` correctly filters out
      the now-NULL non-streaming values.
- [x] `cargo test -p ts-turn --release`: 10 passed — turn-level
      assembly unaffected.
- [x] Live deploy on wuneng:4500 with both this fix and #3 applied;
      a new non-streaming call captured after restart has
      `ttft_ms = null, e2e_latency_ms = 2145 ms` (E2E preserved,
      TTFT correctly NULL'd).
- [x] Smoothness regression suite (PR #3) re-run after deploy:
      dashboard / performance / traffic all pass with 0.0 px chart
      bbox delta — no regression to the auto-refresh fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)