### PR TITLE
feat: in-progress agent-turn visibility via in-memory registry (zero DB write amplification)

### DIFF
--- a/console/src/components/ui/turn-status-badge.tsx
+++ b/console/src/components/ui/turn-status-badge.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils"
 
 const colorMap: Record<string, string> = {
+  in_progress: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
   complete: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
   incomplete: "bg-gray-100 text-gray-600 dark:bg-gray-800/30 dark:text-gray-400",
 }
@@ -11,10 +12,13 @@ export function TurnStatusBadge({ status }: { status: string | null }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium",
+        "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium",
         colorMap[status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800/30 dark:text-gray-400",
       )}
     >
+      {status === "in_progress" && (
+        <span className="size-1.5 rounded-full bg-blue-500 animate-pulse" />
+      )}
       {status}
     </span>
   )

--- a/console/src/pages/agent-turns.tsx
+++ b/console/src/pages/agent-turns.tsx
@@ -9,7 +9,7 @@ import { FilterDropdown } from "@/components/ui/filter-dropdown"
 import { AgentTurnDetailPanel } from "./agent-turn-detail-panel"
 import type { AgentTurnListItem } from "@/types/api"
 
-const STATUS_OPTIONS = ["complete", "incomplete"]
+const STATUS_OPTIONS = ["in_progress", "complete", "incomplete"]
 const AGENT_KIND_OPTIONS = ["claude-cli", "codex-cli", "generic"]
 
 const PAGE_SIZES = [20, 50, 100] as const

--- a/server/app/tokenscope/src/main.rs
+++ b/server/app/tokenscope/src/main.rs
@@ -511,6 +511,12 @@ async fn run_pipeline(cli: Cli) {
         // against the corresponding entry in `per_pipeline_metrics`, and
         // shared (storage sink + queue probes) workers against
         // `shared_metrics`. There is no cross-pipeline metrics stage.
+        // In-memory registry of in-progress agent turns. Shared by every
+        // turn-tracker shard (writers) and the API's /api/agent-turns
+        // handler (reader) so the console sees in-progress turns alongside
+        // finalized ones without DB write amplification.
+        let active_turns = ts_turn::new_active_turn_registry();
+
         let Pipeline {
             pipeline_txs,
             pipeline_sources,
@@ -524,6 +530,7 @@ async fn run_pipeline(cli: Cli) {
             storage.clone(),
             &mut per_pipeline_metrics,
             &mut shared_metrics,
+            active_turns.clone(),
         );
 
         // Start each per-pipeline MetricsSystem and, if enabled, one
@@ -605,6 +612,7 @@ async fn run_pipeline(cli: Cli) {
                     drained: drained.clone(),
                 };
                 let pcap_extract_roots = pcap_extract_roots.clone();
+                let api_active_turns = active_turns.clone();
                 Some(tokio::spawn(async move {
                     let router = ts_api::router(
                         api_storage,
@@ -612,6 +620,7 @@ async fn run_pipeline(cli: Cli) {
                         api_runtime_config,
                         api_health,
                         pcap_extract_roots,
+                        api_active_turns,
                     );
                     #[cfg(feature = "console")]
                     let router = router.fallback(console::static_handler);
@@ -811,6 +820,11 @@ async fn run_pipeline(cli: Cli) {
                         drained: drained.clone(),
                     };
                     let pcap_extract_roots = pcap_extract_roots.clone();
+                    // No pipelines were configured ⇒ no tracker is running ⇒
+                    // the registry stays empty for the lifetime of this
+                    // process. Construct a fresh empty one so the API still
+                    // serves /api/agent-turns (returning DB rows only).
+                    let api_active_turns = ts_turn::new_active_turn_registry();
                     Some(tokio::spawn(async move {
                         let router = ts_api::router(
                             api_storage,
@@ -818,6 +832,7 @@ async fn run_pipeline(cli: Cli) {
                             api_runtime_config,
                             api_health,
                             pcap_extract_roots,
+                            api_active_turns,
                         );
                         #[cfg(feature = "console")]
                         let router = router.fallback(console::static_handler);

--- a/server/app/tokenscope/src/pipeline.rs
+++ b/server/app/tokenscope/src/pipeline.rs
@@ -125,6 +125,7 @@ impl Pipeline {
         storage: Arc<dyn StorageBackend>,
         per_pipeline_metrics: &mut [MetricsSystem],
         shared_metrics: &mut MetricsSystem,
+        active_turns: ts_turn::ActiveTurnRegistry,
     ) -> Self {
         // ---- Shared sinks (fan-in across every pipeline) ----
         // Use the max queue capacity across all pipelines for shared channels.
@@ -353,6 +354,7 @@ impl Pipeline {
                 turn_shard_rxs,
                 turns_tx.clone(),
                 metrics_sys,
+                Some(active_turns.clone()),
             );
             debug_assert_eq!(turn_handles.len(), turn_shards);
             for (j, h) in turn_handles.into_iter().enumerate() {

--- a/server/app/tokenscope/tests/pipeline_e2e.rs
+++ b/server/app/tokenscope/tests/pipeline_e2e.rs
@@ -121,6 +121,7 @@ async fn run_pipeline_multi(fixture_names: &[&str]) -> Option<(TempDir, PathBuf)
         storage.clone(),
         &mut per_pipeline_metrics,
         &mut shared_metrics,
+        ts_turn::new_active_turn_registry(),
     );
     let _metrics_svcs: Vec<_> = per_pipeline_metrics
         .into_iter()

--- a/server/ts-api/Cargo.toml
+++ b/server/ts-api/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 ts-common.workspace = true
 ts-llm.workspace = true
 ts-storage.workspace = true
+ts-turn.workspace = true
 ts-pcap-extract = { workspace = true }
 axum.workspace = true
 tokio.workspace = true

--- a/server/ts-api/src/lib.rs
+++ b/server/ts-api/src/lib.rs
@@ -26,6 +26,7 @@ use ts_common::error::{AppError, Result};
 use ts_common::internal_metrics::MetricsSvc;
 use ts_pcap_extract::PipelineRoot;
 use ts_storage::StorageBackend;
+use ts_turn::ActiveTurnRegistry;
 
 /// Carriers for `/api/internal-metrics` — every per-pipeline `MetricsSvc`
 /// plus the cross-pipeline (storage) one. Build this in `main.rs` after
@@ -64,6 +65,18 @@ pub struct ApiHealthContext {
     pub drained: Arc<AtomicBool>,
 }
 
+/// Composite state for the `/api/agent-turns*` routes. Carries both the
+/// storage backend (for finalized rows) and the in-memory
+/// `ActiveTurnRegistry` (for in-progress rows). The list handler unions
+/// the two; detail / calls only need storage. We pass the composite
+/// around for all three handlers so the registry is available where it
+/// matters without a separate router for the list endpoint.
+#[derive(Clone)]
+pub struct ApiAgentTurnsContext {
+    pub storage: Arc<dyn StorageBackend>,
+    pub active_turns: ActiveTurnRegistry,
+}
+
 /// Bind the API server listener. Call this before spawning so bind errors
 /// propagate to the caller (and can abort startup).
 pub async fn bind(config: &ApiConfig) -> Result<TcpListener> {
@@ -82,6 +95,7 @@ pub fn router(
     runtime_config: ApiRuntimeConfigContext,
     health: ApiHealthContext,
     pcap_roots: Arc<Vec<PipelineRoot>>,
+    active_turns: ActiveTurnRegistry,
 ) -> Router {
     let internal_metrics_routes = Router::new()
         .route(
@@ -105,6 +119,24 @@ pub fn router(
         .route("/api/pcap/extract", get(routes::pcap_extract::handler))
         .with_state(pcap_roots);
 
+    // Agent-turns routes use a composite state (storage + in-memory
+    // active-turn registry) so the list handler can union finalized
+    // (DuckDB) and in-progress (RAM) rows in one response. detail/calls
+    // only need storage but ride on the same composite for plumbing
+    // simplicity.
+    let agent_turns_state = ApiAgentTurnsContext {
+        storage: storage.clone(),
+        active_turns,
+    };
+    let agent_turns_routes = Router::new()
+        .route("/api/agent-turns", get(routes::agent_turns::list))
+        .route("/api/agent-turns/{id}", get(routes::agent_turns::detail))
+        .route(
+            "/api/agent-turns/{id}/calls",
+            get(routes::agent_turns::calls),
+        )
+        .with_state(agent_turns_state);
+
     Router::new()
         .route("/api/filters/wire-apis", get(routes::filters::wire_apis))
         .route("/api/filters/models", get(routes::filters::models))
@@ -127,12 +159,6 @@ pub fn router(
             "/api/http-exchanges/{id}",
             get(routes::http_exchanges::detail),
         )
-        .route("/api/agent-turns", get(routes::agent_turns::list))
-        .route("/api/agent-turns/{id}", get(routes::agent_turns::detail))
-        .route(
-            "/api/agent-turns/{id}/calls",
-            get(routes::agent_turns::calls),
-        )
         .route("/api/agent-sessions", get(routes::agent_sessions::list))
         .route(
             "/api/agent-sessions/{source_id}/{session_id}",
@@ -147,5 +173,6 @@ pub fn router(
         .merge(runtime_config_routes)
         .merge(health_routes)
         .merge(pcap_extract_routes)
+        .merge(agent_turns_routes)
         .layer(CorsLayer::permissive())
 }

--- a/server/ts-api/src/routes/agent_turns.rs
+++ b/server/ts-api/src/routes/agent_turns.rs
@@ -1,14 +1,13 @@
-use std::sync::Arc;
-
 use axum::extract::State;
 use axum::response::IntoResponse;
 use serde::Deserialize;
-use ts_storage::query::TurnsQuery;
-use ts_storage::StorageBackend;
+use ts_storage::query::{TurnListItem, TurnsQuery};
+use ts_turn::AgentTurn;
 
 use crate::extractors::{Path, Query};
 use crate::params::*;
 use crate::response::{ApiError, ApiResponse};
+use crate::ApiAgentTurnsContext;
 
 #[derive(Debug, Deserialize)]
 pub struct TurnsParams {
@@ -50,7 +49,7 @@ fn default_page_size() -> u32 {
 }
 
 pub async fn list(
-    State(storage): State<Arc<dyn StorageBackend>>,
+    State(ctx): State<ApiAgentTurnsContext>,
     Query(params): Query<TurnsParams>,
 ) -> Result<impl IntoResponse, ApiError> {
     let page_size = params.page_size.min(200);
@@ -67,24 +66,190 @@ pub async fn list(
         page_size,
     };
 
-    let page = storage.query_turns(&query).await?;
+    let mut page = ctx.storage.query_turns(&query).await?;
+
+    // Snapshot the in-memory active-turn registry, filter by the same
+    // params the SQL query used, and prepend matching rows to page 1 so
+    // the console shows in-progress turns alongside finalized ones in a
+    // single list. The DB stays terminal-only — no write amplification.
+    let in_progress = collect_in_progress(&ctx, &query);
+    let in_progress_count = in_progress.len() as u64;
+
+    if params.page == 1 && !in_progress.is_empty() {
+        // Always-newest-first: in-progress turns are by definition
+        // currently in flight, so they sort to the head of `start_time desc`
+        // (the default). Even with a custom sort, listing them first is the
+        // "live tip" semantic we want.
+        let mut merged = in_progress;
+        merged.extend(std::mem::take(&mut page.items));
+        page.items = merged;
+    }
+    // total counts the union: DB rows + in-progress rows (the registry's
+    // entries are not in any DB page yet). Pagination math overestimates
+    // by at most `in_progress_count` rows (~ # active sessions, typically
+    // <= 100), which the UI renders as "maybe one extra empty page" — an
+    // acceptable trade for not having to rewrite the page boundary logic.
+    page.total = page.total.saturating_add(in_progress_count);
     Ok(ApiResponse::ok(page))
 }
 
+/// Read the active-turn registry under its read lock, filter by the
+/// query's time range, dimension filter, status, agent_kind, and
+/// client_ip lists, and convert the survivors to `TurnListItem`s.
+fn collect_in_progress(ctx: &ApiAgentTurnsContext, query: &TurnsQuery) -> Vec<TurnListItem> {
+    let map = match ctx.active_turns.read() {
+        Ok(g) => g,
+        Err(_) => return Vec::new(), // poisoned lock — degrade to empty
+    };
+    let start_us = query.time_range.start_us;
+    let end_us = query.time_range.end_us;
+    let filter = &query.filter;
+
+    let mut out: Vec<TurnListItem> = map
+        .values()
+        .filter(|t| {
+            // Time-range overlap with the requested window. An in-progress
+            // turn is "live" between start_time_us and end_time_us
+            // (whatever its latest call's complete_time was). Match if any
+            // part of [start_time_us, end_time_us] overlaps the query window.
+            t.end_time_us >= start_us && t.start_time_us <= end_us
+        })
+        .filter(|t| matches_filter(t, filter))
+        .filter(|t| {
+            // status filter: in-progress rows match only if `in_progress`
+            // is in the requested set, OR if the filter is empty (= all).
+            query.statuses.is_empty() || query.statuses.iter().any(|s| s == "in_progress")
+        })
+        .filter(|t| {
+            query.agent_kinds.is_empty() || query.agent_kinds.iter().any(|k| k == &t.agent_kind)
+        })
+        .filter(|t| {
+            query.client_ips.is_empty()
+                || query
+                    .client_ips
+                    .iter()
+                    .any(|ip| ip == &t.client_ip.to_string())
+        })
+        .map(agent_turn_to_list_item)
+        .collect();
+
+    // Most-recent first by start_time_us — matches the default UI sort.
+    out.sort_by(|a, b| b.start_time.cmp(&a.start_time));
+    out
+}
+
+/// Convert a tracker-side `AgentTurn` to the API list response shape.
+fn agent_turn_to_list_item(t: &AgentTurn) -> TurnListItem {
+    TurnListItem {
+        turn_id: t.turn_id.clone(),
+        source_id: t.source_id.clone(),
+        session_id: t.session_id.clone(),
+        start_time: t.start_time_us,
+        end_time: t.end_time_us,
+        duration_ms: t.duration_ms,
+        wire_api: t.wire_api.clone(),
+        agent_kind: t.agent_kind.clone(),
+        client_ip: t.client_ip.to_string(),
+        server_ip: t.server_ip.to_string(),
+        primary_model: t.models_used.first().cloned(),
+        models_used: t.models_used.clone(),
+        call_count: t.call_count,
+        total_input_tokens: t.total_input_tokens,
+        total_output_tokens: t.total_output_tokens,
+        status: t.status.to_string(),
+        final_finish_reason: t.final_finish_reason.clone(),
+        user_input_preview: t.user_input_preview.clone(),
+        final_answer_preview: t.final_answer_preview.clone(),
+    }
+}
+
+/// Wire-api / model / server-ip dimension filter — mirrors
+/// `query_turns`'s SQL WHERE clause. Each list is an OR group; an empty
+/// list means "any". The turn matches if for every non-empty list at
+/// least one entry matches the corresponding turn field (with `model`
+/// matching against the turn's `models_used` set since a turn can span
+/// several models).
+fn matches_filter(t: &AgentTurn, f: &ts_storage::query::DimensionFilter) -> bool {
+    if !f.wire_apis.is_empty() && !f.wire_apis.iter().any(|w| w == &t.wire_api) {
+        return false;
+    }
+    if !f.models.is_empty() && !f.models.iter().any(|m| t.models_used.iter().any(|tm| tm == m)) {
+        return false;
+    }
+    let server_ip_str = t.server_ip.to_string();
+    if !f.server_ips.is_empty() && !f.server_ips.iter().any(|ip| ip == &server_ip_str) {
+        return false;
+    }
+    true
+}
+
 pub async fn detail(
-    State(storage): State<Arc<dyn StorageBackend>>,
+    State(ctx): State<ApiAgentTurnsContext>,
     Path(turn_id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    match storage.query_turn_by_id(&turn_id).await? {
+    // First look in the in-memory registry — for in-progress turns
+    // there is no DB row yet; the snapshot is the only place where the
+    // turn detail lives.
+    if let Ok(map) = ctx.active_turns.read() {
+        if let Some(t) = map.get(&turn_id) {
+            return Ok(ApiResponse::ok(agent_turn_to_detail(t.clone())));
+        }
+    }
+    match ctx.storage.query_turn_by_id(&turn_id).await? {
         Some(detail) => Ok(ApiResponse::ok(detail)),
         None => Err(ApiError::NotFound(format!("turn not found: {turn_id}"))),
     }
 }
 
+/// Convert a snapshot `AgentTurn` to a `TurnDetail`-shaped payload. The
+/// DB-side `query_turn_by_id` returns a richer `TurnDetail` that pulls
+/// full bodies from referenced `llm_calls` rows; for in-progress turns
+/// we don't have those joins, so the previews and counts are returned
+/// as-is. The frontend tolerates the lighter payload (preview-only).
+fn agent_turn_to_detail(t: AgentTurn) -> ts_storage::query::TurnDetail {
+    use ts_storage::query::TurnDetail;
+    TurnDetail {
+        turn_id: t.turn_id,
+        source_id: t.source_id,
+        session_id: t.session_id,
+        wire_api: t.wire_api,
+        agent_kind: t.agent_kind,
+        client_ip: t.client_ip.to_string(),
+        server_ip: t.server_ip.to_string(),
+        start_time: t.start_time_us,
+        end_time: t.end_time_us,
+        duration_ms: t.duration_ms,
+        call_count: t.call_count,
+        models_used: t.models_used,
+        subagents_used: t.subagents_used,
+        total_input_tokens: t.total_input_tokens,
+        total_output_tokens: t.total_output_tokens,
+        total_cache_read_input_tokens: t.total_cache_read_input_tokens,
+        total_cache_creation_input_tokens: t.total_cache_creation_input_tokens,
+        total_cost_usd: t.total_cost_usd,
+        status: t.status.to_string(),
+        final_finish_reason: t.final_finish_reason,
+        user_call_id: t.user_call_id,
+        user_input: t.user_input_preview,
+        final_call_id: t.final_call_id,
+        final_answer: t.final_answer_preview,
+        call_ids: t.call_ids,
+        metadata: Some(t.metadata),
+    }
+}
+
 pub async fn calls(
-    State(storage): State<Arc<dyn StorageBackend>>,
+    State(ctx): State<ApiAgentTurnsContext>,
     Path(turn_id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let items = storage.query_turn_calls(&turn_id).await?;
+    // In-progress turns currently have no `llm_calls` join — return
+    // an empty list rather than a 404 so the UI can render the detail
+    // panel without a "calls table failed to load" toast.
+    if let Ok(map) = ctx.active_turns.read() {
+        if map.contains_key(&turn_id) {
+            return Ok(ApiResponse::ok(Vec::<ts_storage::query::TurnCallItem>::new()));
+        }
+    }
+    let items = ctx.storage.query_turn_calls(&turn_id).await?;
     Ok(ApiResponse::ok(items))
 }

--- a/server/ts-api/src/routes/agent_turns.rs
+++ b/server/ts-api/src/routes/agent_turns.rs
@@ -242,13 +242,22 @@ pub async fn calls(
     State(ctx): State<ApiAgentTurnsContext>,
     Path(turn_id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // In-progress turns currently have no `llm_calls` join — return
-    // an empty list rather than a 404 so the UI can render the detail
-    // panel without a "calls table failed to load" toast.
-    if let Ok(map) = ctx.active_turns.read() {
-        if map.contains_key(&turn_id) {
-            return Ok(ApiResponse::ok(Vec::<ts_storage::query::TurnCallItem>::new()));
-        }
+    // In-progress turns: pull call_ids from the in-memory registry
+    // snapshot, then ask storage to fetch the matching `llm_calls`
+    // rows. A call may be ingested into the tracker microseconds before
+    // its row gets flushed from `WriteBuffer` to DuckDB; in that
+    // narrow window the call is missing from the result and shows up on
+    // the next refresh. Total lag is bounded by storage.flush_interval_ms
+    // (200 ms after PR #5).
+    let in_progress_call_ids: Option<Vec<String>> = ctx
+        .active_turns
+        .read()
+        .ok()
+        .and_then(|map| map.get(&turn_id).map(|t| t.call_ids.clone()));
+
+    if let Some(call_ids) = in_progress_call_ids {
+        let items = ctx.storage.query_calls_by_ids(&call_ids).await?;
+        return Ok(ApiResponse::ok(items));
     }
     let items = ctx.storage.query_turn_calls(&turn_id).await?;
     Ok(ApiResponse::ok(items))

--- a/server/ts-api/src/routes/llm_calls.rs
+++ b/server/ts-api/src/routes/llm_calls.rs
@@ -147,6 +147,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let resp = app
@@ -190,6 +191,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let resp = app

--- a/server/ts-api/src/routes/metrics.rs
+++ b/server/ts-api/src/routes/metrics.rs
@@ -298,6 +298,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         // start/end are seconds (matches existing /api/metrics/* convention).
@@ -374,6 +375,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let start_s = (ts / 1_000_000) - 1;
@@ -457,6 +459,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let start_s = (ts / 1_000_000) - 1;
@@ -559,6 +562,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let start_s = ts / 1_000_000;
@@ -614,6 +618,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
 
         let start_s = 1_700_000_040i64;
@@ -652,6 +657,7 @@ mod tests {
             test_runtime_config_context(),
             test_health_context(),
             std::sync::Arc::new(vec![]),
+            ts_turn::new_active_turn_registry(),
         );
         let resp = app
             .oneshot(

--- a/server/ts-storage/src/backend.rs
+++ b/server/ts-storage/src/backend.rs
@@ -64,6 +64,14 @@ pub trait StorageBackend: Send + Sync {
     async fn query_turns(&self, query: &TurnsQuery) -> Result<TurnsPage>;
     async fn query_turn_by_id(&self, turn_id: &str) -> Result<Option<TurnDetail>>;
     async fn query_turn_calls(&self, turn_id: &str) -> Result<Vec<TurnCallItem>>;
+    /// Sister of `query_turn_calls` for in-progress turns: the API
+    /// already knows the call_ids (from the in-memory active-turn
+    /// registry) and only needs Step 2 of the join. Returns the same
+    /// `TurnCallItem` shape so the frontend's calls panel renders
+    /// identically whether the turn is still in progress or finalized.
+    /// Calls not yet flushed from `WriteBuffer` to `llm_calls` are
+    /// silently skipped — they appear on the next refresh.
+    async fn query_calls_by_ids(&self, call_ids: &[String]) -> Result<Vec<TurnCallItem>>;
 
     /// Paginated session list (view over `agent_turns`; no materialised
     /// session table). A session is included when at least one of its turns

--- a/server/ts-storage/src/duckdb.rs
+++ b/server/ts-storage/src/duckdb.rs
@@ -432,6 +432,142 @@ fn parse_json_string_list(raw: Option<&str>) -> Vec<String> {
     }
 }
 
+/// Shared "fetch calls by id list" — used by both `query_turn_calls`
+/// (which derives the ids from the persisted `agent_turns.call_ids`)
+/// and `query_calls_by_ids` (which receives the ids directly from the
+/// API for in-progress turns whose call_ids live in the in-memory
+/// active-turn registry). Calls not yet flushed from `WriteBuffer` to
+/// `llm_calls` simply don't return — caller treats that as "show
+/// fewer rows on this refresh, more on the next one."
+fn read_calls_by_ids_sync(
+    conn: &duckdb::Connection,
+    call_ids: &[String],
+) -> Result<Vec<TurnCallItem>> {
+    if call_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(call_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT
+            id,
+            epoch_ms(request_time),
+            epoch_ms(response_time),
+            epoch_ms(complete_time),
+            wire_api, model, status_code, is_stream,
+            finish_reason, ttft_ms, e2e_latency_ms,
+            input_tokens, output_tokens,
+            request_path, client_ip, client_port,
+            server_ip, server_port,
+            request_body, response_body,
+            request_headers, response_headers
+        FROM llm_calls
+        WHERE id IN ({placeholders})
+        ORDER BY request_time ASC, complete_time ASC"
+    );
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| AppError::Storage(format!("failed to prepare turn_calls step2: {e}")))?;
+    let mut rows = stmt
+        .query(duckdb::params_from_iter(call_ids.iter()))
+        .map_err(|e| AppError::Storage(format!("failed to execute turn_calls step2: {e}")))?;
+
+    let mut items = Vec::new();
+    let mut seq: u32 = 0;
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| AppError::Storage(format!("row error: {e}")))?
+    {
+        seq += 1;
+        items.push(TurnCallItem {
+            id: row
+                .get(0)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            sequence: seq,
+            request_time: row
+                .get(1)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            response_time: row
+                .get::<_, Option<i64>>(2)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            complete_time: row
+                .get::<_, Option<i64>>(3)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            wire_api: row
+                .get(4)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            model: row
+                .get(5)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            status_code: row
+                .get::<_, Option<u16>>(6)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            is_stream: row
+                .get(7)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            finish_reason: row
+                .get::<_, Option<String>>(8)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            ttft_ms: row
+                .get::<_, Option<f64>>(9)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            e2e_latency_ms: row
+                .get::<_, Option<f64>>(10)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            input_tokens: {
+                let v: Option<u32> = row
+                    .get(11)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                v
+            },
+            output_tokens: {
+                let v: Option<u32> = row
+                    .get(12)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                v
+            },
+            tokens_estimated: false, // overwritten below once we read response_body
+            request_path: row
+                .get(13)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            client_ip: row
+                .get(14)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            client_port: row
+                .get(15)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            server_ip: row
+                .get(16)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            server_port: row
+                .get(17)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            request_body: row
+                .get::<_, Option<String>>(18)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            response_body: row
+                .get::<_, Option<String>>(19)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            request_headers: row
+                .get::<_, Option<String>>(20)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+            response_headers: row
+                .get::<_, Option<String>>(21)
+                .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
+        });
+        let last = items.last_mut().expect("just pushed");
+        last.tokens_estimated = derive_tokens_estimated(
+            last.input_tokens,
+            last.output_tokens,
+            last.response_body.as_deref(),
+        );
+    }
+    Ok(items)
+}
+
 enum ExtractKind {
     User,
     Assistant,
@@ -2725,139 +2861,24 @@ impl StorageBackend for DuckDbBackend {
             };
 
             let call_ids = parse_json_string_list(call_ids_raw.as_deref());
-            if call_ids.is_empty() {
-                return Ok(Vec::new());
-            }
-
-            // Step 2: fetch calls by id via PK point-lookups in IN (...).
-            let placeholders = std::iter::repeat("?")
-                .take(call_ids.len())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let sql = format!(
-                "SELECT
-                    id,
-                    epoch_ms(request_time),
-                    epoch_ms(response_time),
-                    epoch_ms(complete_time),
-                    wire_api, model, status_code, is_stream,
-                    finish_reason, ttft_ms, e2e_latency_ms,
-                    input_tokens, output_tokens,
-                    request_path, client_ip, client_port,
-                    server_ip, server_port,
-                    request_body, response_body,
-                    request_headers, response_headers
-                FROM llm_calls
-                WHERE id IN ({placeholders})
-                ORDER BY request_time ASC, complete_time ASC"
-            );
-
-            let mut stmt = conn.prepare(&sql).map_err(|e| {
-                AppError::Storage(format!("failed to prepare turn_calls step2: {e}"))
-            })?;
-
-            let mut rows = stmt
-                .query(duckdb::params_from_iter(call_ids.iter()))
-                .map_err(|e| {
-                    AppError::Storage(format!("failed to execute turn_calls step2: {e}"))
-                })?;
-
-            let mut items = Vec::new();
-            let mut seq: u32 = 0;
-            while let Some(row) = rows
-                .next()
-                .map_err(|e| AppError::Storage(format!("row error: {e}")))?
-            {
-                seq += 1;
-                items.push(TurnCallItem {
-                    id: row
-                        .get(0)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    sequence: seq,
-                    request_time: row
-                        .get(1)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    response_time: row
-                        .get::<_, Option<i64>>(2)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    complete_time: row
-                        .get::<_, Option<i64>>(3)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    wire_api: row
-                        .get(4)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    model: row
-                        .get(5)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    status_code: row
-                        .get::<_, Option<u16>>(6)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    is_stream: row
-                        .get(7)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    finish_reason: row
-                        .get::<_, Option<String>>(8)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    ttft_ms: row
-                        .get::<_, Option<f64>>(9)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    e2e_latency_ms: row
-                        .get::<_, Option<f64>>(10)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    input_tokens: {
-                        let v: Option<u32> = row
-                            .get(11)
-                            .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
-                        v
-                    },
-                    output_tokens: {
-                        let v: Option<u32> = row
-                            .get(12)
-                            .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
-                        v
-                    },
-                    tokens_estimated: false, // overwritten below once we read response_body
-                    request_path: row
-                        .get(13)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    client_ip: row
-                        .get(14)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    client_port: row
-                        .get(15)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    server_ip: row
-                        .get(16)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    server_port: row
-                        .get(17)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    request_body: row
-                        .get::<_, Option<String>>(18)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    response_body: row
-                        .get::<_, Option<String>>(19)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    request_headers: row
-                        .get::<_, Option<String>>(20)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                    response_headers: row
-                        .get::<_, Option<String>>(21)
-                        .map_err(|e| AppError::Storage(format!("read error: {e}")))?,
-                });
-                // Now backfill tokens_estimated from the values just inserted.
-                let last = items.last_mut().expect("just pushed");
-                last.tokens_estimated = derive_tokens_estimated(
-                    last.input_tokens,
-                    last.output_tokens,
-                    last.response_body.as_deref(),
-                );
-            }
-
-            Ok(items)
+            // Step 2 lives in a shared helper so `query_calls_by_ids` (used
+            // by the API for in-progress turns whose call_ids come from
+            // the in-memory registry) can reuse the exact same projection.
+            read_calls_by_ids_sync(&conn, &call_ids)
         })
         .await
         .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
+    }
+
+    async fn query_calls_by_ids(&self, call_ids: &[String]) -> Result<Vec<TurnCallItem>> {
+        if call_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.read_pool.acquire().await?;
+        let call_ids: Vec<String> = call_ids.to_vec();
+        tokio::task::spawn_blocking(move || read_calls_by_ids_sync(&conn, &call_ids))
+            .await
+            .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
     }
 
     async fn query_sessions(&self, query: &SessionListQuery) -> Result<SessionsPage> {

--- a/server/ts-storage/src/sink.rs
+++ b/server/ts-storage/src/sink.rs
@@ -326,6 +326,9 @@ mod tests {
         async fn query_turn_calls(&self, _turn_id: &str) -> Result<Vec<TurnCallItem>> {
             Ok(vec![])
         }
+        async fn query_calls_by_ids(&self, _call_ids: &[String]) -> Result<Vec<TurnCallItem>> {
+            Ok(vec![])
+        }
         async fn query_sessions(&self, _query: &SessionListQuery) -> Result<SessionsPage> {
             Ok(SessionsPage {
                 items: vec![],

--- a/server/ts-turn/src/lib.rs
+++ b/server/ts-turn/src/lib.rs
@@ -7,6 +7,6 @@ pub mod model;
 pub mod stage;
 pub mod tracker;
 
-pub use model::{AgentTurn, TurnKey, TurnStatus};
+pub use model::{new_active_turn_registry, ActiveTurnRegistry, AgentTurn, TurnKey, TurnStatus};
 pub use stage::spawn_turn_stage;
 pub use tracker::{TurnEvent, TurnTracker};

--- a/server/ts-turn/src/model.rs
+++ b/server/ts-turn/src/model.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::net::IpAddr;
+use std::sync::{Arc, RwLock};
 
 /// Composite key identifying a single in-flight turn.
 ///
@@ -13,13 +15,22 @@ pub struct TurnKey {
     pub turn_id: String,
 }
 
-/// Whether this turn closed cleanly. The wire-level reason (e.g. `end_turn`,
-/// `max_tokens`, `refusal`) lives in `final_finish_reason: Option<String>` —
-/// status only encodes "did a terminal land before finalize". `Incomplete`
-/// means we never saw a wire-level terminal: idle timeout, pcap EOF, server
-/// shutdown, or connection RST mid-stream.
+/// Lifecycle state of an agent turn. Three states:
+///
+/// * `InProgress` — at least one call has been ingested for this turn, no
+///   wire-level terminal has landed yet. Lives only in the in-memory
+///   [`ActiveTurnRegistry`]; never written to the `agent_turns` table.
+/// * `Complete` — a main-agent terminal call (e.g. `end_turn`,
+///   `max_tokens`, `refusal`) landed and the buffer's grace window expired.
+///   Persisted to the `agent_turns` table.
+/// * `Incomplete` — buffer drained without a terminal (idle timeout, pcap
+///   EOF, server shutdown, RST mid-stream). Persisted to `agent_turns`.
+///
+/// The wire-level reason (e.g. `end_turn`) lives separately in
+/// `final_finish_reason: Option<String>`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TurnStatus {
+    InProgress,
     Complete,
     Incomplete,
 }
@@ -27,10 +38,41 @@ pub enum TurnStatus {
 impl fmt::Display for TurnStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            TurnStatus::InProgress => write!(f, "in_progress"),
             TurnStatus::Complete => write!(f, "complete"),
             TurnStatus::Incomplete => write!(f, "incomplete"),
         }
     }
+}
+
+/// In-memory registry of currently-in-flight agent turns, keyed by
+/// `turn_id`. Each `TurnTracker` writes a snapshot here on every ingest
+/// (replacing any prior snapshot for the same turn_id), and removes the
+/// entry when the turn finalizes. The `ts-api` `/api/agent-turns` handler
+/// reads this registry, filters by the requested time window, and unions
+/// the result with rows persisted in DuckDB so the console sees both
+/// in-progress and finalized turns in one list.
+///
+/// Why a registry instead of writing to DuckDB on every call:
+/// * On a busy capbench run (100 concurrent agents × 50 calls/turn) the
+///   per-call DB upsert path would cost ~50 000 writes per session.
+///   HashMap insert is ~100 ns; DuckDB upsert is ~5 ms. Same visibility
+///   guarantee, no write amplification.
+/// * The `agent_turns` table stays the canonical source of truth for
+///   *finalized* turns (clean SQL semantics; survives restart). The
+///   registry is a short-lived "currently observable" view layered on
+///   top of it.
+///
+/// A server restart loses the registry; in-progress turns vanish from
+/// `/api/agent-turns` until either the next ingest re-creates them or
+/// the turn finalizes and writes to DuckDB. This matches the existing
+/// in-memory `SessionBuffer` behavior — both were already RAM-only.
+pub type ActiveTurnRegistry = Arc<RwLock<HashMap<String, AgentTurn>>>;
+
+/// Construct an empty `ActiveTurnRegistry` ready to share between
+/// trackers and the API.
+pub fn new_active_turn_registry() -> ActiveTurnRegistry {
+    Arc::new(RwLock::new(HashMap::new()))
 }
 
 /// Aggregated record for one agent turn (user input → final assistant output).

--- a/server/ts-turn/src/stage.rs
+++ b/server/ts-turn/src/stage.rs
@@ -13,16 +13,22 @@ use tokio::task::JoinHandle;
 use ts_common::internal_metrics::{Metric, MetricsSystem};
 use ts_llm::model::TurnShardInput;
 
-use crate::model::AgentTurn;
+use crate::model::{ActiveTurnRegistry, AgentTurn};
 use crate::tracker::{TrackerConfig, TurnEvent, TurnTracker};
 
 /// Spawn one turn-tracker task per shard (inferred from `shard_rxs.len()`).
 /// Panics on empty `shard_rxs` — a wiring bug in the composition root.
+///
+/// `active_registry` is the shared in-memory map of in-progress turns,
+/// written by every tracker on each ingest and read by the API. `None`
+/// disables the in-progress visibility path (used by tests that don't
+/// need it).
 pub fn spawn_turn_stage(
     tracker_cfg: TrackerConfig,
     shard_rxs: Vec<mpsc::Receiver<TurnShardInput>>,
     turns_tx: mpsc::Sender<AgentTurn>,
     metrics_sys: &mut MetricsSystem,
+    active_registry: Option<ActiveTurnRegistry>,
 ) -> Vec<JoinHandle<()>> {
     assert!(
         !shard_rxs.is_empty(),
@@ -63,9 +69,10 @@ pub fn spawn_turn_stage(
                 Metric::TurnHeartbeatsReceived,
             ],
         );
+        let registry_clone = active_registry.clone();
         handles.push(tokio::spawn(async move {
             let shard = i;
-            let mut tracker = TurnTracker::new(tracker_cfg, worker_metrics);
+            let mut tracker = TurnTracker::with_registry(tracker_cfg, worker_metrics, registry_clone);
             let reason = 'main: loop {
                 let input = match rx.recv().await {
                     Some(x) => x,
@@ -204,6 +211,7 @@ mod tests {
             vec![shard_rx],
             turns_tx.clone(),
             &mut metrics_sys,
+            None,
         );
         let _svc = metrics_sys.start();
         drop(turns_tx);
@@ -255,6 +263,7 @@ mod tests {
             shard_rxs,
             turns_tx.clone(),
             &mut metrics_sys,
+            None,
         );
         let _svc = metrics_sys.start();
         drop(turns_tx);
@@ -301,6 +310,7 @@ mod tests {
             vec![],
             _turns_tx,
             &mut metrics_sys,
+            None,
         );
     }
 }

--- a/server/ts-turn/src/tracker.rs
+++ b/server/ts-turn/src/tracker.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use ts_common::internal_metrics::{Metric, MetricsWorker};
 use ts_llm::model::AgentCall;
 
-use crate::model::{AgentTurn, TurnStatus};
+use crate::model::{ActiveTurnRegistry, AgentTurn, TurnStatus};
 
 const FINAL_ANSWER_PREVIEW_CHARS: usize = 500;
 const USER_INPUT_PREVIEW_CHARS: usize = 500;
@@ -93,6 +93,14 @@ struct SessionBuffer {
     /// Latest per-source `virtual_now` observed for this buffer, in
     /// event-time µs. Used as the idle reference by `sweep` / `gc_buffers`.
     last_activity_us: i64,
+    /// Stable `turn_id` for the in-progress turn currently assembling in
+    /// this buffer. Minted lazily on the first ingest after the previous
+    /// turn was finalized; reused by every snapshot inserted into the
+    /// `ActiveTurnRegistry` and by the eventual `Completed` turn so the
+    /// in-memory in-progress entry's id matches the row that gets
+    /// persisted (lets the API drop the registry entry without a
+    /// frontend "row jump"). Cleared on every finalize / sweep / flush.
+    current_turn_id: Option<String>,
 }
 
 /// Single stateful owner of turn assembly. Passive: callers drive it via
@@ -120,16 +128,35 @@ pub struct TurnTracker {
     /// only controls how often `sweep` iterates buffers, not correctness.
     last_sweep_us: i64,
     metrics: MetricsWorker,
+    /// Optional in-memory registry of in-progress turns, shared between
+    /// every tracker and the API handler. When present, every `ingest_at`
+    /// upserts a snapshot into the registry, and every finalize /
+    /// sweep / flush removes the entry. `None` is used by tests that
+    /// don't care about the snapshot path.
+    active_registry: Option<ActiveTurnRegistry>,
 }
 
 impl TurnTracker {
     pub fn new(config: TrackerConfig, metrics: MetricsWorker) -> Self {
+        Self::with_registry(config, metrics, None)
+    }
+
+    /// Variant that wires an [`ActiveTurnRegistry`] into the tracker so
+    /// the API can read in-progress snapshots without going through the
+    /// DB or a channel fan-out. Pipelines call this; tests that don't
+    /// exercise the snapshot path use [`Self::new`].
+    pub fn with_registry(
+        config: TrackerConfig,
+        metrics: MetricsWorker,
+        active_registry: Option<ActiveTurnRegistry>,
+    ) -> Self {
         Self {
             config,
             buffers: HashMap::new(),
             virtual_now_by_source: HashMap::new(),
             last_sweep_us: 0,
             metrics,
+            active_registry,
         }
     }
 
@@ -169,6 +196,7 @@ impl TurnTracker {
             .or(ic.call.response_time)
             .unwrap_or(ic.call.request_time);
         let source_id = ic.call.source_id.clone();
+        let session_id = ic.agent.session_id.clone();
         let virtual_now = self.bump_event_time(&source_id, arrival_ts);
         self.metrics.counter(Metric::TurnCallsIngested).inc();
 
@@ -179,7 +207,7 @@ impl TurnTracker {
             return self.flush_ready_buffers(now_wall);
         }
 
-        let key = (source_id, ic.agent.session_id.clone());
+        let key = (source_id.clone(), session_id.clone());
         let buf = self.buffers.entry(key).or_default();
 
         if let Some(hw) = buf.last_finalized_request_time {
@@ -207,7 +235,93 @@ impl TurnTracker {
             buf.grace_started_at_wall = Some(now_wall);
         }
 
+        // Mint a stable `turn_id` for this in-progress turn the first time we
+        // see a call after the previous turn finalized. Reused by every
+        // registry snapshot AND by the eventual persisted `Completed`, so the
+        // `agent_turns` row's `turn_id` matches the in-progress entry the
+        // console has been showing. Cleared by `emit_or_discard` after
+        // finalize so the next ingest mints a fresh one.
+        if buf.current_turn_id.is_none() {
+            buf.current_turn_id = Some(Uuid::now_v7().to_string());
+        }
+
+        // Refresh the registry's snapshot for this turn. Cheap (one HashMap
+        // upsert + an AgentTurn alloc); skipped if no registry is wired (e.g.
+        // tests via `TurnTracker::new`).
+        self.refresh_active_snapshot(&source_id, &session_id);
+
         self.flush_ready_buffers(now_wall)
+    }
+
+    /// Build the in-progress AgentTurn snapshot for a given session and
+    /// upsert it into the active registry. Truncates the partition at the
+    /// first main-agent terminal so multi-turn buffers don't mix two
+    /// turns' state into one snapshot. Applies the same discard rule as
+    /// `emit_or_discard` so we don't leak phantom in-progress rows for
+    /// sub-agent-only filler sessions.
+    fn refresh_active_snapshot(&self, source_id: &str, session_id: &str) {
+        let registry = match &self.active_registry {
+            Some(r) => r,
+            None => return,
+        };
+        let buf = match self.buffers.get(&(source_id.to_string(), session_id.to_string())) {
+            Some(b) => b,
+            None => return,
+        };
+        let turn_id = match &buf.current_turn_id {
+            Some(id) => id.clone(),
+            None => return,
+        };
+
+        // Partition: calls up to and including the first main-agent terminal.
+        let partition: Vec<&AgentCall> = {
+            let mut sorted: Vec<&BufferedCall> = buf.pending.values().flatten().collect();
+            sorted.sort_by_key(|bc| bc.ic.call.request_time);
+            let mut acc: Vec<&AgentCall> = Vec::with_capacity(sorted.len());
+            for bc in sorted {
+                acc.push(&bc.ic);
+                if bc.is_terminal {
+                    break;
+                }
+            }
+            acc
+        };
+        if partition.is_empty() {
+            return;
+        }
+        // Same discard rule as emit_or_discard — only show in-progress rows
+        // whose partition has a main-agent user_turn_start. Without this, a
+        // sub-agent dispatch's first call (which carries
+        // `is_user_turn_start=Some(true)` AND `subagent_name=Some(_)`) would
+        // produce a phantom row that finalize will eventually drop.
+        let has_user_start = partition.iter().any(|ic| {
+            ic.agent.subagent_name.is_none() && ic.agent.is_user_turn_start == Some(true)
+        });
+        if !has_user_start {
+            return;
+        }
+
+        let mut snap = build_turn(&partition, Some(turn_id.clone()), Some(TurnStatus::InProgress));
+        snap.source_id = source_id.to_string();
+        snap.session_id = session_id.to_string();
+
+        if let Ok(mut map) = registry.write() {
+            map.insert(turn_id, snap);
+        }
+    }
+
+    /// Read-side helper used by tests to inspect the registry contents
+    /// without going through the lock directly. Returns a clone of every
+    /// in-progress snapshot currently registered. Production reads happen
+    /// in `ts-api` directly against the `ActiveTurnRegistry` Arc.
+    pub fn snapshot_active(&self) -> Vec<AgentTurn> {
+        match &self.active_registry {
+            Some(reg) => reg
+                .read()
+                .map(|map| map.values().cloned().collect())
+                .unwrap_or_default(),
+            None => Vec::new(),
+        }
     }
 
     /// Walk every buffer; for each whose front-pending terminal's grace has
@@ -239,7 +353,28 @@ impl TurnTracker {
             );
         }
         self.gc_buffers();
+        self.drop_completed_from_registry(&events);
         events
+    }
+
+    /// After any Completed turn is emitted, drop its in-progress entry
+    /// from the registry — the persisted DB row replaces it in the API's
+    /// UNION view, so leaving the snapshot would double-count. Idempotent;
+    /// safe to call with stacked-partition turn_ids that were never in
+    /// the registry.
+    fn drop_completed_from_registry(&self, events: &[TurnEvent]) {
+        let registry = match &self.active_registry {
+            Some(r) => r,
+            None => return,
+        };
+        let mut map = match registry.write() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        for ev in events {
+            let TurnEvent::Completed(t) = ev;
+            map.remove(&t.turn_id);
+        }
     }
 
     /// Drop fully-drained buffers whose `last_activity_us` is well past the
@@ -339,6 +474,10 @@ impl TurnTracker {
                 .expect("non-empty");
             buf.last_finalized_request_time = Some(max_request_time);
             buf.grace_started_at_wall = None;
+            // Reuse the in-progress turn_id so the persisted Incomplete
+            // turn shares the same id the registry has been advertising.
+            // The registry entry will be dropped at the end of this fn.
+            let turn_id_override = buf.current_turn_id.take();
 
             // sweep already counts itself via FinalizeKind::Idle inside
             // emit_or_discard; the returned bool isn't needed here.
@@ -346,12 +485,14 @@ impl TurnTracker {
                 &key.0,
                 &key.1,
                 &drained,
+                turn_id_override,
                 &self.metrics,
                 &mut events,
                 FinalizeKind::Idle,
             );
         }
         self.gc_buffers();
+        self.drop_completed_from_registry(&events);
         events
     }
 
@@ -407,17 +548,25 @@ impl TurnTracker {
                 .expect("non-empty");
             buf.last_finalized_request_time = Some(max_request_time);
             buf.grace_started_at_wall = None;
+            // Step 1's finalize_session may already have consumed
+            // current_turn_id; if any non-terminal tail is still here it
+            // belongs to a turn that the shutdown caught mid-flight. Reuse
+            // the id when present so the API's UNION view doesn't briefly
+            // show two rows (in-progress + Incomplete) for the same turn.
+            let turn_id_override = buf.current_turn_id.take();
             // flush_all's non-terminal tail doesn't have a dedicated counter
             // beyond TurnsCompleted (bumped inside emit_or_discard).
             let _ = emit_or_discard(
                 &key.0,
                 &key.1,
                 &drained,
+                turn_id_override,
                 &self.metrics,
                 &mut events,
                 FinalizeKind::Flush,
             );
         }
+        self.drop_completed_from_registry(&events);
         events
     }
 }
@@ -481,10 +630,19 @@ fn finalize_session(
         // the loop may have already pushed a Completed in a previous
         // iteration, which would falsely bump the grace counter for a
         // discarded partition.
+        //
+        // First pass through the loop: hand the buffer's in-progress
+        // current_turn_id to emit_or_discard so the persisted Completed
+        // shares the id with the active-registry snapshot. Subsequent
+        // partitions in the same buffer are independent turns that never
+        // had an in-progress entry, so they get fresh UUIDs (None →
+        // build_turn mints).
+        let turn_id_override = buf.current_turn_id.take();
         let emitted = emit_or_discard(
             source_id,
             session_id,
             &turn_calls,
+            turn_id_override,
             metrics,
             events,
             FinalizeKind::Flush, // grace-driven; only bump grace counter if actually emitted
@@ -500,7 +658,13 @@ fn finalize_session(
 
 /// Apply the discard rule and emit (or count-and-drop) one turn per drained
 /// partition. The caller has already removed `calls` from the buffer and
-/// updated bookkeeping.
+/// updated bookkeeping. Pass `turn_id_override` to reuse the in-progress
+/// snapshot's `turn_id` (so the persisted `Completed` carries the same id
+/// the active registry has been advertising — when the API drops the
+/// registry entry on UNION, the row appears to "transition" in place
+/// rather than disappear-and-reappear). `None` lets `build_turn` mint a
+/// fresh UUID — used by partitions that never had an in-progress entry
+/// (stacked terminals in one finalize_session loop, shutdown drains).
 ///
 /// Returns `true` iff a `TurnEvent::Completed` was actually pushed — callers
 /// that need to count grace-finalizations can rely on this instead of
@@ -511,6 +675,7 @@ fn emit_or_discard(
     source_id: &str,
     session_id: &str,
     calls: &[BufferedCall],
+    turn_id_override: Option<String>,
     metrics: &MetricsWorker,
     events: &mut Vec<TurnEvent>,
     kind: FinalizeKind,
@@ -533,7 +698,7 @@ fn emit_or_discard(
     }
 
     let refs: Vec<&AgentCall> = calls.iter().map(|bc| &bc.ic).collect();
-    let mut turn = build_turn(&refs);
+    let mut turn = build_turn(&refs, turn_id_override, None);
     // The buffer key is authoritative for source/session — call.source_id
     // can legitimately be empty in tests; identity.session_id may differ
     // from a future cross-bucket scheme. Using the key keeps us consistent.
@@ -553,7 +718,20 @@ fn push_unique(list: &mut Vec<String>, value: String) {
     }
 }
 
-/// Pure constructor over a request_time-sorted, complete partition.
+/// Pure constructor over a request_time-sorted partition.
+///
+/// `turn_id_override`: caller-supplied id. Used by the in-progress
+/// snapshot path so every snapshot for the same in-flight turn shares
+/// one id, and the eventual finalized `AgentTurn` carries the same id
+/// the registry has been advertising. `None` mints a fresh UUID.
+///
+/// `status_override`: forces a status. Used by the in-progress snapshot
+/// path to pin `InProgress` even when the partition's terminal call has
+/// already landed (which can happen briefly during the grace window —
+/// the user shouldn't see the row flip via a snapshot; that transition
+/// belongs to the persisted Completed). `None` falls back to derived
+/// status (Complete iff a main-agent terminal is in the partition;
+/// Incomplete otherwise).
 ///
 /// Turn status and `final_*` are both derived from the composed main-agent
 /// terminal pick — `agent.subagent_name.is_none() && agent.is_turn_terminal`,
@@ -565,7 +743,11 @@ fn push_unique(list: &mut Vec<String>, value: String) {
 /// canonical decision lives upstream. For partitions drained via idle-sweep
 /// / EOF-flush with no terminal in the buffer, `final_*` stay `None` and
 /// status falls to `Incomplete`.
-fn build_turn(calls: &[&AgentCall]) -> AgentTurn {
+fn build_turn(
+    calls: &[&AgentCall],
+    turn_id_override: Option<String>,
+    status_override: Option<TurnStatus>,
+) -> AgentTurn {
     assert!(!calls.is_empty(), "build_turn requires at least one call");
     let first = calls[0];
     let source_id = first.call.source_id.clone();
@@ -574,7 +756,7 @@ fn build_turn(calls: &[&AgentCall]) -> AgentTurn {
     let wire_api = first.call.wire_api.to_string();
     let client_ip = first.call.client_ip;
     let server_ip = first.call.server_ip;
-    let turn_id = Uuid::now_v7().to_string();
+    let turn_id = turn_id_override.unwrap_or_else(|| Uuid::now_v7().to_string());
 
     let start_time_us = first.call.request_time;
     let end_time_us = calls
@@ -651,11 +833,15 @@ fn build_turn(calls: &[&AgentCall]) -> AgentTurn {
     // `terminal` is `Some` iff a real wire-level terminal landed before
     // finalize. Wire-level vocabulary (`end_turn`, `max_tokens`, `refusal`,
     // `completed`, …) lives entirely in `final_finish_reason` below; status
-    // is the binary "did we close cleanly" signal.
-    let status = match terminal {
+    // is the lifecycle signal. `status_override` lets the in-progress
+    // snapshot path pin `InProgress` even when the terminal has already
+    // landed in the partition (which can happen briefly during the grace
+    // window — the row should flip to Complete only via the Completed
+    // event, never via an in-progress snapshot).
+    let status = status_override.unwrap_or_else(|| match terminal {
         Some(_) => TurnStatus::Complete,
         None => TurnStatus::Incomplete,
-    };
+    });
 
     let (final_answer_preview, final_call_id, final_finish_reason) = match terminal {
         Some(ic) => {
@@ -1322,5 +1508,243 @@ mod tests {
         // And nothing should now be buffered for this session beyond what's
         // already finalized — c0 was dropped at the entry guard.
         assert_eq!(t.active_count(), 0);
+    }
+
+    // -----------------------------------------------------------------
+    // ActiveTurnRegistry — in-memory in-progress visibility (PR B / Plan C)
+    // -----------------------------------------------------------------
+
+    fn mk_tracker_with_registry() -> (TurnTracker, crate::model::ActiveTurnRegistry) {
+        let reg = crate::model::new_active_turn_registry();
+        let t = TurnTracker::with_registry(TrackerConfig::default(), test_metrics(), Some(reg.clone()));
+        (t, reg)
+    }
+
+    fn registry_snapshot(reg: &crate::model::ActiveTurnRegistry) -> Vec<AgentTurn> {
+        reg.read().unwrap().values().cloned().collect()
+    }
+
+    #[test]
+    fn registry_holds_in_progress_after_first_call() {
+        // First user_start call: tracker mints turn_id, builds an
+        // InProgress snapshot, and inserts it into the registry. The
+        // API reading the registry sees the turn before any DB write.
+        let (mut t, reg) = mk_tracker_with_registry();
+        let c1 = anthropic_call("S-reg", 1_000_000, "text", "tool_use");
+        let id1 = call_info_for_anthropic(&c1);
+        let events = t.ingest(ic(c1, id1));
+        assert!(
+            drain_completed(events).is_empty(),
+            "no terminal landed yet — no Completed event"
+        );
+
+        let snaps = registry_snapshot(&reg);
+        assert_eq!(snaps.len(), 1, "exactly one in-progress snapshot");
+        let s = &snaps[0];
+        assert_eq!(s.status, TurnStatus::InProgress);
+        assert_eq!(s.call_count, 1);
+        assert_eq!(s.session_id, "S-reg");
+        assert!(s.final_finish_reason.is_none());
+        assert!(s.final_call_id.is_none());
+    }
+
+    #[test]
+    fn registry_updates_in_place_on_each_ingest() {
+        // Subsequent calls in the same turn upsert the SAME registry
+        // entry (same turn_id) with the latest cumulative state — the
+        // map never grows beyond one entry per session.
+        let (mut t, reg) = mk_tracker_with_registry();
+        let c1 = anthropic_call("S-upd", 1_000_000, "text", "tool_use");
+        let id1 = call_info_for_anthropic(&c1);
+        let _ = t.ingest(ic(c1, id1));
+        let first_id = registry_snapshot(&reg)[0].turn_id.clone();
+
+        let c2 = anthropic_call("S-upd", 2_000_000, "tool_result", "tool_use");
+        let id2 = call_info_for_anthropic(&c2);
+        let _ = t.ingest(ic(c2, id2));
+        let c3 = anthropic_call("S-upd", 3_000_000, "tool_result", "tool_use");
+        let id3 = call_info_for_anthropic(&c3);
+        let _ = t.ingest(ic(c3, id3));
+
+        let snaps = registry_snapshot(&reg);
+        assert_eq!(snaps.len(), 1, "one entry per session, upserted in place");
+        let s = &snaps[0];
+        assert_eq!(s.turn_id, first_id, "turn_id stable across ingests");
+        assert_eq!(s.call_count, 3, "snapshot reflects cumulative state");
+        assert_eq!(s.status, TurnStatus::InProgress);
+    }
+
+    #[test]
+    fn registry_drops_entry_after_grace_completes_turn() {
+        // Once the terminal call lands and grace expires, the persisted
+        // Completed event reuses the in-progress turn_id, AND the
+        // registry entry is removed so the API doesn't double-count
+        // the turn (one in-memory + one in DuckDB).
+        let (mut t, reg) = mk_tracker_with_registry();
+        let now = std::time::Instant::now();
+
+        let c1 = anthropic_call("S-grace", 1_000_000, "text", "tool_use");
+        let id1 = call_info_for_anthropic(&c1);
+        let _ = t.ingest_at(ic(c1, id1), now);
+        let in_progress_id = registry_snapshot(&reg)[0].turn_id.clone();
+        assert_eq!(registry_snapshot(&reg).len(), 1);
+
+        let c2 = anthropic_call("S-grace", 2_000_000, "tool_result", "end_turn");
+        let id2 = call_info_for_anthropic(&c2);
+        let _ = t.ingest_at(ic(c2, id2), now + Duration::from_millis(50));
+
+        // Force grace expiry.
+        let later = now + Duration::from_secs(2);
+        let events = t.flush_all_at(later);
+        let completed = drain_completed(events);
+        assert_eq!(completed.len(), 1, "exactly one Completed");
+        assert_eq!(
+            completed[0].turn_id, in_progress_id,
+            "Completed reuses in-progress turn_id (UI sees in-place transition)"
+        );
+        assert_eq!(completed[0].status, TurnStatus::Complete);
+        assert!(
+            registry_snapshot(&reg).is_empty(),
+            "registry entry must be removed once Completed lands in DB"
+        );
+    }
+
+    #[test]
+    fn registry_drops_entry_after_idle_sweep() {
+        // Idle path: no terminal arrives, but `idle_timeout_us` of
+        // event-time inactivity passes. Sweep emits Completed/Incomplete
+        // and the registry entry is removed so the user sees the row
+        // flip in place from in_progress to incomplete (rather than the
+        // in-progress row hanging around with the same turn_id as a
+        // newly-persisted incomplete row).
+        let cfg = TrackerConfig {
+            idle_timeout_us: 1_000_000,
+            sweep_interval_us: 100_000,
+            grace: Duration::from_millis(1_000),
+        };
+        let reg = crate::model::new_active_turn_registry();
+        let mut t = TurnTracker::with_registry(cfg, test_metrics(), Some(reg.clone()));
+        let now = std::time::Instant::now();
+
+        let c1 = anthropic_call("S-idle", 1_000_000, "text", "tool_use");
+        let id1 = call_info_for_anthropic(&c1);
+        let _ = t.ingest_at(ic(c1, id1), now);
+        let in_progress_id = registry_snapshot(&reg)[0].turn_id.clone();
+
+        let events = t.advance_time_at(3_500_000, "", now);
+        let completed = drain_completed(events);
+        assert_eq!(completed.len(), 1, "idle sweep emits exactly one Completed");
+        assert_eq!(completed[0].turn_id, in_progress_id);
+        assert_eq!(completed[0].status, TurnStatus::Incomplete);
+        assert!(
+            registry_snapshot(&reg).is_empty(),
+            "idle sweep must drop the in-progress registry entry"
+        );
+    }
+
+    #[test]
+    fn registry_skips_subagent_only_partition() {
+        // The discard rule (no main-agent user_turn_start → drop on
+        // finalize) must apply at registry-insert time too — otherwise
+        // the API would briefly show a phantom in-progress row that
+        // never makes it to the DB. We synthesize the case by feeding
+        // a tool_result first (continuation, no user_start) and asserting
+        // the registry stays empty until a user_start call arrives.
+        let (mut t, reg) = mk_tracker_with_registry();
+        // tool_result body ⇒ is_user_turn_start = false on main agent.
+        let c1 = anthropic_call("S-no-start", 1_000_000, "tool_result", "tool_use");
+        let id1 = call_info_for_anthropic(&c1);
+        let _ = t.ingest(ic(c1, id1));
+        assert!(
+            registry_snapshot(&reg).is_empty(),
+            "no user_start ⇒ registry stays empty"
+        );
+
+        // user_start arrives — registry now populates.
+        let c2 = anthropic_call("S-no-start", 2_000_000, "text", "tool_use");
+        let id2 = call_info_for_anthropic(&c2);
+        let _ = t.ingest(ic(c2, id2));
+        let snaps = registry_snapshot(&reg);
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].call_count, 2, "snapshot includes both buffered calls");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn registry_handles_100_sessions_no_panics() {
+        // Stress test (Plan C analogue of the original DB-upsert test):
+        // 100 distinct sessions, each ingesting 50 calls in parallel
+        // tasks, all sharing the SAME tracker behind a Mutex. The
+        // registry's RwLock + the tracker's serialized ingest path must
+        // not panic, deadlock, or leak entries.
+        //
+        // Why a Mutex around the tracker rather than 100 trackers: the
+        // production wiring runs ONE TurnTracker per shard, sharded by
+        // session_id, so a single tracker really does see all sessions.
+        // 100 concurrent ingests through a Mutex models that fan-in
+        // worst case.
+        use std::sync::{Arc as StdArc, Mutex as StdMutex};
+
+        let (tracker, reg) = mk_tracker_with_registry();
+        let tracker = StdArc::new(StdMutex::new(tracker));
+
+        const N_SESSIONS: usize = 100;
+        const ITERS: usize = 50;
+
+        let mut joins = Vec::with_capacity(N_SESSIONS);
+        for s in 0..N_SESSIONS {
+            let tracker = tracker.clone();
+            joins.push(tokio::spawn(async move {
+                let session = format!("S-stress-{s}");
+                for k in 0..ITERS {
+                    // Each call needs a strictly-increasing request_time
+                    // within its session so the orphan guard doesn't
+                    // drop later arrivals.
+                    let body = if k == 0 { "text" } else { "tool_result" };
+                    let ts_us = 1_000_000 + (s as i64) * 10_000_000 + k as i64;
+                    let call = anthropic_call(&session, ts_us, body, "tool_use");
+                    let id = call_info_for_anthropic(&call);
+                    {
+                        let mut tr = tracker.lock().unwrap();
+                        let _ = tr.ingest(ic(call, id));
+                    }
+                    // Yield so other tasks can interleave.
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for j in joins {
+            j.await.unwrap();
+        }
+
+        // Every session is in-progress (no terminals fired) → registry
+        // should have exactly 100 entries, each with call_count = ITERS.
+        let snaps = registry_snapshot(&reg);
+        assert_eq!(
+            snaps.len(),
+            N_SESSIONS,
+            "exactly one in-progress entry per session"
+        );
+        assert!(
+            snaps.iter().all(|s| s.call_count == ITERS as u32),
+            "every snapshot reflects the full per-session ingest count"
+        );
+        assert!(
+            snaps.iter().all(|s| s.status == TurnStatus::InProgress),
+            "every snapshot is in_progress"
+        );
+
+        // Finalize all of them via flush_all and confirm registry empties.
+        let mut tr = tracker.lock().unwrap();
+        let events = tr.flush_all_at(std::time::Instant::now() + Duration::from_secs(2));
+        let completed = drain_completed(events);
+        assert_eq!(
+            completed.len(),
+            N_SESSIONS,
+            "every session emits one Completed (Incomplete, no terminals)"
+        );
+        assert!(
+            registry_snapshot(&reg).is_empty(),
+            "registry must be drained after flush_all"
+        );
     }
 }

--- a/server/ts-turn/tests/integration.rs
+++ b/server/ts-turn/tests/integration.rs
@@ -112,6 +112,7 @@ async fn run_pcap_full_sharded(
         turn_shard_rxs,
         turns_tx,
         &mut metrics_sys,
+        None,
     );
 
     ts_metrics::spawn_metrics_stage(metrics_shard_rxs, m_out_tx, &mut metrics_sys);
@@ -240,6 +241,7 @@ async fn run_pcap_collecting_calls(
         turn_shard_rxs,
         turns_tx,
         &mut metrics_sys,
+        None,
     );
 
     ts_metrics::spawn_metrics_stage(metrics_shard_rxs, m_out_tx, &mut metrics_sys);


### PR DESCRIPTION
## Summary

Closes the "Agent Turns is delayed by minutes" complaint at the root.
Turns are now visible in the console **the moment the first call lands**
— not after wire-level `end_turn` + 1 s grace, not after 600 s idle.

Companion to #5 (which cuts the storage flush latency). Together: the
per-call "real-time" budget is ~250 ms (capture → DuckDB) and the
per-turn "in-progress visibility" budget is the same ~250 ms (capture →
in-memory registry → API → console).

## Architecture: in-memory registry, not DB upserts

The first iteration persisted every snapshot to `agent_turns` via
`INSERT ... ON CONFLICT DO UPDATE`. User flagged the write
amplification:

> 这个方案如果出现大量agent的时候是不是会大规模写入数据库？有人质
> 疑是否查询时候聚合是更合理？或者分阶段处理

For 100 concurrent agents × 50 calls/turn that's 50 000 upserts per
session — bad scaling for a backend whose read traffic is one console
user × 5 s poll. We pivoted to an in-memory `Arc<RwLock<HashMap>>`
shared between tracker writers and the API reader:

```
       LlmCall
          │
          ▼
   TurnTracker::ingest_at
          │
          ├─► SessionBuffer (existing pending state)
          │
          └─► ActiveTurnRegistry  ◄────┐
                  │                     │
                  │                     │ /api/agent-turns
                  ▼                     │   UNION
            (RAM, ~100ns/insert)        │
                                        │
   TurnEvent::Completed ──► DuckDB ─────┘
   (registry entry removed)
```

`agent_turns` table stays terminal-only (clean SQL semantics, survives
restart). The registry is short-lived "currently observable" view
layered on top — survives nothing, and shouldn't.

## Changes

### `ts-turn`
- `TurnStatus::InProgress` variant; Display prints `in_progress`.
- `ActiveTurnRegistry = Arc<RwLock<HashMap<String, AgentTurn>>>`,
  created via `new_active_turn_registry()`.
- `TurnTracker::with_registry(...)` wires the shared registry; `new(...)`
  keeps the registry-less path for legacy tests.
- `SessionBuffer.current_turn_id: Option<String>`: stable id minted on
  the first ingest after the previous turn finalized; reused across
  every snapshot AND the eventual Completed event so the persisted DB
  row inherits the same id the console has been showing → the API
  drops the registry entry on UNION and the row appears to "transition"
  in place rather than disappearing-and-reappearing.
- `ingest_at`: builds an InProgress snapshot truncated at the first
  main-agent terminal (so multi-turn buffers don't mix state) and
  upserts the registry. Same discard rule as `emit_or_discard` — no
  main-agent `user_turn_start` ⇒ no entry, so filler sessions never
  produce phantom rows.
- `flush_ready_buffers` / `sweep` / `flush_all_at`: pass
  `current_turn_id` to `emit_or_discard` and remove every Completed's
  turn_id from the registry afterwards (no double-counting).
- `build_turn` extended with `turn_id_override` + `status_override`.
- `spawn_turn_stage(... , Option<ActiveTurnRegistry>)`.

### `ts-api`
- `ApiAgentTurnsContext { storage, active_turns }` composite state.
- `/api/agent-turns` list: registry → filter by query params → convert
  to `TurnListItem` → prepend to page 1, total += count.
- `/api/agent-turns/{id}`: registry fallback for in-progress turns.
- `/api/agent-turns/{id}/calls`: empty list for in-progress turns.
- `ts-turn` added as `ts-api` dep.

### `tokenscope` (composition root)
- One `ActiveTurnRegistry` per process, threaded into both
  `Pipeline::build` and `ts_api::router(...)`.

### `console`
- `TurnStatusBadge`: blue-pulse animated dot for `in_progress`,
  emerald `complete`, gray `incomplete`.
- `agent-turns` page: `STATUS_OPTIONS = ["in_progress", "complete",
  "incomplete"]` so the filter dropdown can isolate live turns.

## Test plan

- [x] 6 new tracker registry tests (`ts-turn` lib): visibility, in-place
      update, both finalization paths drop the entry, discard rule,
      100-session concurrent stress.
- [x] All 36 pre-existing tracker lib tests pass.
- [x] 10 reorder tests + 2 stage tests + integration test pass.
- [x] 78 ts-storage tests + 14 ts-api tests + tokenscope app test pass.
- [x] Workspace builds clean with `--features console`.
- [x] Live deploy on wuneng:4500: API returns 200, agent-turns endpoint
      returns DB-backed turns; in-progress visibility verifiable once
      LiteLLM-proxy traffic resumes (currently a quiet period).

## Follow-up (not in this PR)

The registry → API path is in place; the hot live-verification needs
real port-4210 / 4271 traffic to drive an in-flight session through.
Once a multi-call agent starts, the row should appear within ~5 s
(next UI tick) with a pulsing `in_progress` badge, and flip to
`complete` / `incomplete` in place when the session ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)