### PR TITLE
refactor: align pipeline.queues keys with pipeline-health metric names

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -130,18 +130,22 @@ Bounded channels between pipeline stages, all default to 4096:
 
 ```toml
 [pipeline.queues]
-raw = 4096
-parsed_packet = 4096
-flow_event = 4096
-turn_event = 4096
-metrics_event = 4096
-call_sink = 4096
-turn_sink = 4096
-metric_sink = 4096
+raw_pkts           = 4096
+parsed_pkts        = 4096
+http_parse_events  = 4096
+http_joiner_events = 4096
+agent_calls        = 4096
+llm_events         = 4096
+storage_calls      = 4096
+storage_turns      = 4096
+storage_metrics    = 4096
+storage_exchanges  = 4096
 ```
 
-Increase queue depths if you observe `internal_metrics` reporting
-backpressure on a specific stage; decrease them if memory is tight.
+Keys mirror the `pipeline-health` page's queue cell labels (drop the
+`q_` prefix). `storage_*` are shared sinks (fan-in across every pipeline);
+the others are per-pipeline. Bump the queue named by the first cell that
+reddens; lower them if memory is tight.
 
 ## `[storage]` — backend selection
 
@@ -299,8 +303,8 @@ shard_count = 2
 [pipeline.metrics]
 shard_count = 2
 [pipeline.queues]
-raw = 16384
-parsed_packet = 16384
+raw_pkts = 16384
+parsed_pkts = 16384
 [[pipeline.sources]]
 type = "cloud-probe"
 endpoint = "tcp://0.0.0.0:5555"

--- a/server/app/tokenscope/src/pipeline.rs
+++ b/server/app/tokenscope/src/pipeline.rs
@@ -128,22 +128,27 @@ impl Pipeline {
         active_turns: ts_turn::ActiveTurnRegistry,
     ) -> Self {
         // ---- Shared sinks (fan-in across every pipeline) ----
-        // Use the max queue capacity across all pipelines for shared channels.
-        let sink_capacity = pipeline_defs
-            .iter()
-            .map(|d| {
-                d.queues
-                    .call_sink
-                    .max(d.queues.turn_sink)
-                    .max(d.queues.metric_sink)
-            })
-            .max()
-            .unwrap_or(4096);
+        // Each shared channel takes the max of its dedicated config across
+        // every pipeline. We don't unify under one knob: a slow `storage_calls`
+        // shouldn't force `storage_turns` to over-allocate.
+        let max_q =
+            |pick: fn(&ts_common::config::QueueConfig) -> usize| -> usize {
+                pipeline_defs
+                    .iter()
+                    .map(|d| pick(&d.queues))
+                    .max()
+                    .unwrap_or(4096)
+            };
+        let calls_cap = max_q(|q| q.storage_calls);
+        let turns_cap = max_q(|q| q.storage_turns);
+        let metrics_cap = max_q(|q| q.storage_metrics);
+        let exchanges_cap = max_q(|q| q.storage_exchanges);
 
-        let (calls_tx, calls_rx) = mpsc::channel::<Arc<LlmCall>>(sink_capacity);
-        let (turns_tx, turns_rx) = mpsc::channel::<AgentTurn>(sink_capacity);
-        let (metrics_out_tx, metrics_out_rx) = mpsc::channel::<LlmMetricsBatch>(sink_capacity);
-        let (http_exchanges_tx, http_exchanges_rx) = mpsc::channel::<HttpExchange>(sink_capacity);
+        let (calls_tx, calls_rx) = mpsc::channel::<Arc<LlmCall>>(calls_cap);
+        let (turns_tx, turns_rx) = mpsc::channel::<AgentTurn>(turns_cap);
+        let (metrics_out_tx, metrics_out_rx) = mpsc::channel::<LlmMetricsBatch>(metrics_cap);
+        let (http_exchanges_tx, http_exchanges_rx) =
+            mpsc::channel::<HttpExchange>(exchanges_cap);
 
         let registry = Arc::new(ts_llm::agents::build_default_registry());
         let wire_api_registry = Arc::new(ts_llm::wire_apis::build_default_wire_api_registry());
@@ -156,13 +161,14 @@ impl Pipeline {
 
         // Shared sink queue depth probes — registered against `shared_metrics`
         // (same MetricsSystem as the storage_sink worker), so they show up in
-        // the `[INTERNAL] global | storage | …` line.
+        // the `[INTERNAL] global | storage | …` line. Each probe reports its
+        // own channel's capacity (not a unified max) so the UI gauge matches
+        // the actual mpsc bound.
         {
-            let cap = sink_capacity as u64;
             let w = calls_tx.downgrade();
             shared_metrics.register_queue_probe_capped(
                 Metric::StorageQueueDepthCalls,
-                cap,
+                calls_cap as u64,
                 move || {
                     w.upgrade()
                         .map_or(0, |s| (s.max_capacity() - s.capacity()) as u64)
@@ -171,7 +177,7 @@ impl Pipeline {
             let w = turns_tx.downgrade();
             shared_metrics.register_queue_probe_capped(
                 Metric::StorageQueueDepthTurns,
-                cap,
+                turns_cap as u64,
                 move || {
                     w.upgrade()
                         .map_or(0, |s| (s.max_capacity() - s.capacity()) as u64)
@@ -180,7 +186,7 @@ impl Pipeline {
             let w = metrics_out_tx.downgrade();
             shared_metrics.register_queue_probe_capped(
                 Metric::StorageQueueDepthMetrics,
-                cap,
+                metrics_cap as u64,
                 move || {
                     w.upgrade()
                         .map_or(0, |s| (s.max_capacity() - s.capacity()) as u64)
@@ -189,7 +195,7 @@ impl Pipeline {
             let w = http_exchanges_tx.downgrade();
             shared_metrics.register_queue_probe_capped(
                 Metric::StorageQueueDepthHttpExchanges,
-                cap,
+                exchanges_cap as u64,
                 move || {
                     w.upgrade()
                         .map_or(0, |s| (s.max_capacity() - s.capacity()) as u64)
@@ -227,7 +233,7 @@ impl Pipeline {
             };
 
             let (parsed_txs, parsed_rxs) =
-                make_shard_channels::<WorkerInput>(flow_shards, q.parsed_packet);
+                make_shard_channels::<WorkerInput>(flow_shards, q.parsed_pkts);
             // Capture weaks now; `parsed_txs` originals are dropped after
             // cloning into dispatchers, but the weaks remain upgradeable as
             // long as any dispatcher task holds a strong clone of the same channel.
@@ -235,21 +241,21 @@ impl Pipeline {
                 parsed_txs.iter().map(|tx| tx.downgrade()).collect();
             let (event_txs, event_rxs) = make_shard_channels::<ts_protocol::model::HttpParseEvent>(
                 flow_shards,
-                q.flow_event,
+                q.http_parse_events,
             );
             let event_weaks: Vec<WeakSender<ts_protocol::model::HttpParseEvent>> =
                 event_txs.iter().map(|tx| tx.downgrade()).collect();
             // Joiner output: per-shard HttpJoinerEvent channels into the LLM stage.
             let (joiner_event_txs, joiner_event_rxs) =
-                make_shard_channels::<HttpJoinerEvent>(flow_shards, q.flow_event);
+                make_shard_channels::<HttpJoinerEvent>(flow_shards, q.http_joiner_events);
             let joiner_event_weaks: Vec<WeakSender<HttpJoinerEvent>> =
                 joiner_event_txs.iter().map(|tx| tx.downgrade()).collect();
             let (turn_shard_txs, turn_shard_rxs) =
-                make_shard_channels::<TurnShardInput>(turn_shards, q.turn_event);
+                make_shard_channels::<TurnShardInput>(turn_shards, q.agent_calls);
             let turn_shard_weaks: Vec<WeakSender<TurnShardInput>> =
                 turn_shard_txs.iter().map(|tx| tx.downgrade()).collect();
             let (metrics_shard_txs, metrics_shard_rxs) =
-                make_shard_channels::<LlmEvent>(metrics_shards, q.metrics_event);
+                make_shard_channels::<LlmEvent>(metrics_shards, q.llm_events);
             let metrics_shard_weaks: Vec<WeakSender<LlmEvent>> =
                 metrics_shard_txs.iter().map(|tx| tx.downgrade()).collect();
 
@@ -260,7 +266,7 @@ impl Pipeline {
             // `hash(source_id) % D`.
             let mut disp_txs = Vec::with_capacity(dispatcher_count);
             for i in 0..dispatcher_count {
-                let (dtx, drx) = mpsc::channel::<RawPacket>(q.raw);
+                let (dtx, drx) = mpsc::channel::<RawPacket>(q.raw_pkts);
                 disp_txs.push(dtx);
                 let worker_txs_clone: Vec<_> = parsed_txs.iter().map(|tx| tx.clone()).collect();
                 let worker_name = if dispatcher_count > 1 {
@@ -398,7 +404,7 @@ impl Pipeline {
                 disp_txs.iter().map(|tx| tx.downgrade()).collect();
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthRaw,
-                q.raw as u64,
+                q.raw_pkts as u64,
                 move || {
                     raw_weaks
                         .iter()
@@ -410,7 +416,7 @@ impl Pipeline {
             );
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthParsed,
-                q.parsed_packet as u64,
+                q.parsed_pkts as u64,
                 move || {
                     parsed_weaks
                         .iter()
@@ -422,7 +428,7 @@ impl Pipeline {
             );
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthHttpParseEvent,
-                q.flow_event as u64,
+                q.http_parse_events as u64,
                 move || {
                     event_weaks
                         .iter()
@@ -434,7 +440,7 @@ impl Pipeline {
             );
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthHttpJoinerEvent,
-                q.flow_event as u64,
+                q.http_joiner_events as u64,
                 move || {
                     joiner_event_weaks
                         .iter()
@@ -446,7 +452,7 @@ impl Pipeline {
             );
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthAgentCall,
-                q.turn_event as u64,
+                q.agent_calls as u64,
                 move || {
                     turn_shard_weaks
                         .iter()
@@ -458,7 +464,7 @@ impl Pipeline {
             );
             metrics_sys.register_queue_probe_capped(
                 Metric::QueueDepthLlmEvent,
-                q.metrics_event as u64,
+                q.llm_events as u64,
                 move || {
                     metrics_shard_weaks
                         .iter()

--- a/server/config/default.toml
+++ b/server/config/default.toml
@@ -78,16 +78,22 @@
 #                         # 0 = no size cap.
 
 # Bounded channel capacities between pipeline stages. All default to 4096.
+# Keys mirror the queue probe metrics shown on the pipeline-health page
+# (without the `q_` prefix), so the dashboard cell that reddens names the
+# config key to bump. `storage_*` are shared sinks (fan-in across every
+# pipeline); the other queues are per-pipeline.
 # Override per-pipeline under [[pipeline]].
 # [pipeline.queues]
-# raw = 4096
-# parsed_packet = 4096
-# flow_event = 4096
-# turn_event = 4096
-# metrics_event = 4096
-# call_sink = 4096
-# turn_sink = 4096
-# metric_sink = 4096
+# raw_pkts           = 4096
+# parsed_pkts        = 4096
+# http_parse_events  = 4096
+# http_joiner_events = 4096
+# agent_calls        = 4096
+# llm_events         = 4096
+# storage_calls      = 4096
+# storage_turns      = 4096
+# storage_metrics    = 4096
+# storage_exchanges  = 4096
 
 # ---------------------------------------------------------------------------
 # Storage

--- a/server/ts-api/src/routes/agent_turns.rs
+++ b/server/ts-api/src/routes/agent_turns.rs
@@ -115,7 +115,7 @@ fn collect_in_progress(ctx: &ApiAgentTurnsContext, query: &TurnsQuery) -> Vec<Tu
             t.end_time_us >= start_us && t.start_time_us <= end_us
         })
         .filter(|t| matches_filter(t, filter))
-        .filter(|t| {
+        .filter(|_t| {
             // status filter: in-progress rows match only if `in_progress`
             // is in the requested set, OR if the filter is empty (= all).
             query.statuses.is_empty() || query.statuses.iter().any(|s| s == "in_progress")
@@ -173,7 +173,12 @@ fn matches_filter(t: &AgentTurn, f: &ts_storage::query::DimensionFilter) -> bool
     if !f.wire_apis.is_empty() && !f.wire_apis.iter().any(|w| w == &t.wire_api) {
         return false;
     }
-    if !f.models.is_empty() && !f.models.iter().any(|m| t.models_used.iter().any(|tm| tm == m)) {
+    if !f.models.is_empty()
+        && !f
+            .models
+            .iter()
+            .any(|m| t.models_used.iter().any(|tm| tm == m))
+    {
         return false;
     }
     let server_ip_str = t.server_ip.to_string();

--- a/server/ts-common/src/config.rs
+++ b/server/ts-common/src/config.rs
@@ -289,45 +289,58 @@ fn default_flow_shard_count() -> usize {
 
 /// Capacities of every bounded `mpsc` channel sitting between pipeline stages.
 /// All default to 4096 — override individually under `[pipeline.queues]`.
+///
+/// Field names mirror the queue probe metrics surfaced by `internal_metrics`
+/// (and the `pipeline-health` UI), modulo the `q_` prefix: e.g. config
+/// `agent_calls` ↔ metric `q_agent_calls`. The `storage_*` quartet feeds the
+/// shared sink that fans every pipeline into one DB writer.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueueConfig {
     /// capture → flow dispatcher
     #[serde(default = "default_queue_capacity")]
-    pub raw: usize,
+    pub raw_pkts: usize,
     /// flow dispatcher → each protocol parser shard (ParsedPacket)
     #[serde(default = "default_queue_capacity")]
-    pub parsed_packet: usize,
-    /// protocol parser → llm stage (HttpParseEvent, per shard)
+    pub parsed_pkts: usize,
+    /// protocol parser → http joiner (HttpParseEvent, per shard)
     #[serde(default = "default_queue_capacity")]
-    pub flow_event: usize,
-    /// llm stage → each turn shard (per shard)
+    pub http_parse_events: usize,
+    /// http joiner → llm stage (HttpJoinerEvent, per shard)
     #[serde(default = "default_queue_capacity")]
-    pub turn_event: usize,
-    /// llm stage → each metrics shard (per shard)
+    pub http_joiner_events: usize,
+    /// llm stage → each turn shard (AgentCall, per shard)
     #[serde(default = "default_queue_capacity")]
-    pub metrics_event: usize,
-    /// llm stage → storage sink (LlmCall records)
+    pub agent_calls: usize,
+    /// llm stage → each metrics shard (LlmEvent, per shard)
     #[serde(default = "default_queue_capacity")]
-    pub call_sink: usize,
-    /// turn stage → storage sink (AgentTurn records)
+    pub llm_events: usize,
+    /// llm stage → shared storage sink (LlmCall records)
     #[serde(default = "default_queue_capacity")]
-    pub turn_sink: usize,
-    /// metrics stage → storage sink (LlmMetric records)
+    pub storage_calls: usize,
+    /// turn stage → shared storage sink (AgentTurn records)
     #[serde(default = "default_queue_capacity")]
-    pub metric_sink: usize,
+    pub storage_turns: usize,
+    /// metrics stage → shared storage sink (LlmMetric records)
+    #[serde(default = "default_queue_capacity")]
+    pub storage_metrics: usize,
+    /// http joiner → shared storage sink (HttpExchange records)
+    #[serde(default = "default_queue_capacity")]
+    pub storage_exchanges: usize,
 }
 
 impl Default for QueueConfig {
     fn default() -> Self {
         Self {
-            raw: default_queue_capacity(),
-            parsed_packet: default_queue_capacity(),
-            flow_event: default_queue_capacity(),
-            turn_event: default_queue_capacity(),
-            metrics_event: default_queue_capacity(),
-            call_sink: default_queue_capacity(),
-            turn_sink: default_queue_capacity(),
-            metric_sink: default_queue_capacity(),
+            raw_pkts: default_queue_capacity(),
+            parsed_pkts: default_queue_capacity(),
+            http_parse_events: default_queue_capacity(),
+            http_joiner_events: default_queue_capacity(),
+            agent_calls: default_queue_capacity(),
+            llm_events: default_queue_capacity(),
+            storage_calls: default_queue_capacity(),
+            storage_turns: default_queue_capacity(),
+            storage_metrics: default_queue_capacity(),
+            storage_exchanges: default_queue_capacity(),
         }
     }
 }
@@ -1199,14 +1212,16 @@ mod phase2_tests {
     #[test]
     fn queue_config_defaults_all_4096() {
         let cfg = QueueConfig::default();
-        assert_eq!(cfg.raw, 4096);
-        assert_eq!(cfg.parsed_packet, 4096);
-        assert_eq!(cfg.flow_event, 4096);
-        assert_eq!(cfg.turn_event, 4096);
-        assert_eq!(cfg.metrics_event, 4096);
-        assert_eq!(cfg.call_sink, 4096);
-        assert_eq!(cfg.turn_sink, 4096);
-        assert_eq!(cfg.metric_sink, 4096);
+        assert_eq!(cfg.raw_pkts, 4096);
+        assert_eq!(cfg.parsed_pkts, 4096);
+        assert_eq!(cfg.http_parse_events, 4096);
+        assert_eq!(cfg.http_joiner_events, 4096);
+        assert_eq!(cfg.agent_calls, 4096);
+        assert_eq!(cfg.llm_events, 4096);
+        assert_eq!(cfg.storage_calls, 4096);
+        assert_eq!(cfg.storage_turns, 4096);
+        assert_eq!(cfg.storage_metrics, 4096);
+        assert_eq!(cfg.storage_exchanges, 4096);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `[pipeline.queues]` 配置 key 与 pipeline-health 页面格子标签（即 metric `short_name` 去掉 `q_` 前缀）一一对应。"哪格变红就改哪个 key"，零翻译成本。
- 把同一个 `flow_event` 配同时控制 `HttpParseEvent` 和 `HttpJoinerEvent` 两条独立 channel 的状况拆开。
- 新增 `storage_exchanges`：之前 `http_exchanges` channel 强制蹭 `max(call_sink, turn_sink, metric_sink)`，用户根本不知道这个队列存在。
- 4 个 shared storage channel 各自取自己 key 的跨 pipeline `max()`，不再统一容量；queue probe 也按各自真实 capacity 上报。

| Old key | New key |
|---|---|
| `raw` | `raw_pkts` |
| `parsed_packet` | `parsed_pkts` |
| `flow_event` (一控二) | `http_parse_events` + `http_joiner_events` |
| `turn_event` | `agent_calls` |
| `metrics_event` | `llm_events` |
| `call_sink` | `storage_calls` |
| `turn_sink` | `storage_turns` |
| `metric_sink` | `storage_metrics` |
| (无) | `storage_exchanges` |

不保留 serde alias：老 key 在新结构下会被 serde 静默忽略落回默认值，比硬失败更迷惑。这是破坏性变更，使用了自定义 `[pipeline.queues]` 的部署需要按上表手动改名。

顺手把 `ts-api/src/routes/agent_turns.rs` 里 cargo 报的 `unused variable: t` 警告 + 一处 rustfmt 收掉。

## Test plan

- [x] `cargo check -p ts-common -p tokenscope` 通过
- [x] `cargo test -p ts-common` 60/60 通过（含更新后的 `queue_config_defaults_all_4096`）
- [ ] 启动一次本地 pipeline，确认 `internal_metrics` 的 queue probe 行仍按各自 capacity 渲染
- [ ] pipeline-health 页面的 backpressure 部分十个格子容量正确显示