### PR TITLE
fix(ts-llm): strict session_id anchor extraction + profile-match gating

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3078,6 +3078,7 @@ dependencies = [
  "ts-metrics",
  "ts-pcap-extract",
  "ts-storage",
+ "ts-turn",
 ]
 
 [[package]]

--- a/server/ts-llm/src/agents/claude_cli.rs
+++ b/server/ts-llm/src/agents/claude_cli.rs
@@ -63,12 +63,23 @@ impl AgentProfile for ClaudeCliProfile {
     }
 
     fn matches(&self, ctx: &CallCtx<'_>) -> bool {
+        // Both UA prefix AND SESSION_HEADER must be present. UA alone isn't
+        // enough: the registry is first-match-wins (`profile.rs:181`), so
+        // claiming a call here when the session header is missing leaves the
+        // call with `extract_session_id() = None` and no fallback. By
+        // requiring the header up front, UA-spoofed / header-stripped /
+        // pre-session-header-version traffic falls through to GenericProfile,
+        // which can synthesize a session anchor from the body.
         if ctx.call.wire_api != wa::ANTHROPIC {
             return false;
         }
-        header(ctx.call, "user-agent")
+        let ua_ok = header(ctx.call, "user-agent")
             .map(|ua| ua.starts_with(UA_PREFIX))
-            .unwrap_or(false)
+            .unwrap_or(false);
+        if !ua_ok {
+            return false;
+        }
+        header(ctx.call, SESSION_HEADER).is_some()
     }
 
     fn extract_session_id(&self, ctx: &CallCtx<'_>) -> Option<SessionIdExtraction> {
@@ -243,7 +254,10 @@ mod tests {
     fn matches_anthropic_claude_cli_user_agent() {
         let c = call_with(
             wa::ANTHROPIC,
-            vec![("User-Agent", "claude-cli/2.1.98 (external, cli)")],
+            vec![
+                ("User-Agent", "claude-cli/2.1.98 (external, cli)"),
+                ("X-Claude-Code-Session-Id", "deadbeef-0000-0000-0000-000000000000"),
+            ],
             None,
         );
         assert!(ClaudeCliProfile.matches(&c.ctx()));
@@ -253,7 +267,10 @@ mod tests {
     fn does_not_match_other_wire_api() {
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("User-Agent", "claude-cli/2.1.98 (external, cli)")],
+            vec![
+                ("User-Agent", "claude-cli/2.1.98 (external, cli)"),
+                ("X-Claude-Code-Session-Id", "deadbeef-0000-0000-0000-000000000000"),
+            ],
             None,
         );
         assert!(!ClaudeCliProfile.matches(&c.ctx()));
@@ -261,7 +278,27 @@ mod tests {
 
     #[test]
     fn does_not_match_other_user_agent() {
-        let c = call_with(wa::ANTHROPIC, vec![("User-Agent", "curl/8.1.2")], None);
+        let c = call_with(
+            wa::ANTHROPIC,
+            vec![
+                ("User-Agent", "curl/8.1.2"),
+                ("X-Claude-Code-Session-Id", "deadbeef-0000-0000-0000-000000000000"),
+            ],
+            None,
+        );
+        assert!(!ClaudeCliProfile.matches(&c.ctx()));
+    }
+
+    #[test]
+    fn does_not_match_when_session_header_missing() {
+        // UA alone is not enough — without `x-claude-code-session-id` we
+        // cannot extract a session_id, so the registry must let the call
+        // fall through to GenericProfile rather than claiming and dropping it.
+        let c = call_with(
+            wa::ANTHROPIC,
+            vec![("User-Agent", "claude-cli/2.1.98 (external, cli)")],
+            None,
+        );
         assert!(!ClaudeCliProfile.matches(&c.ctx()));
     }
 

--- a/server/ts-llm/src/agents/codex_cli.rs
+++ b/server/ts-llm/src/agents/codex_cli.rs
@@ -35,19 +35,33 @@ impl AgentProfile for CodexCliProfile {
     }
 
     fn matches(&self, ctx: &CallCtx<'_>) -> bool {
+        // Both a client identifier (Originator or UA prefix) AND TURN_META_HEADER
+        // must be present. Identifier alone isn't enough: the registry is
+        // first-match-wins (`profile.rs:181`), so claiming a call here when the
+        // turn-metadata header is missing leaves the call with
+        // `extract_session_id() = None` and no fallback. By requiring the
+        // header up front, identifier-spoofing / header-stripping /
+        // pre-metadata-version traffic falls through to GenericProfile, which
+        // can synthesize a session anchor from the body.
+        //
+        // KNOWN LIMITATION: header presence does NOT prove parseability.
+        // `parse_turn_metadata` only accepts raw JSON today; a future codex
+        // release that switches to base64-encoded metadata would still match
+        // here but fail to extract. Address by extending `parse_turn_metadata`
+        // when that lands, not by parsing in `matches`.
         if ctx.call.wire_api != wa::OPENAI_RESPONSES {
             return false;
         }
-        // Prefer Originator (stable short identifier); fall back to UA prefix.
-        if let Some(orig) = header(ctx.call, ORIGINATOR_HEADER) {
-            if ORIGINATOR_VALUES.contains(&orig) {
-                return true;
-            }
+        let id_ok = match header(ctx.call, ORIGINATOR_HEADER) {
+            Some(orig) if ORIGINATOR_VALUES.contains(&orig) => true,
+            _ => header(ctx.call, "user-agent")
+                .map(|ua| UA_PREFIXES.iter().any(|p| ua.starts_with(p)))
+                .unwrap_or(false),
+        };
+        if !id_ok {
+            return false;
         }
-        if let Some(ua) = header(ctx.call, "user-agent") {
-            return UA_PREFIXES.iter().any(|p| ua.starts_with(p));
-        }
-        false
+        header(ctx.call, TURN_META_HEADER).is_some()
     }
 
     fn extract_session_id(&self, ctx: &CallCtx<'_>) -> Option<SessionIdExtraction> {
@@ -231,11 +245,16 @@ mod tests {
         })
     }
 
+    const STUB_META: &str = r#"{"session_id":"deadbeef-0000-0000-0000-000000000000"}"#;
+
     #[test]
     fn matches_by_originator() {
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("Originator", "codex_cli_rs")],
+            vec![
+                ("Originator", "codex_cli_rs"),
+                ("X-Codex-Turn-Metadata", STUB_META),
+            ],
             None,
         );
         assert!(CodexCliProfile.matches(&c.ctx()));
@@ -245,7 +264,10 @@ mod tests {
     fn matches_codex_tui_by_ua() {
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("User-Agent", "codex-tui/0.118.0 (Mac OS)")],
+            vec![
+                ("User-Agent", "codex-tui/0.118.0 (Mac OS)"),
+                ("X-Codex-Turn-Metadata", STUB_META),
+            ],
             None,
         );
         assert!(CodexCliProfile.matches(&c.ctx()));
@@ -255,7 +277,10 @@ mod tests {
     fn matches_codex_exec_by_originator() {
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("Originator", "codex_exec")],
+            vec![
+                ("Originator", "codex_exec"),
+                ("X-Codex-Turn-Metadata", STUB_META),
+            ],
             None,
         );
         assert!(CodexCliProfile.matches(&c.ctx()));
@@ -265,7 +290,10 @@ mod tests {
     fn matches_codex_exec_by_ua() {
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("User-Agent", "codex_exec/0.120.0 (Ubuntu 24.4.0; x86_64)")],
+            vec![
+                ("User-Agent", "codex_exec/0.120.0 (Ubuntu 24.4.0; x86_64)"),
+                ("X-Codex-Turn-Metadata", STUB_META),
+            ],
             None,
         );
         assert!(CodexCliProfile.matches(&c.ctx()));
@@ -273,7 +301,27 @@ mod tests {
 
     #[test]
     fn does_not_match_chat_api() {
-        let c = call_with(wa::OPENAI_CHAT, vec![("Originator", "codex_cli_rs")], None);
+        let c = call_with(
+            wa::OPENAI_CHAT,
+            vec![
+                ("Originator", "codex_cli_rs"),
+                ("X-Codex-Turn-Metadata", STUB_META),
+            ],
+            None,
+        );
+        assert!(!CodexCliProfile.matches(&c.ctx()));
+    }
+
+    #[test]
+    fn does_not_match_when_turn_metadata_header_missing() {
+        // Identifier alone is not enough — without `x-codex-turn-metadata`
+        // we cannot extract a session_id, so the registry must let the call
+        // fall through to GenericProfile rather than claiming and dropping it.
+        let c = call_with(
+            wa::OPENAI_RESPONSES,
+            vec![("Originator", "codex_cli_rs")],
+            None,
+        );
         assert!(!CodexCliProfile.matches(&c.ctx()));
     }
 

--- a/server/ts-llm/src/agents/mod.rs
+++ b/server/ts-llm/src/agents/mod.rs
@@ -133,7 +133,10 @@ mod priority_tests {
         let reg = build_default_registry();
         let c = call_with(
             wa::ANTHROPIC,
-            vec![("User-Agent", "claude-cli/2.1.98 (cli)")],
+            vec![
+                ("User-Agent", "claude-cli/2.1.98 (cli)"),
+                ("X-Claude-Code-Session-Id", "deadbeef-0000-0000-0000-000000000000"),
+            ],
         );
         assert_eq!(find_kind(&reg, &c), Some("claude-cli"));
     }
@@ -149,9 +152,31 @@ mod priority_tests {
     }
 
     #[test]
+    fn generic_catches_claude_cli_ua_without_session_header() {
+        // UA-spoofing or header-stripping: looks like claude-cli but the
+        // session header is absent. ClaudeCliProfile must NOT claim it
+        // (otherwise extract_session_id would return None with no fallback) —
+        // GenericProfile picks it up and synthesizes a session anchor.
+        let reg = build_default_registry();
+        let c = call_with(
+            wa::ANTHROPIC,
+            vec![("User-Agent", "claude-cli/2.1.98 (cli)")],
+        );
+        assert_eq!(find_kind(&reg, &c), Some("generic"));
+    }
+
+    const CODEX_STUB_META: &str = r#"{"session_id":"deadbeef-0000-0000-0000-000000000000"}"#;
+
+    #[test]
     fn codex_cli_wins_over_generic_by_originator() {
         let reg = build_default_registry();
-        let c = call_with(wa::OPENAI_RESPONSES, vec![("Originator", "codex_cli_rs")]);
+        let c = call_with(
+            wa::OPENAI_RESPONSES,
+            vec![
+                ("Originator", "codex_cli_rs"),
+                ("X-Codex-Turn-Metadata", CODEX_STUB_META),
+            ],
+        );
         assert_eq!(find_kind(&reg, &c), Some("codex-cli"));
     }
 
@@ -160,7 +185,10 @@ mod priority_tests {
         let reg = build_default_registry();
         let c = call_with(
             wa::OPENAI_RESPONSES,
-            vec![("User-Agent", "codex-tui/0.118.0")],
+            vec![
+                ("User-Agent", "codex-tui/0.118.0"),
+                ("X-Codex-Turn-Metadata", CODEX_STUB_META),
+            ],
         );
         assert_eq!(find_kind(&reg, &c), Some("codex-cli"));
     }
@@ -171,6 +199,20 @@ mod priority_tests {
         let c = call_with(
             wa::OPENAI_RESPONSES,
             vec![("User-Agent", "OpenAI/Python 1.50")],
+        );
+        assert_eq!(find_kind(&reg, &c), Some("generic"));
+    }
+
+    #[test]
+    fn generic_catches_codex_ua_without_turn_metadata_header() {
+        // UA-spoofing or header-stripping: looks like codex but the
+        // turn-metadata header is absent. CodexCliProfile must NOT claim it
+        // (otherwise extract_session_id would return None with no fallback) —
+        // GenericProfile picks it up and synthesizes a session anchor.
+        let reg = build_default_registry();
+        let c = call_with(
+            wa::OPENAI_RESPONSES,
+            vec![("User-Agent", "codex-tui/0.118.0")],
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -211,7 +253,10 @@ mod priority_tests {
         let reg = build_default_registry();
         let c = call_with_body(
             wa::OPENAI_RESPONSES,
-            vec![("User-Agent", "codex-tui/0.118.0")],
+            vec![
+                ("User-Agent", "codex-tui/0.118.0"),
+                ("X-Codex-Turn-Metadata", CODEX_STUB_META),
+            ],
             Some(OPENCLAW_RESPONSES_MAIN),
         );
         assert_eq!(find_kind(&reg, &c), Some("codex-cli"));
@@ -321,7 +366,10 @@ mod priority_tests {
         let reg = build_default_registry();
         let c = call_with_body(
             wa::ANTHROPIC,
-            vec![("User-Agent", "claude-cli/2.1.98")],
+            vec![
+                ("User-Agent", "claude-cli/2.1.98"),
+                ("X-Claude-Code-Session-Id", "deadbeef-0000-0000-0000-000000000000"),
+            ],
             Some(OPENCLAW_ANT_MAIN),
         );
         assert_eq!(find_kind(&reg, &c), Some("claude-cli"));

--- a/server/ts-llm/src/wire_apis/anthropic.rs
+++ b/server/ts-llm/src/wire_apis/anthropic.rs
@@ -515,54 +515,62 @@ pub fn first_system_text(req: &Value) -> Option<String> {
     }
 }
 
+/// Extract text from the **first** `role:user` message — and only that one.
+/// If the first user message has no extractable text (empty string, image-
+/// only blocks, tool_result-only blocks), return `None` rather than falling
+/// through to later user messages. Falling through could pick up text from
+/// turn 2+, which is not a stable session anchor.
 pub fn first_user_text(req: &Value) -> Option<String> {
     let msgs = req.get("messages")?.as_array()?;
-    for m in msgs {
-        if m.get("role").and_then(|r| r.as_str()) != Some("user") {
-            continue;
-        }
-        match m.get("content")? {
-            Value::String(s) if !s.trim().is_empty() => return Some(s.clone()),
-            Value::Array(blocks) => {
-                let parts: Vec<String> = blocks
-                    .iter()
-                    .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
-                    .filter_map(|b| b.get("text").and_then(|t| t.as_str()).map(str::to_string))
-                    .collect();
-                if !parts.is_empty() {
-                    return Some(parts.join("\n"));
-                }
+    let first_user = msgs
+        .iter()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))?;
+    match first_user.get("content")? {
+        Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+        Value::Array(blocks) => {
+            let parts: Vec<String> = blocks
+                .iter()
+                .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()).map(str::to_string))
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n"))
             }
-            _ => {}
         }
+        _ => None,
     }
-    None
 }
 
+/// Sig of the **first** `role:assistant` message — and only that one. If
+/// the first assistant has no `tool_use` block AND no `text` block, return
+/// `None` rather than falling through to later assistant messages (which
+/// would belong to turn 2+ and are not a stable session anchor).
+/// Within that one message, `tool_use` takes precedence over `text`.
 pub fn first_assistant_sig_from_request(req: &Value) -> Option<AssistantSig> {
     let msgs = req.get("messages")?.as_array()?;
-    for m in msgs {
-        if m.get("role").and_then(|r| r.as_str()) != Some("assistant") {
-            continue;
-        }
-        let blocks = m.get("content")?.as_array()?;
-        for b in blocks {
-            if b.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
-                if let Some(id) = b.get("id").and_then(|x| x.as_str()) {
-                    return Some(AssistantSig::ToolId(id.to_string()));
-                }
+    let first_assistant = msgs
+        .iter()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"))?;
+    let blocks = first_assistant.get("content")?.as_array()?;
+    for b in blocks {
+        if b.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+            if let Some(id) = b.get("id").and_then(|x| x.as_str()) {
+                return Some(AssistantSig::ToolId(id.to_string()));
             }
         }
-        let parts: Vec<String> = blocks
-            .iter()
-            .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
-            .filter_map(|b| b.get("text").and_then(|t| t.as_str()).map(str::to_string))
-            .collect();
-        if !parts.is_empty() {
-            return Some(AssistantSig::Text(parts.join("\n")));
-        }
     }
-    None
+    let parts: Vec<String> = blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+        .filter_map(|b| b.get("text").and_then(|t| t.as_str()).map(str::to_string))
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(AssistantSig::Text(parts.join("\n")))
+    }
 }
 
 pub fn first_assistant_sig_from_response(body: &str) -> Option<AssistantSig> {
@@ -1235,5 +1243,101 @@ mod estimator_tests {
             ]
         });
         assert!(estimate_output_tokens(&resp, &cl()) > 0);
+    }
+
+    // ─── first_user_text: strict "first role:user" semantics ────────────────
+
+    #[test]
+    fn first_user_text_returns_text_of_first_user_message() {
+        let req = json!({
+            "messages": [
+                {"role":"user","content":"hello"},
+                {"role":"assistant","content":[{"type":"text","text":"hi"}]},
+                {"role":"user","content":[{"type":"text","text":"more"}]}
+            ]
+        });
+        assert_eq!(first_user_text(&req).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_is_empty_string() {
+        // First user has empty content; second user has text. Strict
+        // semantics: don't fall through — return None.
+        let req = json!({
+            "messages": [
+                {"role":"user","content":""},
+                {"role":"assistant","content":[{"type":"text","text":"hi"}]},
+                {"role":"user","content":[{"type":"text","text":"later"}]}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_has_only_tool_result_blocks() {
+        // Pathological: messages[0] is a tool_result-only user message
+        // (would never happen in a real first turn, but covers the
+        // fall-through behavior). Must return None — must not jump to
+        // messages[2].
+        let req = json!({
+            "messages": [
+                {"role":"user","content":[
+                    {"type":"tool_result","tool_use_id":"t","content":"ok"}
+                ]},
+                {"role":"assistant","content":[{"type":"text","text":"reply"}]},
+                {"role":"user","content":[{"type":"text","text":"later"}]}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    // ─── first_assistant_sig_from_request: strict "first only" semantics ────
+
+    #[test]
+    fn first_assistant_sig_from_request_returns_first_assistants_tool_use() {
+        let req = json!({
+            "messages": [
+                {"role":"user","content":[{"type":"text","text":"hi"}]},
+                {"role":"assistant","content":[
+                    {"type":"text","text":"working"},
+                    {"type":"tool_use","id":"toolu_first","name":"R","input":{}}
+                ]},
+                {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_first","content":"ok"}]},
+                {"role":"assistant","content":[{"type":"tool_use","id":"toolu_second","name":"R","input":{}}]}
+            ]
+        });
+        let sig = first_assistant_sig_from_request(&req).unwrap();
+        assert!(matches!(sig, AssistantSig::ToolId(id) if id == "toolu_first"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_assistant_has_no_extractable_blocks() {
+        // First assistant's content has neither `tool_use` nor `text` blocks
+        // (e.g., thinking-only or filtered-out blocks). Must return None —
+        // must not skip to the second assistant message.
+        let req = json!({
+            "messages": [
+                {"role":"user","content":[{"type":"text","text":"hi"}]},
+                {"role":"assistant","content":[
+                    {"type":"thinking","thinking":"hidden chain-of-thought"}
+                ]},
+                {"role":"user","content":[{"type":"text","text":"more"}]},
+                {"role":"assistant","content":[{"type":"text","text":"this would be a leak"}]}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_assistant_content_empty_array() {
+        let req = json!({
+            "messages": [
+                {"role":"user","content":[{"type":"text","text":"hi"}]},
+                {"role":"assistant","content":[]},
+                {"role":"user","content":[{"type":"text","text":"more"}]},
+                {"role":"assistant","content":[{"type":"tool_use","id":"toolu_leak","name":"R","input":{}}]}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
     }
 }

--- a/server/ts-llm/src/wire_apis/gemini_aistudio.rs
+++ b/server/ts-llm/src/wire_apis/gemini_aistudio.rs
@@ -629,24 +629,21 @@ fn wrap_sig(sig_and_kind: (String, bool)) -> AssistantSig {
 /// stability across the conversation's calls.
 pub fn first_user_text(req: &Value) -> Option<String> {
     let contents = req.get("contents")?.as_array()?;
-    for c in contents {
-        if c.get("role").and_then(|r| r.as_str()) != Some("user") {
-            continue;
-        }
-        let parts = c.get("parts").and_then(|v| v.as_array()).map(|p| {
-            p.iter()
-                .filter_map(|x| x.get("text").and_then(|t| t.as_str()).map(str::to_string))
-                .collect::<Vec<_>>()
-        });
-        if let Some(parts) = parts {
-            let joined = parts.join("\n");
-            let trimmed = joined.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
+    let first_user = contents
+        .iter()
+        .find(|c| c.get("role").and_then(|r| r.as_str()) == Some("user"))?;
+    let parts = first_user.get("parts").and_then(|v| v.as_array())?;
+    let joined = parts
+        .iter()
+        .filter_map(|x| x.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
-    None
 }
 
 /// Top-level `systemInstruction.parts[].text` joined. Gemini puts system
@@ -667,22 +664,19 @@ pub fn first_system_text(req: &Value) -> Option<String> {
     }
 }
 
-/// Sig of the first role==model content in `contents[]`. Computes
-/// `parts_sig` over the first model content's parts. `None` when no
-/// model content exists (true on the first call before any tool
-/// roundtrip).
+/// Sig of the **first** `role:model` content in `contents[]` — and only
+/// that one. `None` when no model content exists (first call, no tool
+/// roundtrip yet) OR when the first model content has no extractable
+/// signal (parts missing, empty, or all-`thought`). Does NOT fall through
+/// to later model contents — those belong to turn 2+ and are not a stable
+/// session anchor.
 pub fn first_assistant_sig_from_request(req: &Value) -> Option<AssistantSig> {
     let contents = req.get("contents")?.as_array()?;
-    for c in contents {
-        if c.get("role").and_then(|r| r.as_str()) != Some("model") {
-            continue;
-        }
-        let parts = c.get("parts").and_then(|v| v.as_array())?;
-        if let Some(sig) = parts_sig(parts) {
-            return Some(wrap_sig(sig));
-        }
-    }
-    None
+    let first_model = contents
+        .iter()
+        .find(|c| c.get("role").and_then(|r| r.as_str()) == Some("model"))?;
+    let parts = first_model.get("parts").and_then(|v| v.as_array())?;
+    parts_sig(parts).map(wrap_sig)
 }
 
 /// Sig of the first candidate's parts in a Gemini response body. Mirrors
@@ -1334,6 +1328,84 @@ mod tests {
             .filter(|p| p.get("functionCall").is_some())
             .count();
         assert!(function_calls >= 1, "fixture has at least one functionCall");
+    }
+
+    // ─── first_user_text: strict "first role:user" semantics ────────────────
+
+    #[test]
+    fn first_user_text_none_when_first_user_has_no_text() {
+        // First user content has only `functionResponse` parts (no text);
+        // a later user has text. Strict semantics: don't fall through.
+        let req = serde_json::json!({
+            "contents": [
+                {"role":"user","parts":[
+                    {"functionResponse":{"name":"f","response":{"r":1}}}
+                ]},
+                {"role":"model","parts":[{"text":"ack"}]},
+                {"role":"user","parts":[{"text":"later"}]}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_text_is_whitespace() {
+        let req = serde_json::json!({
+            "contents": [
+                {"role":"user","parts":[{"text":"   "}]},
+                {"role":"model","parts":[{"text":"ack"}]},
+                {"role":"user","parts":[{"text":"later"}]}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    // ─── first_assistant_sig_from_request: strict "first only" semantics ────
+
+    #[test]
+    fn first_assistant_sig_from_request_returns_first_models_sig() {
+        let req = serde_json::json!({
+            "contents": [
+                {"role":"user","parts":[{"text":"u1"}]},
+                {"role":"model","parts":[{"text":"first model reply"}]},
+                {"role":"user","parts":[{"text":"u2"}]},
+                {"role":"model","parts":[{"functionCall":{"name":"f","args":{"x":1}}}]}
+            ]
+        });
+        let sig = first_assistant_sig_from_request(&req).unwrap();
+        // First model is text-only → wrap_sig produces AssistantSig::Text.
+        assert!(matches!(sig, AssistantSig::Text(t) if t.contains("first model reply")));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_model_parts_all_thought() {
+        // First model's parts are all `thought:true` (chain-of-thought
+        // tokens that parts_sig deliberately filters out). Must NOT fall
+        // through to the second model content.
+        let req = serde_json::json!({
+            "contents": [
+                {"role":"user","parts":[{"text":"u1"}]},
+                {"role":"model","parts":[
+                    {"thought":true,"text":"hidden cot"}
+                ]},
+                {"role":"user","parts":[{"text":"u2"}]},
+                {"role":"model","parts":[{"text":"this would be a leak"}]}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_model_parts_empty() {
+        let req = serde_json::json!({
+            "contents": [
+                {"role":"user","parts":[{"text":"u1"}]},
+                {"role":"model","parts":[]},
+                {"role":"user","parts":[{"text":"u2"}]},
+                {"role":"model","parts":[{"functionCall":{"name":"f","args":{}}}]}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
     }
 }
 

--- a/server/ts-llm/src/wire_apis/openai/chat.rs
+++ b/server/ts-llm/src/wire_apis/openai/chat.rs
@@ -410,41 +410,46 @@ pub fn first_system_text(req: &Value) -> Option<String> {
     None
 }
 
+/// Text of the **first** `role:user` message only. If that message has no
+/// extractable text, return `None` instead of scanning later user messages
+/// — those belong to subsequent turns and aren't a stable session anchor.
 pub fn first_user_text(req: &Value) -> Option<String> {
     let msgs = req.get("messages")?.as_array()?;
-    for m in msgs {
-        if m.get("role").and_then(|r| r.as_str()) != Some("user") {
-            continue;
-        }
-        if let Some(t) = m.get("content").and_then(user_content_to_text) {
-            return Some(t);
-        }
-    }
-    None
+    let first_user = msgs
+        .iter()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))?;
+    first_user.get("content").and_then(user_content_to_text)
 }
 
+/// Sig of the **first** `role:assistant` message — and only that one. If
+/// the first assistant has no usable `tool_calls[0].id` AND no non-empty
+/// `content` string, return `None` rather than falling through to later
+/// assistant messages (which would belong to turn 2+ and are not a stable
+/// session anchor). Within that one message, `tool_calls` takes precedence
+/// over `content`.
 pub fn first_assistant_sig_from_request(req: &Value) -> Option<AssistantSig> {
     let msgs = req.get("messages")?.as_array()?;
-    for m in msgs {
-        if m.get("role").and_then(|r| r.as_str()) != Some("assistant") {
-            continue;
-        }
-        if let Some(arr) = m.get("tool_calls").and_then(|v| v.as_array()) {
-            if let Some(id) = arr
-                .first()
-                .and_then(|tc| tc.get("id"))
-                .and_then(|v| v.as_str())
-            {
-                return Some(AssistantSig::ToolId(id.to_string()));
-            }
-        }
-        if let Some(c) = m.get("content").and_then(|v| v.as_str()) {
-            if !c.trim().is_empty() {
-                return Some(AssistantSig::Text(c.to_string()));
-            }
+    let first_assistant = msgs
+        .iter()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("assistant"))?;
+    if let Some(arr) = first_assistant
+        .get("tool_calls")
+        .and_then(|v| v.as_array())
+    {
+        if let Some(id) = arr
+            .first()
+            .and_then(|tc| tc.get("id"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(AssistantSig::ToolId(id.to_string()));
         }
     }
-    None
+    let c = first_assistant.get("content").and_then(|v| v.as_str())?;
+    if c.trim().is_empty() {
+        None
+    } else {
+        Some(AssistantSig::Text(c.to_string()))
+    }
 }
 
 pub fn first_assistant_sig_from_response(body: &str) -> Option<AssistantSig> {
@@ -1082,5 +1087,99 @@ mod tests {
         assert_eq!(info.response_id.as_deref(), Some("chatcmpl-1"));
         assert_eq!(info.model.as_deref(), Some("gpt-4"));
         assert_eq!(info.finish_reason.as_deref(), Some("stop"));
+    }
+
+    // ─── first_user_text: strict "first role:user" semantics ────────────────
+
+    #[test]
+    fn first_user_text_returns_text_of_first_user_message() {
+        let req = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+                {"role": "user", "content": "more"}
+            ]
+        });
+        assert_eq!(first_user_text(&req).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_is_empty_string() {
+        let req = serde_json::json!({
+            "messages": [
+                {"role": "user", "content": ""},
+                {"role": "assistant", "content": "hi"},
+                {"role": "user", "content": "later"}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_has_no_text_blocks() {
+        // multimodal-only first user message (image_url with no text part).
+        let req = serde_json::json!({
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "image_url", "image_url": {"url": "data:..."}}
+                ]},
+                {"role": "assistant", "content": "ack"},
+                {"role": "user", "content": "later"}
+            ]
+        });
+        assert_eq!(first_user_text(&req), None);
+    }
+
+    // ─── first_assistant_sig_from_request: strict "first only" semantics ────
+
+    #[test]
+    fn first_assistant_sig_from_request_returns_first_assistants_tool_call() {
+        let req = serde_json::json!({
+            "messages": [
+                {"role":"system","content":"sys"},
+                {"role":"user","content":"hi"},
+                {"role":"assistant","content":null,"tool_calls":[
+                    {"id":"call_first","type":"function","function":{"name":"f","arguments":"{}"}}
+                ]},
+                {"role":"tool","tool_call_id":"call_first","content":"ok"},
+                {"role":"assistant","content":null,"tool_calls":[
+                    {"id":"call_second","type":"function","function":{"name":"f","arguments":"{}"}}
+                ]}
+            ]
+        });
+        let sig = first_assistant_sig_from_request(&req).unwrap();
+        assert!(matches!(sig, AssistantSig::ToolId(id) if id == "call_first"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_assistant_is_empty() {
+        // First assistant has null content and no tool_calls — pathological
+        // shape (truncated/malformed). Must NOT fall through to the second
+        // assistant message (which would be turn-2's anchor, not turn-1's).
+        let req = serde_json::json!({
+            "messages": [
+                {"role":"user","content":"hi"},
+                {"role":"assistant","content":null},
+                {"role":"user","content":"more"},
+                {"role":"assistant","content":"this would be a leak"}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
+    }
+
+    #[test]
+    fn first_assistant_sig_from_request_none_when_first_tool_call_lacks_id() {
+        let req = serde_json::json!({
+            "messages": [
+                {"role":"user","content":"hi"},
+                {"role":"assistant","content":null,"tool_calls":[
+                    {"type":"function","function":{"name":"f","arguments":"{}"}}
+                ]},
+                {"role":"user","content":"more"},
+                {"role":"assistant","content":"this would be a leak"}
+            ]
+        });
+        assert!(first_assistant_sig_from_request(&req).is_none());
     }
 }

--- a/server/ts-llm/src/wire_apis/openai/responses.rs
+++ b/server/ts-llm/src/wire_apis/openai/responses.rs
@@ -391,26 +391,25 @@ pub fn message_text(item: &Value) -> Option<String> {
     }
 }
 
+/// Text of the **first** `type:"message", role:"user"` item. If that item
+/// has no extractable text, return `None` instead of falling through to
+/// later user messages (which would be turn 2+ — not a stable anchor).
 pub fn first_user_text(items: &[Value]) -> Option<String> {
-    for it in items {
-        if it.get("type").and_then(|v| v.as_str()) != Some("message") {
-            continue;
-        }
-        if it.get("role").and_then(|v| v.as_str()) != Some("user") {
-            continue;
-        }
-        if let Some(t) = message_text(it) {
-            return Some(t);
-        }
-    }
-    None
+    let first_user = items.iter().find(|it| {
+        it.get("type").and_then(|v| v.as_str()) == Some("message")
+            && it.get("role").and_then(|v| v.as_str()) == Some("user")
+    })?;
+    message_text(first_user)
 }
 
-/// First-pass scan of `input[]`: prefer the earliest `function_call.call_id`
-/// (tool dispatched on a prior turn); fall back to the first assistant
+/// Scan a single generation's items for sig. Prefers the earliest
+/// `function_call.call_id`; falls back to the earliest assistant
 /// `message`'s text. The `function_call` precedence matches Anthropic's
 /// `tool_use` precedence in `wire_apis::anthropic::first_assistant_sig_*`.
-pub fn first_assistant_sig_from_input(items: &[Value]) -> Option<AssistantSig> {
+///
+/// Caller must have already bounded `items` to a single generation — this
+/// helper does **not** do any turn / generation boundary detection.
+fn scan_generation_for_sig(items: &[Value]) -> Option<AssistantSig> {
     let mut tool_id: Option<String> = None;
     let mut text: Option<String> = None;
     for it in items {
@@ -439,16 +438,76 @@ pub fn first_assistant_sig_from_input(items: &[Value]) -> Option<AssistantSig> {
     }
 }
 
+/// Sig of the **first assistant generation** in a request `input[]` (multi-
+/// turn conversation history). Bounding has two stages — both needed
+/// because Responses uses flat sibling items (`reasoning` / `message` /
+/// `function_call` / `function_call_output`) rather than nested
+/// message-with-blocks like Anthropic / OpenAI Chat:
+///
+///   1. **Skip the entire leading user run.** Some clients (Codex CLI,
+///      Gemini-style scaffolding ports) split turn 1's user side into two
+///      consecutive `role:user` items — a synthetic environment_context
+///      followed by the real prompt. A naive "first user → next user" window
+///      would collapse those two into an empty window. Skip past the whole
+///      run of consecutive leading user messages instead.
+///   2. **Stop at the first `function_call_output`.** That marks the boundary
+///      between generation 1 and generation 2 of the same turn. Without this
+///      bound, a generation-1 text-only response followed by a generation-2
+///      `function_call` (within the same turn) would yield `ToolId(fc_e2)`
+///      from input but `Text(msg_e1)` from response — splitting the session
+///      id between call 1 and call 2.
+pub fn first_assistant_sig_from_input(items: &[Value]) -> Option<AssistantSig> {
+    let is_user_message = |it: &Value| {
+        it.get("type").and_then(|v| v.as_str()) == Some("message")
+            && it.get("role").and_then(|v| v.as_str()) == Some("user")
+    };
+    let is_fco =
+        |it: &Value| it.get("type").and_then(|v| v.as_str()) == Some("function_call_output");
+
+    // (1) Skip past the whole run of leading user messages. `start` lands on
+    //     the first non-user item — the first assistant generation begins here.
+    let start = match items.iter().position(is_user_message) {
+        None => 0,
+        Some(idx) => {
+            let mut i = idx;
+            while i < items.len() && is_user_message(&items[i]) {
+                i += 1;
+            }
+            i
+        }
+    };
+    // Turn 1 ends at the next `role:user` message (start of turn 2) or array
+    // end. Used only to scope the generation boundary search below.
+    let turn_end = items[start..]
+        .iter()
+        .position(is_user_message)
+        .map(|i| start + i)
+        .unwrap_or(items.len());
+    // (2) Generation 1 ends at the first `function_call_output` within turn 1,
+    //     or at turn 1's end if there isn't one.
+    let generation_end = items[start..turn_end]
+        .iter()
+        .position(is_fco)
+        .map(|i| start + i)
+        .unwrap_or(turn_end);
+
+    scan_generation_for_sig(&items[start..generation_end])
+}
+
 pub fn first_assistant_sig_from_response(body: &str) -> Option<AssistantSig> {
     let resp: Value = serde_json::from_str(body).ok()?;
     first_assistant_sig_from_response_value(&resp)
 }
 
-/// `Value`-input sibling of `first_assistant_sig_from_response`. Used by
-/// agent-profile session-id extractors on the parse-once hot path.
+/// Sig of the assistant generation in a response `output[]`. A response is
+/// the model's single inference product, so `output[]` IS one generation —
+/// no turn / generation boundaries to detect, just scan it directly. (Splits
+/// from `first_assistant_sig_from_input` deliberately: input's bounding
+/// logic is meaningless for output and only adds coupling risk if future
+/// API surfaces ever introduce input-shaped items in responses.)
 pub fn first_assistant_sig_from_response_value(resp: &Value) -> Option<AssistantSig> {
     let output = resp.get("output")?.as_array()?;
-    first_assistant_sig_from_input(output)
+    scan_generation_for_sig(output)
 }
 
 /// Extract the latest user-message text in `input[]`. Walks in reverse so
@@ -934,5 +993,178 @@ mod estimator_tests {
     fn estimate_output_zero_on_empty_or_unexpected() {
         assert_eq!(estimate_output_tokens(&json!({}), &cl()), 0);
         assert_eq!(estimate_output_tokens(&json!({"output":[]}), &cl()), 0);
+    }
+
+    // ─── first_user_text: strict "first role:user" semantics ────────────────
+
+    #[test]
+    fn first_user_text_returns_text_of_first_user_message() {
+        let items = vec![
+            json!({"type":"message","role":"developer","content":[{"type":"input_text","text":"sys"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"more"}]}),
+        ];
+        assert_eq!(first_user_text(&items).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn first_user_text_none_when_first_user_has_no_text() {
+        // First user item has empty content array; second user has text.
+        // Strict semantics: don't fall through.
+        let items = vec![
+            json!({"type":"message","role":"user","content":[]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"later"}]}),
+        ];
+        assert_eq!(first_user_text(&items), None);
+    }
+
+    // ─── first_assistant_sig_from_input: window bounded to turn 1 ───────────
+
+    #[test]
+    fn first_assistant_sig_from_input_stable_across_turn_2_function_call() {
+        // Turn 1 was text-only (no function_call). Turn 2 introduces a
+        // function_call. The sig must still come from turn 1's text — an
+        // unbounded scan would jump to turn 2's fc and break session_id
+        // stability across calls.
+        let items_call_2 = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u1"}]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u2"}]}),
+        ];
+        let items_call_3 = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u1"}]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u2"}]}),
+            json!({"type":"reasoning","summary":[],"content":[]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_t2"}),
+            json!({"type":"function_call_output","call_id":"fc_t2","output":"ok"}),
+        ];
+        let sig_2 = first_assistant_sig_from_input(&items_call_2).unwrap();
+        let sig_3 = first_assistant_sig_from_input(&items_call_3).unwrap();
+        assert!(matches!(&sig_2, AssistantSig::Text(t) if t == "hello"));
+        assert!(matches!(&sig_3, AssistantSig::Text(t) if t == "hello"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_input_picks_fc_within_first_turn() {
+        // Turn 1 has text + function_call; turn 2 also has function_call.
+        // The bounded scan must pick turn 1's fc, not turn 2's.
+        let items = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u1"}]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_t1"}),
+            json!({"type":"function_call_output","call_id":"fc_t1","output":"ok"}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u2"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_t2"}),
+        ];
+        let sig = first_assistant_sig_from_input(&items).unwrap();
+        assert!(matches!(sig, AssistantSig::ToolId(id) if id == "fc_t1"));
+    }
+
+    // ─── first_assistant_sig_from_response_value: direct generation scan ──────
+
+    #[test]
+    fn first_assistant_sig_from_response_value_picks_fc_over_text() {
+        // Standard response: reasoning + assistant text + function_call.
+        // The response path scans the generation directly (no input bounding)
+        // and applies the same fc > text precedence.
+        let resp = json!({"output":[
+            {"type":"reasoning","summary":[],"content":[]},
+            {"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]},
+            {"type":"function_call","name":"f","arguments":"{}","call_id":"fc_resp"},
+        ]});
+        let sig = first_assistant_sig_from_response_value(&resp).unwrap();
+        assert!(matches!(sig, AssistantSig::ToolId(id) if id == "fc_resp"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_response_value_falls_back_to_text_when_no_fc() {
+        let resp = json!({"output":[
+            {"type":"reasoning","summary":[],"content":[]},
+            {"type":"message","role":"assistant","content":[{"type":"output_text","text":"final"}]},
+        ]});
+        let sig = first_assistant_sig_from_response_value(&resp).unwrap();
+        assert!(matches!(sig, AssistantSig::Text(t) if t == "final"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_response_value_does_not_apply_input_bounding() {
+        // Pathological output that mixes input-shaped items (a stray
+        // function_call_output, a stray user message) into a response.
+        // The response path must NOT short-circuit at the fco (which is
+        // input-only generation boundary) or skip leading user items;
+        // it just scans the whole array and picks fc > text. This guards
+        // against re-coupling response_value back to input's bounding logic.
+        let resp = json!({"output":[
+            {"type":"message","role":"assistant","content":[{"type":"output_text","text":"intro"}]},
+            {"type":"function_call_output","call_id":"fc_dummy","output":"x"},
+            {"type":"function_call","name":"f","arguments":"{}","call_id":"fc_after_fco"},
+        ]});
+        let sig = first_assistant_sig_from_response_value(&resp).unwrap();
+        // input bounding would have stopped at the fco and returned Text(intro);
+        // response scan ignores fco semantics → picks fc_after_fco.
+        assert!(matches!(sig, AssistantSig::ToolId(id) if id == "fc_after_fco"));
+    }
+
+    #[test]
+    fn first_assistant_sig_from_input_codex_dual_user_prefix() {
+        // Codex CLI splits turn 1's user side into two consecutive
+        // `role:user` items: a synthetic environment_context, then the real
+        // prompt. The leading user run must be skipped past entirely;
+        // generation 1 starts at the assistant generation AFTER both users.
+        // Sig must be stable across calls within turn 1 and across turn 2.
+        let items_call_1_resp_only = vec![
+            // Sanity-equivalent of what call 1's response output gives us:
+            json!({"type":"reasoning","summary":[],"content":[]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_e1"}),
+        ];
+        let sig_call_1 = first_assistant_sig_from_input(&items_call_1_resp_only).unwrap();
+
+        let items_call_2 = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"environment_context"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"real prompt"}]}),
+            json!({"type":"reasoning","summary":[],"content":[]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_e1"}),
+            json!({"type":"function_call_output","call_id":"fc_e1","output":"ok"}),
+        ];
+        let sig_call_2 = first_assistant_sig_from_input(&items_call_2).unwrap();
+
+        let items_turn_2_call = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"environment_context"}]}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"real prompt"}]}),
+            json!({"type":"reasoning","summary":[],"content":[]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_e1"}),
+            json!({"type":"function_call_output","call_id":"fc_e1","output":"ok"}),
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"follow-up"}]}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_t2"}),
+        ];
+        let sig_turn_2 = first_assistant_sig_from_input(&items_turn_2_call).unwrap();
+
+        for sig in [&sig_call_1, &sig_call_2, &sig_turn_2] {
+            assert!(matches!(sig, AssistantSig::ToolId(id) if id == "fc_e1"));
+        }
+    }
+
+    #[test]
+    fn first_assistant_sig_from_input_generation_1_text_only_does_not_leak_to_generation_2() {
+        // Generation 1 is text-only; generation 2 (within the same turn 1, after
+        // an fco) carries a function_call. Strict "generation 1 only" semantics
+        // means we must return Text(generation_1_msg), not ToolId(fc_e2).
+        // (This shape only arises with non-standard agents that loop through
+        // a turn without producing a final terminal generation, but the bound
+        // is what guarantees session_id stability when it does.)
+        let items = vec![
+            json!({"type":"message","role":"user","content":[{"type":"input_text","text":"u1"}]}),
+            json!({"type":"message","role":"assistant","content":[{"type":"output_text","text":"intermediate"}]}),
+            json!({"type":"function_call_output","call_id":"fc_dummy","output":"x"}),
+            json!({"type":"function_call","name":"f","arguments":"{}","call_id":"fc_e2"}),
+        ];
+        let sig = first_assistant_sig_from_input(&items).unwrap();
+        assert!(matches!(sig, AssistantSig::Text(t) if t == "intermediate"));
     }
 }


### PR DESCRIPTION
## Summary

Stabilizes `session_id` across calls in multi-turn conversations. Two related leaks let the wrong text become the session anchor:

- **Profile-match gating** — `ClaudeCliProfile` / `CodexCliProfile` now require their session-anchor header (`x-claude-code-session-id` / `x-codex-turn-metadata`) at `matches()` time. The registry is first-match-wins with no fallback, so UA-only matching previously claimed identifier-spoofed / header-stripped traffic and dropped it on the floor (`extract_session_id() = None`). With the header gate, those calls fall through to `GenericProfile`, which can synthesize an anchor from the body.
- **Anchor strictness** — `first_user_text` and `first_assistant_sig_from_request` (Anthropic / OpenAI Chat / OpenAI Responses / Gemini) now return `None` instead of falling through to later turns when turn 1's user/assistant has no extractable signal. Prevents turn-2 text from anchoring the conversation.
- **OpenAI Responses `input[]` bounding** — `first_assistant_sig_from_input` now skips the entire leading user run (Codex CLI / Gemini-style scaffolding splits turn-1's user side into two consecutive `role:user` items) and stops at the first `function_call_output` (boundary between generation 1 and generation 2 of the same turn). Splits the response-side scan into a dedicated `scan_generation_for_sig` helper since `output[]` is one inference's product with no turn boundaries.
- **Rename** — internal \"emission\" → \"generation\" (canonical LLM term).

## Test plan

- [x] `cargo test -p ts-llm` — 30+ new regression tests across the touched modules pass
- [ ] Replay a multi-turn Claude CLI capture: confirm `session_id` is stable across all calls in the conversation
- [ ] Replay a multi-turn Codex CLI capture (with `function_call_output` between generations): confirm same call stays on one `session_id` rather than splitting
- [ ] Send UA-spoofed Anthropic traffic with no `x-claude-code-session-id`: confirm `GenericProfile` claims it and synthesizes a session anchor