### PR TITLE
feat(settings): in-app capture configuration + self-restart

### DIFF
--- a/console/src/app.tsx
+++ b/console/src/app.tsx
@@ -11,6 +11,7 @@ import { AgentSessionsPage } from "@/pages/agent-sessions"
 import { AgentSessionDetailPage } from "@/pages/agent-session-detail"
 import { AgentTurnsPage } from "@/pages/agent-turns"
 import { HttpExchangesPage } from "@/pages/http-exchanges"
+import { SettingsPage } from "@/pages/settings"
 import { PipelineHealthPage } from "@/pages/debug-pipeline-health"
 import { RuntimeConfigPage } from "@/pages/debug-runtime-config"
 import { DebugIndexPage } from "@/pages/debug-index"
@@ -40,6 +41,7 @@ export default function App() {
             <Route path="/agent-turns" element={<AgentTurnsPage />} />
             <Route path="/llm-calls" element={<LlmCallsPage />} />
             <Route path="/http-exchanges" element={<HttpExchangesPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
           </Route>
           <Route path="/debug" element={<DebugIndexPage />} />
           <Route path="/debug/pipeline-health" element={<PipelineHealthPage />} />

--- a/console/src/components/layout/sidebar.tsx
+++ b/console/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Network,
   PanelLeftClose,
   PanelLeftOpen,
+  Settings,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useSidebarStore } from "@/stores/sidebar"
@@ -28,6 +29,7 @@ const navItems = [
   { to: "/agent-turns", icon: MessagesSquare, label: "Agent Turns" },
   { to: "/llm-calls", icon: Sparkles, label: "LLM Calls" },
   { to: "/http-exchanges", icon: Network, label: "HTTP Exchanges" },
+  { to: "/settings", icon: Settings, label: "Settings" },
 ]
 
 export function Sidebar() {

--- a/console/src/components/settings/chip-input.tsx
+++ b/console/src/components/settings/chip-input.tsx
@@ -1,0 +1,79 @@
+import { useState, type KeyboardEvent } from "react"
+import { X } from "lucide-react"
+
+/**
+ * Lightweight chip input for the structured BPF editor. Tokens are added
+ * on Enter / comma / blur and removed via the × button or Backspace on
+ * an empty input.
+ */
+export function ChipInput({
+  values,
+  onChange,
+  placeholder,
+  validate,
+}: {
+  values: string[]
+  onChange: (next: string[]) => void
+  placeholder?: string
+  /** Optional per-token validator. Invalid tokens are accepted but shown red. */
+  validate?: (token: string) => boolean
+}) {
+  const [draft, setDraft] = useState("")
+
+  const commit = (raw: string) => {
+    const cleaned = raw.trim().replace(/,$/, "").trim()
+    if (cleaned === "") return
+    if (values.includes(cleaned)) {
+      setDraft("")
+      return
+    }
+    onChange([...values, cleaned])
+    setDraft("")
+  }
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault()
+      commit(draft)
+    } else if (e.key === "Backspace" && draft === "" && values.length > 0) {
+      e.preventDefault()
+      onChange(values.slice(0, -1))
+    }
+  }
+
+  return (
+    <div className="flex min-h-[28px] flex-wrap items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1">
+      {values.map((v, i) => {
+        const ok = validate ? validate(v) : true
+        return (
+          <span
+            key={`${v}-${i}`}
+            className={
+              ok
+                ? "inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
+                : "inline-flex items-center gap-1 rounded bg-destructive/10 px-1.5 py-0.5 font-mono text-xs text-destructive"
+            }
+          >
+            {v}
+            <button
+              type="button"
+              onClick={() => onChange(values.filter((_, idx) => idx !== i))}
+              className="opacity-60 hover:opacity-100"
+              aria-label={`Remove ${v}`}
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        )
+      })}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => commit(draft)}
+        onKeyDown={onKey}
+        placeholder={values.length === 0 ? placeholder : ""}
+        className="min-w-[120px] flex-1 bg-transparent px-1 py-0.5 text-xs outline-none placeholder:text-muted-foreground"
+      />
+    </div>
+  )
+}

--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -1,0 +1,494 @@
+import { useMemo, useState } from "react"
+import { AlertCircle, ChevronDown, ChevronRight, Trash2 } from "lucide-react"
+import type { CaptureInterface, CaptureSource } from "@/types/api"
+import { groupInterfaces } from "@/lib/interface-groups"
+import { isValidHost, isValidPort, parseBpf, synthBpf } from "@/lib/bpf"
+import { ChipInput } from "./chip-input"
+
+const DEFAULT_SNAPLEN = 262_144
+const DEFAULT_CLOUD_PROBE_ENDPOINT = "tcp://0.0.0.0:5555"
+const DEFAULT_CLOUD_PROBE_HWM = 1000
+
+// ============================================================================
+// SourceEditorRow — dispatches by type
+// ============================================================================
+
+export function SourceEditorRow({
+  source,
+  interfaces,
+  onChange,
+  onRemove,
+  canRemove,
+}: {
+  source: CaptureSource
+  interfaces: CaptureInterface[]
+  onChange: (next: CaptureSource) => void
+  onRemove: () => void
+  canRemove: boolean
+}) {
+  return (
+    <li className="rounded-md border border-border/60 bg-background p-3">
+      <div className="mb-2 flex items-center gap-2 text-xs">
+        <SourceTypeBadge type={source.type} />
+        <SourceTypeSwitcher current={source} onSwitch={onChange} />
+        <div className="flex-1" />
+        {canRemove && (
+          <button
+            onClick={onRemove}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
+            title="Remove this source"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        )}
+      </div>
+      {source.type === "pcap" && (
+        <PcapForm source={source} interfaces={interfaces} onChange={onChange} />
+      )}
+      {source.type === "cloud-probe" && (
+        <CloudProbeForm source={source} onChange={onChange} />
+      )}
+      {source.type === "pcap-file" && (
+        <PcapFileForm source={source} onChange={onChange} />
+      )}
+    </li>
+  )
+}
+
+function SourceTypeBadge({ type }: { type: CaptureSource["type"] }) {
+  const meta = TYPE_META[type]
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-primary">
+      <span>{meta.icon}</span>
+      <span>{meta.label}</span>
+    </span>
+  )
+}
+
+function SourceTypeSwitcher({
+  current,
+  onSwitch,
+}: {
+  current: CaptureSource
+  onSwitch: (s: CaptureSource) => void
+}) {
+  return (
+    <select
+      value={current.type}
+      onChange={(e) => onSwitch(defaultFor(e.target.value as CaptureSource["type"]))}
+      className="rounded-md border border-border bg-background px-2 py-0.5 text-xs"
+      title="Change source type"
+    >
+      <option value="pcap">Live network interface</option>
+      <option value="cloud-probe">Remote ZMQ stream</option>
+      <option value="pcap-file">PCAP file replay</option>
+    </select>
+  )
+}
+
+const TYPE_META: Record<CaptureSource["type"], { icon: string; label: string }> = {
+  pcap: { icon: "📡", label: "Live" },
+  "cloud-probe": { icon: "🔌", label: "ZMQ" },
+  "pcap-file": { icon: "📂", label: "Replay" },
+}
+
+export function defaultFor(type: CaptureSource["type"]): CaptureSource {
+  if (type === "pcap") {
+    return {
+      type: "pcap",
+      interface: "any",
+      bpf_filter: null,
+      snaplen: DEFAULT_SNAPLEN,
+      source_id: null,
+    }
+  }
+  if (type === "cloud-probe") {
+    return {
+      type: "cloud-probe",
+      endpoint: DEFAULT_CLOUD_PROBE_ENDPOINT,
+      recv_hwm: DEFAULT_CLOUD_PROBE_HWM,
+    }
+  }
+  return {
+    type: "pcap-file",
+    path: "",
+    realtime: false,
+    source_id: null,
+  }
+}
+
+// ============================================================================
+// PcapForm — friendly structured editor with raw-BPF fallback
+// ============================================================================
+
+function PcapForm({
+  source,
+  interfaces,
+  onChange,
+}: {
+  source: Extract<CaptureSource, { type: "pcap" }>
+  interfaces: CaptureInterface[]
+  onChange: (next: CaptureSource) => void
+}) {
+  // Decide initial mode: structured if BPF parses cleanly, else raw.
+  const parsed = useMemo(() => parseBpf(source.bpf_filter), [source.bpf_filter])
+  const [mode, setMode] = useState<"structured" | "raw">(parsed ? "structured" : "raw")
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
+  const groups = useMemo(() => groupInterfaces(interfaces), [interfaces])
+  const currentNotInList =
+    !interfaces.some((i) => i.name === source.interface) && source.interface !== ""
+
+  // When in structured mode and the user types invalid input we still
+  // update bpf_filter to the synth output; the parent server-side
+  // validator will reject. We show inline validation hints here too.
+  const updateStructured = (ports: number[], hosts: string[]) => {
+    const next = synthBpf({ ports, hosts })
+    onChange({ ...source, bpf_filter: next === "" ? null : next })
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Interface */}
+      <Field
+        label="Network interface"
+        hint="Where on this host to capture from. 'any' covers every interface, including loopback."
+      >
+        <select
+          value={source.interface}
+          onChange={(e) => onChange({ ...source, interface: e.target.value })}
+          className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+        >
+          {currentNotInList && (
+            <option value={source.interface}>{source.interface} (current — not in list)</option>
+          )}
+          <optgroup label="Recommended">
+            {groups.recommended.map((i) => (
+              <option key={i.name} value={i.name}>
+                {formatInterfaceOption(i)}
+              </option>
+            ))}
+          </optgroup>
+          {groups.virtual.length > 0 && (
+            <optgroup label={`Virtual (${groups.virtual.length})`}>
+              {groups.virtual.map((i) => (
+                <option key={i.name} value={i.name}>
+                  {formatInterfaceOption(i)}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+      </Field>
+
+      {/* What to capture */}
+      <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+        <div className="mb-2 flex items-center justify-between text-xs">
+          <span className="font-medium">What to capture</span>
+          <button
+            type="button"
+            onClick={() => setMode((m) => (m === "structured" ? "raw" : "structured"))}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            {mode === "structured" ? "Switch to raw BPF" : "Switch to ports/hosts"}
+          </button>
+        </div>
+
+        {mode === "structured" ? (
+          <StructuredFilter
+            ports={parsed?.ports ?? []}
+            hosts={parsed?.hosts ?? []}
+            onChange={updateStructured}
+          />
+        ) : (
+          <RawBpfInput
+            value={source.bpf_filter ?? ""}
+            onChange={(v) => onChange({ ...source, bpf_filter: v === "" ? null : v })}
+            structuredAvailable={parsed !== null}
+            onBackToStructured={() => setMode("structured")}
+          />
+        )}
+      </div>
+
+      {/* Advanced */}
+      <Disclosure
+        open={advancedOpen}
+        onToggle={() => setAdvancedOpen((v) => !v)}
+        label="Advanced"
+      >
+        <Field
+          label="Snaplen (bytes)"
+          hint="Per-packet capture limit. 262144 handles GRO super-frames; lower wastes nothing but truncates large LLM POST bodies."
+        >
+          <input
+            type="number"
+            min={64}
+            max={1 << 20}
+            value={source.snaplen}
+            onChange={(e) =>
+              onChange({ ...source, snaplen: Number(e.target.value) || DEFAULT_SNAPLEN })
+            }
+            className="w-32 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </Field>
+      </Disclosure>
+    </div>
+  )
+}
+
+function StructuredFilter({
+  ports,
+  hosts,
+  onChange,
+}: {
+  ports: number[]
+  hosts: string[]
+  onChange: (ports: number[], hosts: string[]) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2 text-xs">
+      <div>
+        <div className="mb-1 text-muted-foreground">Ports (TCP)</div>
+        <ChipInput
+          values={ports.map(String)}
+          onChange={(next) =>
+            onChange(
+              next.map(Number).filter((n) => Number.isInteger(n)),
+              hosts,
+            )
+          }
+          placeholder="e.g. 4210, 4271 — press Enter or comma"
+          validate={(t) => isValidPort(t)}
+        />
+      </div>
+      <div>
+        <div className="mb-1 text-muted-foreground">Hosts (IPv4 / hostname)</div>
+        <ChipInput
+          values={hosts}
+          onChange={(next) => onChange(ports, next)}
+          placeholder="e.g. 10.0.0.1 — leave empty to capture from any host"
+          validate={(t) => isValidHost(t)}
+        />
+      </div>
+      <div className="text-[11px] text-muted-foreground">
+        Empty = capture all TCP. Multiple ports or hosts are ORed; ports AND hosts
+        when both are set.
+      </div>
+    </div>
+  )
+}
+
+function RawBpfInput({
+  value,
+  onChange,
+  structuredAvailable,
+  onBackToStructured,
+}: {
+  value: string
+  onChange: (v: string) => void
+  structuredAvailable: boolean
+  onBackToStructured: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-2 text-xs">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Raw libpcap filter expression"
+        className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+      />
+      <div className="text-[11px] text-muted-foreground">
+        Free-form{" "}
+        <a
+          href="https://www.tcpdump.org/manpages/pcap-filter.7.html"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          pcap-filter(7)
+        </a>{" "}
+        expression. Validated server-side before save.
+      </div>
+      {!structuredAvailable && value.trim() !== "" ? (
+        <div className="flex items-start gap-1.5 rounded-md bg-muted/40 px-2 py-1.5 text-[11px] text-muted-foreground">
+          <AlertCircle className="mt-0.5 size-3 shrink-0" />
+          <span>
+            This expression uses features beyond ports + hosts. The ports/hosts
+            editor would silently lose them.
+          </span>
+        </div>
+      ) : (
+        structuredAvailable && (
+          <button
+            type="button"
+            onClick={onBackToStructured}
+            className="self-start text-[11px] text-primary underline"
+          >
+            ← back to ports/hosts editor
+          </button>
+        )
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// CloudProbeForm
+// ============================================================================
+
+function CloudProbeForm({
+  source,
+  onChange,
+}: {
+  source: Extract<CaptureSource, { type: "cloud-probe" }>
+  onChange: (next: CaptureSource) => void
+}) {
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  // Endpoint is a ZMQ TCP URI like `tcp://0.0.0.0:5555`. Show a friendly
+  // host:port input; we add/strip the `tcp://` prefix automatically.
+  const friendly = source.endpoint.replace(/^tcp:\/\//, "")
+  const updateEndpoint = (v: string) => {
+    const trimmed = v.trim().replace(/^tcp:\/\//, "")
+    onChange({ ...source, endpoint: trimmed === "" ? "" : `tcp://${trimmed}` })
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      <Field
+        label="Listen on"
+        hint="ZMQ address tokenscope will bind to receive packets from remote probes. Format host:port. 0.0.0.0 = all addresses on this host."
+      >
+        <div className="flex items-center">
+          <span className="rounded-l-md border border-r-0 border-border bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+            tcp://
+          </span>
+          <input
+            value={friendly}
+            onChange={(e) => updateEndpoint(e.target.value)}
+            placeholder="0.0.0.0:5555"
+            className="flex-1 rounded-r-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </div>
+      </Field>
+      <Disclosure
+        open={advancedOpen}
+        onToggle={() => setAdvancedOpen((v) => !v)}
+        label="Advanced"
+      >
+        <Field
+          label="Receive queue depth"
+          hint="ZMQ high-water mark. Caps how many in-flight messages the receiver buffers when downstream stages stall."
+        >
+          <input
+            type="number"
+            min={1}
+            value={source.recv_hwm}
+            onChange={(e) =>
+              onChange({
+                ...source,
+                recv_hwm: Number(e.target.value) || DEFAULT_CLOUD_PROBE_HWM,
+              })
+            }
+            className="w-32 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </Field>
+      </Disclosure>
+    </div>
+  )
+}
+
+// ============================================================================
+// PcapFileForm
+// ============================================================================
+
+function PcapFileForm({
+  source,
+  onChange,
+}: {
+  source: Extract<CaptureSource, { type: "pcap-file" }>
+  onChange: (next: CaptureSource) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <Field
+        label="File path"
+        hint="Absolute path to a .pcap or .pcapng file readable by the tokenscope process."
+      >
+        <input
+          value={source.path}
+          onChange={(e) => onChange({ ...source, path: e.target.value })}
+          placeholder="/path/to/capture.pcap"
+          className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+        />
+      </Field>
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={source.realtime}
+          onChange={(e) => onChange({ ...source, realtime: e.target.checked })}
+        />
+        <span>Replay at original wall-clock speed (otherwise as fast as possible)</span>
+      </label>
+    </div>
+  )
+}
+
+// ============================================================================
+// Shared primitives
+// ============================================================================
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <label className="text-xs font-medium">{label}</label>
+      </div>
+      {children}
+      {hint && <div className="text-[11px] text-muted-foreground">{hint}</div>}
+    </div>
+  )
+}
+
+function Disclosure({
+  open,
+  onToggle,
+  label,
+  children,
+}: {
+  open: boolean
+  onToggle: () => void
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        {label}
+      </button>
+      {open && <div className="mt-2">{children}</div>}
+    </div>
+  )
+}
+
+function formatInterfaceOption(i: CaptureInterface): string {
+  const flags: string[] = []
+  if (!i.is_up) flags.push("down")
+  if (i.is_loopback) flags.push("loopback")
+  if (i.is_wireless) flags.push("wireless")
+  const flagStr = flags.length > 0 ? `  [${flags.join(", ")}]` : ""
+  const addrStr = i.addresses.length > 0 ? `  ·  ${i.addresses[0]}` : ""
+  return `${i.name}${addrStr}${flagStr}`
+}

--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -10,7 +10,9 @@ const DEFAULT_CLOUD_PROBE_ENDPOINT = "tcp://0.0.0.0:5555"
 const DEFAULT_CLOUD_PROBE_HWM = 1000
 
 // ============================================================================
-// SourceEditorRow — dispatches by type
+// SourceEditorRow — dispatches by type; the type itself is fixed (no
+// in-row switcher) because the Settings page now organises sources into
+// per-type sections.
 // ============================================================================
 
 export function SourceEditorRow({
@@ -18,29 +20,24 @@ export function SourceEditorRow({
   interfaces,
   onChange,
   onRemove,
-  canRemove,
 }: {
   source: CaptureSource
   interfaces: CaptureInterface[]
   onChange: (next: CaptureSource) => void
   onRemove: () => void
-  canRemove: boolean
 }) {
   return (
     <li className="rounded-md border border-border/60 bg-background p-3">
       <div className="mb-2 flex items-center gap-2 text-xs">
-        <SourceTypeBadge type={source.type} />
-        <SourceTypeSwitcher current={source} onSwitch={onChange} />
+        <span className="text-muted-foreground">{rowHeading(source.type)}</span>
         <div className="flex-1" />
-        {canRemove && (
-          <button
-            onClick={onRemove}
-            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
-            title="Remove this source"
-          >
-            <Trash2 className="size-3.5" />
-          </button>
-        )}
+        <button
+          onClick={onRemove}
+          className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
+          title="Remove this source"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
       </div>
       {source.type === "pcap" && (
         <PcapForm source={source} interfaces={interfaces} onChange={onChange} />
@@ -55,41 +52,15 @@ export function SourceEditorRow({
   )
 }
 
-function SourceTypeBadge({ type }: { type: CaptureSource["type"] }) {
-  const meta = TYPE_META[type]
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-primary">
-      <span>{meta.icon}</span>
-      <span>{meta.label}</span>
-    </span>
-  )
-}
-
-function SourceTypeSwitcher({
-  current,
-  onSwitch,
-}: {
-  current: CaptureSource
-  onSwitch: (s: CaptureSource) => void
-}) {
-  return (
-    <select
-      value={current.type}
-      onChange={(e) => onSwitch(defaultFor(e.target.value as CaptureSource["type"]))}
-      className="rounded-md border border-border bg-background px-2 py-0.5 text-xs"
-      title="Change source type"
-    >
-      <option value="pcap">Live network interface</option>
-      <option value="cloud-probe">Remote ZMQ stream</option>
-      <option value="pcap-file">PCAP file replay</option>
-    </select>
-  )
-}
-
-const TYPE_META: Record<CaptureSource["type"], { icon: string; label: string }> = {
-  pcap: { icon: "📡", label: "Live" },
-  "cloud-probe": { icon: "🔌", label: "ZMQ" },
-  "pcap-file": { icon: "📂", label: "Replay" },
+function rowHeading(type: CaptureSource["type"]): string {
+  switch (type) {
+    case "pcap":
+      return "Live capture from local interface"
+    case "cloud-probe":
+      return "ZMQ receiver for remote probe stream"
+    case "pcap-file":
+      return "PCAP file replay"
+  }
 }
 
 export function defaultFor(type: CaptureSource["type"]): CaptureSource {

--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -9,6 +9,25 @@ const DEFAULT_SNAPLEN = 262_144
 const DEFAULT_CLOUD_PROBE_ENDPOINT = "tcp://0.0.0.0:5555"
 const DEFAULT_CLOUD_PROBE_HWM = 1000
 
+/**
+ * Default BPF for a newly-added live-capture source: the common ports
+ * that LLM serving stacks listen on, so out-of-the-box capture sees
+ * traffic without the user having to know BPF syntax. Users can edit
+ * via the structured ports/hosts panel or switch to raw BPF.
+ *
+ *   1234   LM Studio
+ *   4000   LiteLLM proxy default
+ *   4200   LiteLLM alt (in active use here)
+ *   8000   vLLM default
+ *   8001   vLLM alt / multi-instance
+ *   8080   common HTTP backend (vLLM, OpenAI-compatible servers)
+ *   9000   generic alt; SGLang served on this in our internal setup
+ *   11434  Ollama default
+ *   30000  SGLang default
+ */
+const DEFAULT_LLM_PORTS = [1234, 4000, 4200, 8000, 8001, 8080, 9000, 11434, 30000]
+const DEFAULT_LLM_PORTS_BPF = DEFAULT_LLM_PORTS.map((p) => `tcp port ${p}`).join(" or ")
+
 // ============================================================================
 // SourceEditorRow — dispatches by type; the type itself is fixed (no
 // in-row switcher) because the Settings page now organises sources into
@@ -68,7 +87,7 @@ export function defaultFor(type: CaptureSource["type"]): CaptureSource {
     return {
       type: "pcap",
       interface: "any",
-      bpf_filter: null,
+      bpf_filter: DEFAULT_LLM_PORTS_BPF,
       snaplen: DEFAULT_SNAPLEN,
       source_id: null,
     }

--- a/console/src/hooks/use-capture-interfaces.ts
+++ b/console/src/hooks/use-capture-interfaces.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+import { apiFetch } from "@/lib/api"
+import type { CaptureInterfacesResponse } from "@/types/api"
+
+/**
+ * Fetch /api/capture/interfaces — the network interfaces libpcap can
+ * enumerate inside the tokenscope process. List changes are rare; refresh
+ * is manual via `refetch`.
+ */
+export function useCaptureInterfaces() {
+  return useQuery({
+    queryKey: ["capture-interfaces"],
+    queryFn: () => apiFetch<CaptureInterfacesResponse>("/api/capture/interfaces"),
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  })
+}

--- a/console/src/hooks/use-update-sources.ts
+++ b/console/src/hooks/use-update-sources.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "@tanstack/react-query"
+import { ApiError } from "@/lib/api"
+import type { ApiResponse, CaptureSource } from "@/types/api"
+
+export interface UpdateSourcesRequest {
+  pipeline_name: string
+  sources: CaptureSource[]
+}
+
+export interface UpdateSourcesResponse {
+  /** How long the server will wait before re-execing itself. */
+  restart_in_ms: number
+}
+
+async function putUpdate(body: UpdateSourcesRequest): Promise<UpdateSourcesResponse> {
+  const res = await fetch("/api/capture/sources", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const parsed = await res.json().catch(() => ({ code: res.status, message: res.statusText }))
+    throw new ApiError(parsed.code ?? res.status, parsed.message ?? res.statusText)
+  }
+  const json: ApiResponse<UpdateSourcesResponse> = await res.json()
+  if (json.code !== 0) throw new ApiError(json.code, json.message)
+  return json.data
+}
+
+/**
+ * Mutation to PUT new capture sources to the server. On success the server
+ * schedules a self-restart after `restart_in_ms` — callers should show a
+ * "restarting…" overlay and poll `/api/health` to detect when the new
+ * process is up.
+ */
+export function useUpdateSources() {
+  return useMutation({
+    mutationFn: putUpdate,
+  })
+}

--- a/console/src/lib/bpf.test.ts
+++ b/console/src/lib/bpf.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { parseBpf, synthBpf } from "./bpf"
+
+describe("synthBpf", () => {
+  test("empty → empty string", () => {
+    expect(synthBpf({ ports: [], hosts: [] })).toBe("")
+  })
+  test("single port", () => {
+    expect(synthBpf({ ports: [80], hosts: [] })).toBe("tcp port 80")
+  })
+  test("multiple ports", () => {
+    expect(synthBpf({ ports: [80, 443], hosts: [] })).toBe(
+      "tcp port 80 or tcp port 443",
+    )
+  })
+  test("single host", () => {
+    expect(synthBpf({ ports: [], hosts: ["10.0.0.1"] })).toBe("host 10.0.0.1")
+  })
+  test("ports and hosts", () => {
+    expect(
+      synthBpf({ ports: [4210, 4271], hosts: ["10.0.0.1"] }),
+    ).toBe("(tcp port 4210 or tcp port 4271) and host 10.0.0.1")
+  })
+})
+
+describe("parseBpf", () => {
+  test("null → empty structured", () => {
+    expect(parseBpf(null)).toEqual({ ports: [], hosts: [] })
+  })
+  test("empty string → empty structured", () => {
+    expect(parseBpf("")).toEqual({ ports: [], hosts: [] })
+    expect(parseBpf("   ")).toEqual({ ports: [], hosts: [] })
+  })
+  test("single port", () => {
+    expect(parseBpf("tcp port 80")).toEqual({ ports: [80], hosts: [] })
+  })
+  test("bare 'port' (without tcp) still parses", () => {
+    expect(parseBpf("port 80")).toEqual({ ports: [80], hosts: [] })
+  })
+  test("multiple ports", () => {
+    expect(parseBpf("tcp port 4210 or tcp port 4271")).toEqual({
+      ports: [4210, 4271],
+      hosts: [],
+    })
+  })
+  test("hosts and ports combined", () => {
+    expect(
+      parseBpf("(tcp port 4210 or tcp port 4271) and host 10.0.0.1"),
+    ).toEqual({ ports: [4210, 4271], hosts: ["10.0.0.1"] })
+  })
+  test("non-structured filter → null", () => {
+    expect(parseBpf("udp")).toBeNull()
+    expect(parseBpf("tcp and not host 1.2.3.4")).toBeNull()
+    expect(parseBpf("vlan 10")).toBeNull()
+  })
+  test("port out of range → null", () => {
+    expect(parseBpf("tcp port 99999")).toBeNull()
+  })
+  test("round-trip", () => {
+    const fixtures = [
+      { ports: [80], hosts: [] },
+      { ports: [80, 443], hosts: [] },
+      { ports: [], hosts: ["10.0.0.1"] },
+      { ports: [4210, 4271], hosts: ["10.0.0.1"] },
+    ]
+    for (const f of fixtures) {
+      const round = parseBpf(synthBpf(f))
+      expect(round).toEqual(f)
+    }
+  })
+})

--- a/console/src/lib/bpf.ts
+++ b/console/src/lib/bpf.ts
@@ -1,0 +1,190 @@
+/**
+ * Round-trip BPF helpers for the Settings page.
+ *
+ * The page only exposes a structured editor for the two common cases —
+ * filter by port(s) and/or filter by host(s) — and synthesises a BPF
+ * string from them. Anything else (icmp, vlan, not, complex expressions
+ * with mixed and/or, …) falls back to raw mode. The parser is the gate:
+ * if it can recognise the existing filter as the synth's output, structured
+ * mode opens cleanly; otherwise the editor stays in raw.
+ *
+ * Intentionally narrow: we don't try to cover every BPF expression. The
+ * structured view is a convenience for the common case, not a general BPF
+ * GUI.
+ */
+
+export interface StructuredBpf {
+  /** TCP/UDP ports (positive integers, ≤ 65535). */
+  ports: number[]
+  /** Host IPv4 / IPv6 literals or hostnames. We don't validate beyond non-empty. */
+  hosts: string[]
+}
+
+const IPV4 = /^(\d{1,3})(?:\.\d{1,3}){3}(?:\/\d{1,2})?$/
+const HOST_TOKEN = /^[A-Za-z0-9._:/-]+$/ // permissive — covers IPv4, simple IPv6, hostnames
+
+/**
+ * Synthesise a BPF filter string from a structured filter. Returns the
+ * empty string when both arrays are empty.
+ *
+ * Shape produced (matches what the parser accepts):
+ *
+ *     <ports>            ports only: `tcp port 80 or tcp port 443`
+ *     <hosts>            hosts only: `host 1.2.3.4 or host 5.6.7.8`
+ *     <ports> and <hosts> both: `(tcp port 80 or tcp port 443) and (host 1.2.3.4)`
+ */
+export function synthBpf(s: StructuredBpf): string {
+  const portsPart = s.ports.length > 0 ? s.ports.map((p) => `tcp port ${p}`).join(" or ") : ""
+  const hostsPart = s.hosts.length > 0 ? s.hosts.map((h) => `host ${h}`).join(" or ") : ""
+
+  if (portsPart && hostsPart) {
+    const lp = s.ports.length > 1 ? `(${portsPart})` : portsPart
+    const lh = s.hosts.length > 1 ? `(${hostsPart})` : hostsPart
+    return `${lp} and ${lh}`
+  }
+  return portsPart || hostsPart
+}
+
+/**
+ * Try to interpret a BPF string as a structured filter. Returns null when
+ * the string contains anything outside the structured grammar — the caller
+ * should then drop into raw mode.
+ *
+ * Accepted shapes (case-insensitive `and`/`or`/`port`/`host`/`tcp`):
+ *   - empty / whitespace-only
+ *   - `tcp port N` (one or more, joined by `or`, optional outer parens)
+ *   - `host H`     (one or more, joined by `or`, optional outer parens)
+ *   - <ports> AND <hosts> in either order
+ */
+export function parseBpf(raw: string | null | undefined): StructuredBpf | null {
+  if (raw == null) return { ports: [], hosts: [] }
+  const trimmed = raw.trim()
+  if (trimmed === "") return { ports: [], hosts: [] }
+
+  // Split on top-level " and " — but not inside parens.
+  const parts = splitTopLevel(trimmed, "and")
+  if (parts.length === 0 || parts.length > 2) return null
+
+  const ports: number[] = []
+  const hosts: string[] = []
+  let sawPorts = false
+  let sawHosts = false
+
+  for (const partRaw of parts) {
+    const part = stripOuterParens(partRaw.trim())
+    const tokens = splitTopLevel(part, "or").map((t) => t.trim())
+    if (tokens.length === 0) return null
+
+    // Each token in this clause must be the same kind (port|host). Mixed
+    // tokens inside one and-clause is fine on the wire but doesn't fit
+    // the structured editor — fall back to raw.
+    let kind: "port" | "host" | null = null
+    for (const t of tokens) {
+      const p = matchPortToken(t)
+      const h = matchHostToken(t)
+      if (p !== null) {
+        if (kind === "host") return null
+        kind = "port"
+        ports.push(p)
+      } else if (h !== null) {
+        if (kind === "port") return null
+        kind = "host"
+        hosts.push(h)
+      } else {
+        return null
+      }
+    }
+    if (kind === "port") {
+      if (sawPorts) return null // two port-clauses joined by `and` is weird; raw
+      sawPorts = true
+    } else if (kind === "host") {
+      if (sawHosts) return null
+      sawHosts = true
+    }
+  }
+
+  return { ports: dedupNum(ports), hosts: dedupStr(hosts) }
+}
+
+// ---- token matchers --------------------------------------------------------
+
+function matchPortToken(t: string): number | null {
+  // Allow "tcp port 80" and "port 80". The synth always emits "tcp port N",
+  // but raw configs in the wild also use bare "port N".
+  const m = t.match(/^(?:tcp\s+)?port\s+(\d{1,5})$/i)
+  if (!m) return null
+  const n = Number(m[1])
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return null
+  return n
+}
+
+function matchHostToken(t: string): string | null {
+  const m = t.match(/^host\s+(\S+)$/i)
+  if (!m) return null
+  const v = m[1]
+  // Sanity check on the value — IPv4/CIDR or a plausible hostname/IPv6.
+  if (IPV4.test(v) || HOST_TOKEN.test(v)) return v
+  return null
+}
+
+// ---- string helpers --------------------------------------------------------
+
+function stripOuterParens(s: string): string {
+  if (s.length < 2 || s[0] !== "(" || s[s.length - 1] !== ")") return s
+  // Ensure the outer pair is balanced — `(a) or (b)` shouldn't be stripped.
+  let depth = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "(") depth++
+    else if (s[i] === ")") {
+      depth--
+      if (depth === 0 && i !== s.length - 1) return s
+    }
+  }
+  return s.slice(1, -1).trim()
+}
+
+/** Split `s` on whole-word `sep` (case-insensitive) at paren-depth 0. */
+function splitTopLevel(s: string, sep: "and" | "or"): string[] {
+  const out: string[] = []
+  const lower = s.toLowerCase()
+  const sepRe = new RegExp(`\\s${sep}\\s`, "i")
+  let depth = 0
+  let start = 0
+  let i = 0
+  while (i < s.length) {
+    const c = s[i]
+    if (c === "(") depth++
+    else if (c === ")") depth--
+    else if (depth === 0 && i + sep.length + 2 <= s.length) {
+      // Look for "<sep>" surrounded by whitespace at this position.
+      const window = lower.slice(i, i + sep.length + 2)
+      if (sepRe.test(window) && /\s/.test(window[0]) && /\s/.test(window[window.length - 1])) {
+        out.push(s.slice(start, i))
+        i += sep.length + 2
+        start = i
+        continue
+      }
+    }
+    i++
+  }
+  out.push(s.slice(start))
+  return out.map((p) => p.trim()).filter(Boolean)
+}
+
+function dedupNum(xs: number[]): number[] {
+  return Array.from(new Set(xs)).sort((a, b) => a - b)
+}
+function dedupStr(xs: string[]): string[] {
+  return Array.from(new Set(xs))
+}
+
+// ---- validation ------------------------------------------------------------
+
+export function isValidPort(s: string): boolean {
+  const n = Number(s)
+  return Number.isInteger(n) && n >= 1 && n <= 65535
+}
+
+export function isValidHost(s: string): boolean {
+  return s.length > 0 && (IPV4.test(s) || HOST_TOKEN.test(s))
+}

--- a/console/src/lib/interface-groups.ts
+++ b/console/src/lib/interface-groups.ts
@@ -1,0 +1,65 @@
+/**
+ * Categorise interfaces by what an operator most likely wants to see first.
+ * The libpcap enumeration on a docker/libvirt host returns 50+ entries —
+ * roughly all of which are virtual bridges, veth peers and VM taps that
+ * nobody wants to scroll past to find `any` or the host's real NIC. This
+ * groups them so the editor can show "Recommended" inline and stash the
+ * rest behind an expander.
+ */
+
+import type { CaptureInterface } from "@/types/api"
+
+export interface InterfaceGroups {
+  /** "Any" pseudo-device + loopback + real-looking NICs and bridges. */
+  recommended: CaptureInterface[]
+  /** veth, vnet, virbr, docker bridges, and similar plumbing. */
+  virtual: CaptureInterface[]
+}
+
+const VIRTUAL_PREFIXES = [
+  "veth", // docker / k8s container veth peer
+  "vnet", // libvirt VM tap
+  "virbr", // libvirt bridge
+  "docker", // docker0 etc.
+  "br-", // docker user-defined bridge (br-<hash>)
+  "cni", // k8s CNI
+  "flannel",
+  "weave",
+  "cali", // calico
+  "tap",
+  "tun",
+]
+
+const ALWAYS_RECOMMENDED = new Set(["any", "lo"])
+
+export function groupInterfaces(all: CaptureInterface[]): InterfaceGroups {
+  const recommended: CaptureInterface[] = []
+  const virtual: CaptureInterface[] = []
+  for (const i of all) {
+    if (ALWAYS_RECOMMENDED.has(i.name)) {
+      recommended.push(i)
+    } else if (isVirtual(i.name)) {
+      virtual.push(i)
+    } else {
+      recommended.push(i)
+    }
+  }
+  // Within recommended, sort: `any` first, then anything with addresses,
+  // then alphabetical. Loopback last in the recommended bucket.
+  recommended.sort((a, b) => {
+    if (a.name === "any") return -1
+    if (b.name === "any") return 1
+    if (a.name === "lo") return 1
+    if (b.name === "lo") return -1
+    const aHas = a.addresses.length > 0 ? 1 : 0
+    const bHas = b.addresses.length > 0 ? 1 : 0
+    if (aHas !== bHas) return bHas - aHas
+    return a.name.localeCompare(b.name)
+  })
+  virtual.sort((a, b) => a.name.localeCompare(b.name))
+  return { recommended, virtual }
+}
+
+function isVirtual(name: string): boolean {
+  return VIRTUAL_PREFIXES.some((p) => name.startsWith(p))
+}

--- a/console/src/pages/settings.tsx
+++ b/console/src/pages/settings.tsx
@@ -233,9 +233,9 @@ function PipelineCard({
         </button>
       </div>
 
-      {/* Sources */}
+      {/* Sources — grouped by type */}
       <div className="border-b border-border px-4 py-3">
-        <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <div className="mb-3 flex items-center gap-2 text-xs font-medium text-muted-foreground">
           <span>Capture sources</span>
           <span>·</span>
           <span>{pipeline.sources.length} configured</span>
@@ -248,14 +248,15 @@ function PipelineCard({
             onSave={onSave}
             saveError={saveError}
           />
-        ) : pipeline.sources.length === 0 ? (
-          <div className="text-xs italic text-muted-foreground">no sources</div>
         ) : (
-          <ul className="flex flex-col gap-2">
-            {pipeline.sources.map((s, i) => (
-              <SourceSummary key={i} source={s} />
-            ))}
-          </ul>
+          <SourcesByType
+            sources={pipeline.sources}
+            isEditing={false}
+            interfaces={interfaces}
+            onChangeAt={() => {}}
+            onRemoveAt={() => {}}
+            onAddOfType={() => {}}
+          />
         )}
       </div>
 
@@ -281,22 +282,161 @@ function PipelineCard({
 }
 
 // ============================================================================
-// SourceSummary — read-only one-line view of a source
+// Type metadata — shared between view and edit panels
+// ============================================================================
+
+type SourceType = CaptureSource["type"]
+
+const TYPE_META: Record<
+  SourceType,
+  { icon: string; title: string; addLabel: string; emptyHint: string }
+> = {
+  pcap: {
+    icon: "📡",
+    title: "Live captures",
+    addLabel: "Add live capture",
+    emptyHint:
+      "(no live captures — packets are not being read from any local NIC)",
+  },
+  "cloud-probe": {
+    icon: "🔌",
+    title: "ZMQ receivers",
+    addLabel: "Add ZMQ receiver",
+    emptyHint:
+      "(none — receive packets streamed in from remote tokenscope probes)",
+  },
+  "pcap-file": {
+    icon: "📂",
+    title: "PCAP replay",
+    addLabel: "Add file replay",
+    emptyHint: "(none — replay packets from a saved .pcap file, for dev / forensic)",
+  },
+}
+
+// ============================================================================
+// SourcesByType — three per-type sections, used by both view and edit modes
+// ============================================================================
+
+function SourcesByType({
+  sources,
+  isEditing,
+  interfaces,
+  onChangeAt,
+  onRemoveAt,
+  onAddOfType,
+}: {
+  sources: CaptureSource[]
+  isEditing: boolean
+  interfaces: CaptureInterface[]
+  onChangeAt: (i: number, next: CaptureSource) => void
+  onRemoveAt: (i: number) => void
+  onAddOfType: (type: SourceType) => void
+}) {
+  // Group original indices by type so removal/update can address the
+  // original array without reordering.
+  const groups: Record<SourceType, number[]> = {
+    pcap: [],
+    "cloud-probe": [],
+    "pcap-file": [],
+  }
+  sources.forEach((s, i) => groups[s.type].push(i))
+  const order: SourceType[] = ["pcap", "cloud-probe", "pcap-file"]
+  return (
+    <div className="flex flex-col gap-3">
+      {order.map((type) => (
+        <SourceTypeSection
+          key={type}
+          type={type}
+          indices={groups[type]}
+          sources={sources}
+          isEditing={isEditing}
+          interfaces={interfaces}
+          onChangeAt={onChangeAt}
+          onRemoveAt={onRemoveAt}
+          onAdd={() => onAddOfType(type)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function SourceTypeSection({
+  type,
+  indices,
+  sources,
+  isEditing,
+  interfaces,
+  onChangeAt,
+  onRemoveAt,
+  onAdd,
+}: {
+  type: SourceType
+  indices: number[]
+  sources: CaptureSource[]
+  isEditing: boolean
+  interfaces: CaptureInterface[]
+  onChangeAt: (i: number, next: CaptureSource) => void
+  onRemoveAt: (i: number) => void
+  onAdd: () => void
+}) {
+  const meta = TYPE_META[type]
+  const empty = indices.length === 0
+  return (
+    <div className="rounded-md border border-border/60">
+      <div className="flex items-center gap-2 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-xs">
+        <span aria-hidden>{meta.icon}</span>
+        <span className="font-semibold">{meta.title}</span>
+        <span className="text-muted-foreground">· {indices.length}</span>
+        <div className="flex-1" />
+        {isEditing && (
+          <button
+            onClick={onAdd}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-0.5 hover:bg-muted"
+          >
+            <Plus className="size-3" /> {meta.addLabel}
+          </button>
+        )}
+      </div>
+      <div className="px-3 py-2">
+        {empty ? (
+          <div className="py-1 text-xs italic text-muted-foreground">{meta.emptyHint}</div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {indices.map((i) =>
+              isEditing ? (
+                <SourceEditorRow
+                  key={i}
+                  source={sources[i]}
+                  interfaces={interfaces}
+                  onChange={(next) => onChangeAt(i, next)}
+                  onRemove={() => onRemoveAt(i)}
+                />
+              ) : (
+                <SourceSummary key={i} source={sources[i]} />
+              ),
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// SourceSummary — read-only one-liner per source (used in view mode)
 // ============================================================================
 
 function SourceSummary({ source }: { source: CaptureSource }) {
   if (source.type === "pcap") {
-    const portsHostsSummary = describeBpf(source.bpf_filter)
     return (
       <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <SourceTypeChip kind="pcap" />
           <span className="font-mono text-sm">
             interface <span className="font-semibold">{source.interface}</span>
           </span>
         </div>
         <div className="mt-1 text-muted-foreground">
-          {portsHostsSummary}
+          {describeBpf(source.bpf_filter)}
           <span className="ml-3">snaplen {source.snaplen.toLocaleString()} B</span>
         </div>
       </li>
@@ -305,10 +445,7 @@ function SourceSummary({ source }: { source: CaptureSource }) {
   if (source.type === "cloud-probe") {
     return (
       <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <SourceTypeChip kind="cloud-probe" />
-          <span className="font-mono text-sm">listen {source.endpoint}</span>
-        </div>
+        <div className="font-mono text-sm">listen {source.endpoint}</div>
         <div className="mt-1 text-muted-foreground">
           receive queue depth {source.recv_hwm}
         </div>
@@ -317,28 +454,11 @@ function SourceSummary({ source }: { source: CaptureSource }) {
   }
   return (
     <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <SourceTypeChip kind="pcap-file" />
-        <span className="break-all font-mono">{source.path}</span>
-      </div>
+      <div className="break-all font-mono text-sm">{source.path}</div>
       <div className="mt-1 text-muted-foreground">
         {source.realtime ? "replay at original speed" : "replay as fast as possible"}
       </div>
     </li>
-  )
-}
-
-function SourceTypeChip({ kind }: { kind: CaptureSource["type"] }) {
-  const map: Record<CaptureSource["type"], { icon: string; label: string }> = {
-    pcap: { icon: "📡", label: "Live capture" },
-    "cloud-probe": { icon: "🔌", label: "ZMQ receiver" },
-    "pcap-file": { icon: "📂", label: "PCAP replay" },
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
-      <span>{map[kind].icon}</span>
-      <span>{map[kind].label}</span>
-    </span>
   )
 }
 
@@ -358,7 +478,7 @@ function describeBpf(bpf: string | null): string {
 }
 
 // ============================================================================
-// SourceEditor — list of editor rows + Save/Cancel
+// SourceEditor — wraps SourcesByType with local row state + Save/Cancel
 // ============================================================================
 
 function SourceEditor({
@@ -374,9 +494,7 @@ function SourceEditor({
   onSave: (sources: CaptureSource[]) => Promise<void>
   saveError: unknown
 }) {
-  const [rows, setRows] = useState<CaptureSource[]>(
-    initial.length > 0 ? initial : [defaultFor("pcap")],
-  )
+  const [rows, setRows] = useState<CaptureSource[]>(initial)
   const [saving, setSaving] = useState(false)
   const [confirming, setConfirming] = useState(false)
 
@@ -385,6 +503,10 @@ function SourceEditor({
   }
   const removeRow = (i: number) => {
     setRows((r) => r.filter((_, idx) => idx !== i))
+    setConfirming(false)
+  }
+  const addOfType = (type: SourceType) => {
+    setRows((r) => [...r, defaultFor(type)])
     setConfirming(false)
   }
 
@@ -397,29 +519,20 @@ function SourceEditor({
     }
   }
 
+  const canSave = rows.length > 0
+
   return (
     <div className="flex flex-col gap-3">
-      <ul className="flex flex-col gap-2">
-        {rows.map((s, i) => (
-          <SourceEditorRow
-            key={i}
-            source={s}
-            interfaces={interfaces}
-            onChange={(next) => updateRow(i, next)}
-            onRemove={() => removeRow(i)}
-            canRemove={rows.length > 1}
-          />
-        ))}
-      </ul>
+      <SourcesByType
+        sources={rows}
+        isEditing
+        interfaces={interfaces}
+        onChangeAt={updateRow}
+        onRemoveAt={removeRow}
+        onAddOfType={addOfType}
+      />
 
       <div className="flex flex-wrap items-center gap-2">
-        <AddSourceMenu
-          onAdd={(type) => {
-            setRows((r) => [...r, defaultFor(type)])
-            setConfirming(false)
-          }}
-          disabled={saving}
-        />
         <div className="flex-1" />
         {!confirming ? (
           <>
@@ -432,8 +545,9 @@ function SourceEditor({
             </button>
             <button
               onClick={() => setConfirming(true)}
-              disabled={saving || rows.length === 0}
+              disabled={saving || !canSave}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              title={!canSave ? "Add at least one source before saving" : undefined}
             >
               Save…
             </button>
@@ -475,81 +589,42 @@ function SourceEditor({
   )
 }
 
-function AddSourceMenu({
-  onAdd,
-  disabled,
-}: {
-  onAdd: (type: CaptureSource["type"]) => void
-  disabled: boolean
-}) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        disabled={disabled}
-        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
-      >
-        <Plus className="size-3.5" /> Add source
-      </button>
-      {open && (
-        <div className="absolute z-10 mt-1 flex w-64 flex-col rounded-md border border-border bg-popover p-1 shadow-md">
-          {(["pcap", "cloud-probe", "pcap-file"] as const).map((t) => (
-            <button
-              key={t}
-              onClick={() => {
-                onAdd(t)
-                setOpen(false)
-              }}
-              className="rounded-sm px-2 py-1.5 text-left text-xs hover:bg-muted"
-            >
-              <div className="font-medium">{ADD_LABEL[t]}</div>
-              <div className="text-[11px] text-muted-foreground">{ADD_HINT[t]}</div>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-const ADD_LABEL: Record<CaptureSource["type"], string> = {
-  pcap: "📡 Live network interface",
-  "cloud-probe": "🔌 Remote ZMQ stream",
-  "pcap-file": "📂 PCAP file replay",
-}
-const ADD_HINT: Record<CaptureSource["type"], string> = {
-  pcap: "Capture packets from a local NIC via libpcap",
-  "cloud-probe": "Receive packets streamed by a remote tokenscope probe",
-  "pcap-file": "Replay packets from a saved .pcap file (dev / forensic)",
-}
-
 // ============================================================================
-// Counters
+// Counters — split by source-type so the live-capture and ZMQ-receiver
+// metrics don't sit jumbled in one grid. Sections with no matching source
+// in the pipeline are omitted entirely (a pipeline with only ZMQ won't
+// render dead-zero packet counters).
 // ============================================================================
 
-const COUNTER_META: Record<
-  string,
-  { label: string; hint?: string; appliesTo: ("pcap" | "cloud-probe" | "pcap-file" | "all")[] }
-> = {
-  pkts_received: { label: "Packets captured", appliesTo: ["pcap", "pcap-file"] },
-  pkts_dropped_kernel: {
+interface CounterDef {
+  key: string
+  label: string
+  hint?: string
+}
+
+const LIVE_COUNTERS: CounterDef[] = [
+  { key: "pkts_received", label: "Packets captured" },
+  {
+    key: "pkts_dropped_kernel",
     label: "Dropped — kernel ring full",
     hint: "Capture couldn't keep up; consider a tighter filter or larger snaplen ring.",
-    appliesTo: ["pcap"],
   },
-  pkts_truncated: {
+  {
+    key: "pkts_truncated",
     label: "Truncated to snaplen",
     hint: "Packet was larger than snaplen; bodies past the cutoff are missing.",
-    appliesTo: ["pcap", "pcap-file"],
   },
-  read_errors: { label: "Read errors", appliesTo: ["pcap", "pcap-file"] },
-  batches_received: { label: "Batches received", appliesTo: ["cloud-probe"] },
-  batches_dropped_zmq: {
+  { key: "read_errors", label: "Read errors" },
+]
+
+const ZMQ_COUNTERS: CounterDef[] = [
+  { key: "batches_received", label: "Batches received" },
+  {
+    key: "batches_dropped_zmq",
     label: "Batches dropped",
     hint: "ZMQ HWM exceeded; downstream stages are saturated.",
-    appliesTo: ["cloud-probe"],
   },
-}
+]
 
 function CountersGrid({
   metrics,
@@ -558,27 +633,52 @@ function CountersGrid({
   metrics: Record<string, number>
   sources: CaptureSource[]
 }) {
-  const kinds = new Set(sources.map((s) => s.type))
-  const visible = Object.entries(COUNTER_META).filter(([, m]) =>
-    m.appliesTo.some((k) => k === "all" || kinds.has(k)),
-  )
-  if (visible.length === 0) {
-    return <div className="text-xs italic text-muted-foreground">no live data yet</div>
+  const hasLive = sources.some((s) => s.type === "pcap" || s.type === "pcap-file")
+  const hasZmq = sources.some((s) => s.type === "cloud-probe")
+  if (!hasLive && !hasZmq) {
+    return (
+      <div className="text-xs italic text-muted-foreground">
+        no sources configured — nothing to count
+      </div>
+    )
   }
   return (
-    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:grid-cols-3 md:grid-cols-4">
-      {visible.map(([key, meta]) => {
-        const v = metrics[key]
-        return (
-          <div key={key} className="flex flex-col">
-            <span className="text-muted-foreground" title={meta.hint}>
-              {meta.label}
-              {meta.hint && <span className="ml-1 text-[10px]">ⓘ</span>}
+    <div className="flex flex-col gap-3">
+      {hasLive && (
+        <CountersSubsection title="Live capture" counters={LIVE_COUNTERS} metrics={metrics} />
+      )}
+      {hasZmq && (
+        <CountersSubsection title="ZMQ receiver" counters={ZMQ_COUNTERS} metrics={metrics} />
+      )}
+    </div>
+  )
+}
+
+function CountersSubsection({
+  title,
+  counters,
+  metrics,
+}: {
+  title: string
+  counters: CounterDef[]
+  metrics: Record<string, number>
+}) {
+  return (
+    <div>
+      <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:grid-cols-3 md:grid-cols-4">
+        {counters.map((c) => (
+          <div key={c.key} className="flex flex-col">
+            <span className="text-muted-foreground" title={c.hint}>
+              {c.label}
+              {c.hint && <span className="ml-1 text-[10px]">ⓘ</span>}
             </span>
-            <span className="font-mono">{fmtCounter(v)}</span>
+            <span className="font-mono">{fmtCounter(metrics[c.key])}</span>
           </div>
-        )
-      })}
+        ))}
+      </div>
     </div>
   )
 }

--- a/console/src/pages/settings.tsx
+++ b/console/src/pages/settings.tsx
@@ -4,13 +4,15 @@ import {
   Loader2,
   RefreshCw,
   Cpu,
-  Network,
   HardDrive,
   Pencil,
   Plus,
-  Trash2,
   AlertCircle,
   Power,
+  Info,
+  ChevronDown,
+  ChevronRight,
+  Network,
 } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useRuntimeConfig } from "@/hooks/use-runtime-config"
@@ -18,6 +20,7 @@ import { useInternalMetrics } from "@/hooks/use-internal-metrics"
 import { useCaptureInterfaces } from "@/hooks/use-capture-interfaces"
 import { useUpdateSources } from "@/hooks/use-update-sources"
 import { apiFetch, ApiError } from "@/lib/api"
+import { groupInterfaces } from "@/lib/interface-groups"
 import type {
   AppConfigShape,
   CaptureInterface,
@@ -25,13 +28,15 @@ import type {
   MetricRecord,
   PipelineShape,
 } from "@/types/api"
+import { SourceEditorRow, defaultFor } from "@/components/settings/source-editor"
 
 /**
- * Settings page — view the capture configuration the running tokenscope
- * process is using, with live per-pipeline counters, and edit the source
- * list. Saving rewrites the on-disk TOML and triggers a self-restart of
- * the tokenscope process; the page polls /api/health until the new
- * process comes back, then refetches all queries.
+ * Settings page — friendly view + edit of the capture configuration the
+ * running tokenscope process is using. Source list is structured by
+ * source type (live NIC / ZMQ receiver / PCAP replay); editor hides BPF
+ * behind a ports+hosts UI for the common case. Saving rewrites the on-
+ * disk TOML and self-restarts; the page polls runtime-config until the
+ * new process is up.
  */
 export function SettingsPage() {
   const queryClient = useQueryClient()
@@ -42,10 +47,6 @@ export function SettingsPage() {
 
   const [editing, setEditing] = useState<string | null>(null)
   const [restartState, setRestartState] = useState<"idle" | "saving" | "restarting">("idle")
-
-  // Snapshot of `loaded_at_ms` when the user triggered the restart, so we
-  // can detect when the new process has come up (its `loaded_at_ms` will
-  // be larger than this).
   const previousLoadedAtRef = useRef<number | null>(null)
 
   const isInitialLoad =
@@ -83,7 +84,6 @@ export function SettingsPage() {
     }
     setEditing(null)
     setRestartState("restarting")
-    // Wait for the new process to come up, then refresh.
     await waitForRestart(previousLoadedAtRef.current ?? 0)
     await queryClient.invalidateQueries()
     setRestartState("idle")
@@ -91,43 +91,25 @@ export function SettingsPage() {
 
   return (
     <div className="relative flex flex-col gap-4 p-4">
-      {/* ===== Header ===== */}
-      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-3">
-        <span className="text-sm font-semibold">Settings</span>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          <span>
-            version <span className="font-mono text-foreground">{config.data.version}</span>
-          </span>
-          <span className="break-all">
-            config <span className="font-mono text-foreground">{config.data.config_path}</span>
-          </span>
-        </div>
-        <button
-          onClick={() => {
-            config.refetch()
-            metrics.refetch()
-            interfaces.refetch()
-          }}
-          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted"
-        >
-          <RefreshCw className={config.isFetching ? "size-3.5 animate-spin" : "size-3.5"} />
-          Refresh
-        </button>
-      </div>
+      <PageHeader
+        version={config.data.version}
+        configPath={config.data.config_path}
+        isFetching={config.isFetching}
+        onRefresh={() => {
+          config.refetch()
+          metrics.refetch()
+          interfaces.refetch()
+        }}
+      />
 
-      <p className="text-xs text-muted-foreground">
-        Saving a new source list rewrites{" "}
-        <span className="font-mono text-foreground">{config.data.config_path}</span> and
-        restarts tokenscope. Pipelines are recreated from scratch — in-flight captures
-        will see a brief gap.
-      </p>
-
-      {/* ===== Pipelines ===== */}
+      {/* Pipelines */}
       {pipelines.length === 0 ? (
-        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
-          No pipelines configured. Tokenscope may be running in CLI mode
-          (--pcap-file / -i overrides the config).
-        </div>
+        <EmptyState>
+          No pipelines configured — tokenscope is running in CLI mode (started with
+          <code className="mx-1 rounded bg-muted px-1 font-mono">--pcap-file</code> or
+          <code className="mx-1 rounded bg-muted px-1 font-mono">-i</code>). Restart
+          without those flags to edit pipelines here.
+        </EmptyState>
       ) : (
         pipelines.map((p) => (
           <PipelineCard
@@ -136,9 +118,7 @@ export function SettingsPage() {
             metrics={metricsByPipeline.get(p.name) ?? {}}
             interfaces={availableInterfaces}
             isEditing={editing === p.name}
-            onEditToggle={() =>
-              setEditing((cur) => (cur === p.name ? null : p.name))
-            }
+            onEditToggle={() => setEditing((cur) => (cur === p.name ? null : p.name))}
             onSave={(sources) => onSave(p.name, sources)}
             saveError={mutate.error}
             disabled={restartState !== "idle"}
@@ -146,14 +126,65 @@ export function SettingsPage() {
         ))
       )}
 
-      {/* ===== Available interfaces ===== */}
-      <InterfacesCard
-        interfaces={availableInterfaces}
-        error={interfaces.error}
-      />
+      <InterfaceHelpExpander interfaces={availableInterfaces} />
 
-      {/* ===== Restart overlay ===== */}
       {restartState !== "idle" && <RestartOverlay state={restartState} />}
+    </div>
+  )
+}
+
+// ============================================================================
+// Header
+// ============================================================================
+
+function PageHeader({
+  version,
+  configPath,
+  isFetching,
+  onRefresh,
+}: {
+  version: string
+  configPath: string
+  isFetching: boolean
+  onRefresh: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex flex-wrap items-center gap-3 px-4 py-2.5">
+        <span className="text-sm font-semibold">Settings</span>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            version <span className="font-mono text-foreground">{version}</span>
+          </span>
+          <span className="break-all">
+            config <span className="font-mono text-foreground">{configPath}</span>
+          </span>
+        </div>
+        <button
+          onClick={onRefresh}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted"
+        >
+          <RefreshCw className={isFetching ? "size-3.5 animate-spin" : "size-3.5"} />
+          Refresh
+        </button>
+      </div>
+      <div className="flex items-start gap-2 border-t border-border bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+        <Info className="mt-0.5 size-3.5 shrink-0" />
+        <p>
+          Capture sources tell tokenscope where packets come from — a live network
+          interface, a remote ZMQ stream from a probe, or a PCAP file. Saving here
+          rewrites the config file and restarts the process; capture pauses for
+          about 2–3 seconds while the new pipeline comes up.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+      {children}
     </div>
   )
 }
@@ -185,10 +216,11 @@ function PipelineCard({
     <div className="rounded-lg border border-border bg-card">
       <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
         <Cpu className="size-4 text-muted-foreground" />
-        <span className="text-sm font-semibold">{pipeline.name}</span>
+        <span className="text-sm font-semibold">Pipeline · {pipeline.name}</span>
         {pipeline.dispatcher_count !== undefined && (
           <span className="ml-2 text-xs text-muted-foreground">
-            {pipeline.dispatcher_count} dispatcher · {pipeline.flow_shard_count ?? "?"} flow shards
+            {pipeline.dispatcher_count} dispatcher · {pipeline.flow_shard_count ?? "?"} flow
+            shards
           </span>
         )}
         <button
@@ -203,7 +235,11 @@ function PipelineCard({
 
       {/* Sources */}
       <div className="border-b border-border px-4 py-3">
-        <div className="mb-2 text-xs font-medium text-muted-foreground">Sources</div>
+        <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <span>Capture sources</span>
+          <span>·</span>
+          <span>{pipeline.sources.length} configured</span>
+        </div>
         {isEditing ? (
           <SourceEditor
             initial={pipeline.sources}
@@ -217,113 +253,64 @@ function PipelineCard({
         ) : (
           <ul className="flex flex-col gap-2">
             {pipeline.sources.map((s, i) => (
-              <SourceRow key={i} source={s} />
+              <SourceSummary key={i} source={s} />
             ))}
           </ul>
         )}
       </div>
 
-      {/* Live counters — capture stage */}
+      {/* Live counters */}
       <div className="border-b border-border px-4 py-3">
-        <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <Network className="size-3.5" /> Live capture counters
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
+          Activity (live)
         </div>
-        <CountersGrid
-          metrics={metrics}
-          keys={[
-            "pkts_received",
-            "pkts_dropped_kernel",
-            "pkts_truncated",
-            "read_errors",
-            "heartbeats_emitted",
-            "batches_received",
-            "batches_dropped_zmq",
-          ]}
-        />
+        <CountersGrid metrics={metrics} sources={pipeline.sources} />
       </div>
 
       {/* pcap_dump */}
       {pipeline.pcap_dump && (
-        <div className="px-4 py-3">
-          <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-            <HardDrive className="size-3.5" /> PCAP dump
-          </div>
-          {pipeline.pcap_dump.enabled ? (
-            <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
-              <KV k="dir" v={pipeline.pcap_dump.dir} mono />
-              <KV k="compression" v={pipeline.pcap_dump.compression} />
-              {pipeline.pcap_dump.retention && (
-                <>
-                  <KV
-                    k="retention"
-                    v={pipeline.pcap_dump.retention.enabled ? "on" : "off"}
-                  />
-                  <KV
-                    k="max age"
-                    v={fmtHours(pipeline.pcap_dump.retention.max_age_hours)}
-                  />
-                  <KV
-                    k="max size"
-                    v={fmtMiB(pipeline.pcap_dump.retention.max_size_mb)}
-                  />
-                </>
-              )}
-              <KV
-                k="files deleted"
-                v={fmtCounter(metrics["dump_retention_files_deleted"])}
-              />
-              <KV
-                k="bytes deleted"
-                v={fmtBytes(metrics["dump_retention_bytes_deleted"])}
-              />
-              <KV k="dump errors" v={fmtCounter(metrics["dump_errors"])} />
-            </div>
-          ) : (
-            <span className="text-xs italic text-muted-foreground">disabled</span>
-          )}
-        </div>
+        <PcapDumpSection
+          dump={pipeline.pcap_dump}
+          retentionFilesDeleted={metrics["dump_retention_files_deleted"]}
+          retentionBytesDeleted={metrics["dump_retention_bytes_deleted"]}
+          dumpErrors={metrics["dump_errors"]}
+        />
       )}
     </div>
   )
 }
 
-function SourceRow({ source }: { source: CaptureSource }) {
+// ============================================================================
+// SourceSummary — read-only one-line view of a source
+// ============================================================================
+
+function SourceSummary({ source }: { source: CaptureSource }) {
   if (source.type === "pcap") {
+    const portsHostsSummary = describeBpf(source.bpf_filter)
     return (
       <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
-            pcap
+          <SourceTypeChip kind="pcap" />
+          <span className="font-mono text-sm">
+            interface <span className="font-semibold">{source.interface}</span>
           </span>
-          <span className="font-mono text-sm">{source.interface}</span>
-          {source.source_id && source.source_id !== source.interface && (
-            <span className="text-muted-foreground">
-              (id <span className="font-mono">{source.source_id}</span>)
-            </span>
-          )}
         </div>
-        <div className="mt-1 grid grid-cols-1 gap-x-3 gap-y-0.5 text-muted-foreground sm:grid-cols-2">
-          <KV
-            k="BPF"
-            v={source.bpf_filter && source.bpf_filter !== "" ? source.bpf_filter : "(none — all TCP)"}
-            mono
-          />
-          <KV k="snaplen" v={`${source.snaplen.toLocaleString()} B`} />
+        <div className="mt-1 text-muted-foreground">
+          {portsHostsSummary}
+          <span className="ml-3">snaplen {source.snaplen.toLocaleString()} B</span>
         </div>
       </li>
     )
   }
-  if (source.type === "pcap-file") {
+  if (source.type === "cloud-probe") {
     return (
       <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
-            pcap-file
-          </span>
-          <span className="break-all font-mono">{source.path}</span>
-          <span className="text-muted-foreground">
-            ({source.realtime ? "realtime replay" : "as-fast-as-possible"})
-          </span>
+          <SourceTypeChip kind="cloud-probe" />
+          <span className="font-mono text-sm">listen {source.endpoint}</span>
+        </div>
+        <div className="mt-1 text-muted-foreground">
+          receive queue depth {source.recv_hwm}
         </div>
       </li>
     )
@@ -331,21 +318,48 @@ function SourceRow({ source }: { source: CaptureSource }) {
   return (
     <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
-          cloud-probe
-        </span>
-        <span className="font-mono">{source.endpoint}</span>
-        <span className="text-muted-foreground">recv_hwm={source.recv_hwm}</span>
+        <SourceTypeChip kind="pcap-file" />
+        <span className="break-all font-mono">{source.path}</span>
+      </div>
+      <div className="mt-1 text-muted-foreground">
+        {source.realtime ? "replay at original speed" : "replay as fast as possible"}
       </div>
     </li>
   )
 }
 
-// ============================================================================
-// SourceEditor
-// ============================================================================
+function SourceTypeChip({ kind }: { kind: CaptureSource["type"] }) {
+  const map: Record<CaptureSource["type"], { icon: string; label: string }> = {
+    pcap: { icon: "📡", label: "Live capture" },
+    "cloud-probe": { icon: "🔌", label: "ZMQ receiver" },
+    "pcap-file": { icon: "📂", label: "PCAP replay" },
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+      <span>{map[kind].icon}</span>
+      <span>{map[kind].label}</span>
+    </span>
+  )
+}
 
-const DEFAULT_SNAPLEN = 262_144
+function describeBpf(bpf: string | null): string {
+  if (!bpf || bpf.trim() === "") return "capturing all TCP traffic"
+  // Heuristic plain-English description for the common cases. Anything
+  // exotic falls back to the raw filter expression.
+  const ports = Array.from(bpf.matchAll(/(?:tcp\s+)?port\s+(\d{1,5})/gi)).map((m) => m[1])
+  const hosts = Array.from(bpf.matchAll(/host\s+(\S+)/gi)).map((m) => m[1])
+  const parts: string[] = []
+  if (ports.length > 0) parts.push(`port${ports.length > 1 ? "s" : ""} ${ports.join(", ")}`)
+  if (hosts.length > 0) parts.push(`host${hosts.length > 1 ? "s" : ""} ${hosts.join(", ")}`)
+  if (parts.length === 0) {
+    return `filter: ${bpf}`
+  }
+  return `${parts.join(" · ")}`
+}
+
+// ============================================================================
+// SourceEditor — list of editor rows + Save/Cancel
+// ============================================================================
 
 function SourceEditor({
   initial,
@@ -360,18 +374,19 @@ function SourceEditor({
   onSave: (sources: CaptureSource[]) => Promise<void>
   saveError: unknown
 }) {
-  const [rows, setRows] = useState<CaptureSource[]>(initial.length ? initial : [defaultPcap()])
+  const [rows, setRows] = useState<CaptureSource[]>(
+    initial.length > 0 ? initial : [defaultFor("pcap")],
+  )
   const [saving, setSaving] = useState(false)
+  const [confirming, setConfirming] = useState(false)
 
-  const updateRow = (i: number, patch: Partial<CaptureSource>) => {
-    setRows((r) =>
-      r.map((row, idx) => (idx === i ? ({ ...row, ...patch } as CaptureSource) : row)),
-    )
+  const updateRow = (i: number, next: CaptureSource) => {
+    setRows((r) => r.map((row, idx) => (idx === i ? next : row)))
   }
   const removeRow = (i: number) => {
     setRows((r) => r.filter((_, idx) => idx !== i))
+    setConfirming(false)
   }
-  const addPcap = () => setRows((r) => [...r, defaultPcap()])
 
   const submit = async () => {
     setSaving(true)
@@ -382,62 +397,70 @@ function SourceEditor({
     }
   }
 
-  // Only pcap rows are editable inline. Other rows (pcap-file, cloud-probe)
-  // are shown read-only to preserve them on save.
   return (
     <div className="flex flex-col gap-3">
       <ul className="flex flex-col gap-2">
-        {rows.map((s, i) =>
-          s.type === "pcap" ? (
-            <PcapEditorRow
-              key={i}
-              source={s}
-              interfaces={interfaces}
-              onChange={(p) => updateRow(i, p)}
-              onRemove={() => removeRow(i)}
-              canRemove={rows.length > 1}
-            />
-          ) : (
-            <li
-              key={i}
-              className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
-            >
-              <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
-              <div className="flex-1">
-                <SourceRow source={s} />
-                <div className="mt-1 italic">
-                  Non-pcap sources stay as-is; edit via the TOML file directly.
-                </div>
-              </div>
-            </li>
-          ),
-        )}
+        {rows.map((s, i) => (
+          <SourceEditorRow
+            key={i}
+            source={s}
+            interfaces={interfaces}
+            onChange={(next) => updateRow(i, next)}
+            onRemove={() => removeRow(i)}
+            canRemove={rows.length > 1}
+          />
+        ))}
       </ul>
 
       <div className="flex flex-wrap items-center gap-2">
-        <button
-          onClick={addPcap}
+        <AddSourceMenu
+          onAdd={(type) => {
+            setRows((r) => [...r, defaultFor(type)])
+            setConfirming(false)
+          }}
           disabled={saving}
-          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
-        >
-          <Plus className="size-3.5" /> Add pcap source
-        </button>
+        />
         <div className="flex-1" />
-        <button
-          onClick={onCancel}
-          disabled={saving}
-          className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={submit}
-          disabled={saving || rows.filter((r) => r.type === "pcap").length === 0}
-          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-        >
-          {saving && <Loader2 className="size-3.5 animate-spin" />}
-          Save &amp; restart
-        </button>
+        {!confirming ? (
+          <>
+            <button
+              onClick={onCancel}
+              disabled={saving}
+              className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => setConfirming(true)}
+              disabled={saving || rows.length === 0}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              Save…
+            </button>
+          </>
+        ) : (
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs">
+            <AlertCircle className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+            <span>
+              Capture will pause for ~2–3 s while tokenscope restarts. Continue?
+            </span>
+            <button
+              onClick={() => setConfirming(false)}
+              disabled={saving}
+              className="rounded-md border border-border bg-background px-2 py-0.5 hover:bg-muted disabled:opacity-50"
+            >
+              No
+            </button>
+            <button
+              onClick={submit}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-0.5 font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving && <Loader2 className="size-3.5 animate-spin" />}
+              Yes, save & restart
+            </button>
+          </div>
+        )}
       </div>
 
       {saveError ? (
@@ -452,135 +475,229 @@ function SourceEditor({
   )
 }
 
-function PcapEditorRow({
-  source,
-  interfaces,
-  onChange,
-  onRemove,
-  canRemove,
+function AddSourceMenu({
+  onAdd,
+  disabled,
 }: {
-  source: Extract<CaptureSource, { type: "pcap" }>
-  interfaces: CaptureInterface[]
-  onChange: (patch: Partial<Extract<CaptureSource, { type: "pcap" }>>) => void
-  onRemove: () => void
-  canRemove: boolean
+  onAdd: (type: CaptureSource["type"]) => void
+  disabled: boolean
 }) {
+  const [open, setOpen] = useState(false)
   return (
-    <li className="rounded-md border border-border/60 bg-background px-3 py-2">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
-          pcap
-        </span>
-        <label className="inline-flex items-center gap-1.5">
-          <span className="text-muted-foreground">interface</span>
-          <select
-            value={source.interface}
-            onChange={(e) => onChange({ interface: e.target.value })}
-            className="rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
-          >
-            {/* Make sure the current interface is selectable even if it
-                isn't in `interfaces` (e.g., enumeration failed). */}
-            {!interfaces.some((i) => i.name === source.interface) && (
-              <option value={source.interface}>{source.interface} (current)</option>
-            )}
-            {interfaces.map((i) => (
-              <option key={i.name} value={i.name}>
-                {i.name}
-                {i.addresses.length > 0 ? `  ·  ${i.addresses[0]}` : ""}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="inline-flex items-center gap-1.5">
-          <span className="text-muted-foreground">snaplen</span>
-          <input
-            type="number"
-            min={64}
-            max={1 << 20}
-            value={source.snaplen}
-            onChange={(e) =>
-              onChange({ snaplen: Number(e.target.value) || DEFAULT_SNAPLEN })
-            }
-            className="w-24 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
-          />
-        </label>
-        <div className="flex-1" />
-        {canRemove && (
-          <button
-            onClick={onRemove}
-            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
-            title="Remove this source"
-          >
-            <Trash2 className="size-3.5" />
-          </button>
-        )}
-      </div>
-      <label className="mt-2 flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">BPF</span>
-        <input
-          type="text"
-          value={source.bpf_filter ?? ""}
-          placeholder="(empty = all TCP)"
-          onChange={(e) =>
-            onChange({ bpf_filter: e.target.value === "" ? null : e.target.value })
-          }
-          className="flex-1 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
-        />
-      </label>
-    </li>
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+      >
+        <Plus className="size-3.5" /> Add source
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 flex w-64 flex-col rounded-md border border-border bg-popover p-1 shadow-md">
+          {(["pcap", "cloud-probe", "pcap-file"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => {
+                onAdd(t)
+                setOpen(false)
+              }}
+              className="rounded-sm px-2 py-1.5 text-left text-xs hover:bg-muted"
+            >
+              <div className="font-medium">{ADD_LABEL[t]}</div>
+              <div className="text-[11px] text-muted-foreground">{ADD_HINT[t]}</div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+const ADD_LABEL: Record<CaptureSource["type"], string> = {
+  pcap: "📡 Live network interface",
+  "cloud-probe": "🔌 Remote ZMQ stream",
+  "pcap-file": "📂 PCAP file replay",
+}
+const ADD_HINT: Record<CaptureSource["type"], string> = {
+  pcap: "Capture packets from a local NIC via libpcap",
+  "cloud-probe": "Receive packets streamed by a remote tokenscope probe",
+  "pcap-file": "Replay packets from a saved .pcap file (dev / forensic)",
+}
+
+// ============================================================================
+// Counters
+// ============================================================================
+
+const COUNTER_META: Record<
+  string,
+  { label: string; hint?: string; appliesTo: ("pcap" | "cloud-probe" | "pcap-file" | "all")[] }
+> = {
+  pkts_received: { label: "Packets captured", appliesTo: ["pcap", "pcap-file"] },
+  pkts_dropped_kernel: {
+    label: "Dropped — kernel ring full",
+    hint: "Capture couldn't keep up; consider a tighter filter or larger snaplen ring.",
+    appliesTo: ["pcap"],
+  },
+  pkts_truncated: {
+    label: "Truncated to snaplen",
+    hint: "Packet was larger than snaplen; bodies past the cutoff are missing.",
+    appliesTo: ["pcap", "pcap-file"],
+  },
+  read_errors: { label: "Read errors", appliesTo: ["pcap", "pcap-file"] },
+  batches_received: { label: "Batches received", appliesTo: ["cloud-probe"] },
+  batches_dropped_zmq: {
+    label: "Batches dropped",
+    hint: "ZMQ HWM exceeded; downstream stages are saturated.",
+    appliesTo: ["cloud-probe"],
+  },
+}
+
+function CountersGrid({
+  metrics,
+  sources,
+}: {
+  metrics: Record<string, number>
+  sources: CaptureSource[]
+}) {
+  const kinds = new Set(sources.map((s) => s.type))
+  const visible = Object.entries(COUNTER_META).filter(([, m]) =>
+    m.appliesTo.some((k) => k === "all" || kinds.has(k)),
+  )
+  if (visible.length === 0) {
+    return <div className="text-xs italic text-muted-foreground">no live data yet</div>
+  }
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:grid-cols-3 md:grid-cols-4">
+      {visible.map(([key, meta]) => {
+        const v = metrics[key]
+        return (
+          <div key={key} className="flex flex-col">
+            <span className="text-muted-foreground" title={meta.hint}>
+              {meta.label}
+              {meta.hint && <span className="ml-1 text-[10px]">ⓘ</span>}
+            </span>
+            <span className="font-mono">{fmtCounter(v)}</span>
+          </div>
+        )
+      })}
+    </div>
   )
 }
 
 // ============================================================================
-// InterfacesCard (read-only)
+// PcapDumpSection
 // ============================================================================
 
-function InterfacesCard({
-  interfaces,
-  error,
+function PcapDumpSection({
+  dump,
+  retentionFilesDeleted,
+  retentionBytesDeleted,
+  dumpErrors,
 }: {
-  interfaces: CaptureInterface[]
-  error: unknown
+  dump: NonNullable<PipelineShape["pcap_dump"]>
+  retentionFilesDeleted: number | undefined
+  retentionBytesDeleted: number | undefined
+  dumpErrors: number | undefined
 }) {
   return (
-    <div className="rounded-lg border border-border bg-card">
-      <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
-        <Network className="size-4 text-muted-foreground" />
-        <span className="text-sm font-semibold">Available interfaces</span>
-        <span className="ml-auto text-xs text-muted-foreground">
-          enumerated by libpcap on this host
-        </span>
+    <div className="px-4 py-3">
+      <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <HardDrive className="size-3.5" /> PCAP dump
       </div>
-      {error ? (
-        <div className="px-4 py-3 text-sm text-destructive">{errorMessage(error)}</div>
-      ) : interfaces.length === 0 ? (
-        <div className="px-4 py-3 text-sm text-muted-foreground">no interfaces visible</div>
+      {dump.enabled ? (
+        <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+          <KV k="Directory" v={dump.dir} mono />
+          <KV k="Compression" v={dump.compression} />
+          {dump.retention && (
+            <>
+              <KV k="Retention" v={dump.retention.enabled ? "on" : "off"} />
+              <KV k="Max age" v={fmtHours(dump.retention.max_age_hours)} />
+              <KV k="Max size" v={fmtMiB(dump.retention.max_size_mb)} />
+            </>
+          )}
+          <KV k="Files reclaimed" v={fmtCounter(retentionFilesDeleted)} />
+          <KV k="Bytes reclaimed" v={fmtBytes(retentionBytesDeleted)} />
+          <KV k="Write errors" v={fmtCounter(dumpErrors)} />
+        </div>
       ) : (
-        <table className="w-full text-xs">
-          <thead className="bg-muted/30 text-muted-foreground">
-            <tr>
-              <th className="px-4 py-2 text-left font-medium">name</th>
-              <th className="px-4 py-2 text-left font-medium">addresses</th>
-              <th className="px-4 py-2 text-left font-medium">flags</th>
-              <th className="px-4 py-2 text-left font-medium">description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {interfaces.map((i) => (
-              <tr key={i.name} className="border-t border-border/60">
-                <td className="px-4 py-1.5 font-mono">{i.name}</td>
-                <td className="px-4 py-1.5 font-mono text-muted-foreground">
-                  {i.addresses.length > 0 ? i.addresses.join(", ") : "—"}
-                </td>
-                <td className="px-4 py-1.5">
-                  <FlagRow iface={i} />
-                </td>
-                <td className="px-4 py-1.5 text-muted-foreground">{i.description ?? "—"}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <span className="text-xs italic text-muted-foreground">disabled</span>
       )}
+    </div>
+  )
+}
+
+// ============================================================================
+// InterfaceHelpExpander — replaces the dumping all-interfaces table
+// ============================================================================
+
+function InterfaceHelpExpander({ interfaces }: { interfaces: CaptureInterface[] }) {
+  const [open, setOpen] = useState(false)
+  if (interfaces.length === 0) return null
+  const groups = groupInterfaces(interfaces)
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left"
+      >
+        {open ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+        <Network className="size-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">Help me pick an interface</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {groups.recommended.length} recommended · {groups.virtual.length} virtual
+        </span>
+      </button>
+      {open && (
+        <div className="border-t border-border px-4 py-3 text-xs">
+          <InterfaceTable interfaces={groups.recommended} title="Recommended" />
+          {groups.virtual.length > 0 && (
+            <details className="mt-3">
+              <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                Virtual interfaces ({groups.virtual.length}) — container veths,
+                libvirt taps, etc.
+              </summary>
+              <div className="mt-2">
+                <InterfaceTable interfaces={groups.virtual} />
+              </div>
+            </details>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InterfaceTable({
+  interfaces,
+  title,
+}: {
+  interfaces: CaptureInterface[]
+  title?: string
+}) {
+  return (
+    <div>
+      {title && <div className="mb-1 font-medium">{title}</div>}
+      <table className="w-full">
+        <thead className="text-muted-foreground">
+          <tr>
+            <th className="py-1 text-left font-medium">name</th>
+            <th className="py-1 text-left font-medium">addresses</th>
+            <th className="py-1 text-left font-medium">flags</th>
+          </tr>
+        </thead>
+        <tbody>
+          {interfaces.map((i) => (
+            <tr key={i.name} className="border-t border-border/60">
+              <td className="py-1 font-mono">{i.name}</td>
+              <td className="py-1 font-mono text-muted-foreground">
+                {i.addresses.length > 0 ? i.addresses.join(", ") : "—"}
+              </td>
+              <td className="py-1">
+                <FlagRow iface={i} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }
@@ -609,7 +726,7 @@ function FlagRow({ iface }: { iface: CaptureInterface }) {
 }
 
 // ============================================================================
-// Restart overlay + helpers
+// Restart overlay + polling
 // ============================================================================
 
 function RestartOverlay({ state }: { state: "saving" | "restarting" }) {
@@ -620,9 +737,7 @@ function RestartOverlay({ state }: { state: "saving" | "restarting" }) {
           <>
             <Loader2 className="size-8 animate-spin text-primary" />
             <div className="text-sm font-medium">Saving configuration…</div>
-            <div className="text-xs text-muted-foreground">
-              Validating and writing TOML
-            </div>
+            <div className="text-xs text-muted-foreground">Validating and writing TOML</div>
           </>
         ) : (
           <>
@@ -638,52 +753,22 @@ function RestartOverlay({ state }: { state: "saving" | "restarting" }) {
   )
 }
 
-/**
- * Poll /api/health until the running process is the *new* one (its
- * loaded_at_ms is greater than what we had before the save), capped at
- * 60 attempts × 1s = 60s in case execv() failed and old process keeps
- * serving.
- */
 async function waitForRestart(prevLoadedAtMs: number): Promise<void> {
-  // Give the server its scheduled 500ms restart delay plus a touch more
-  // before the first probe — earlier probes will all succeed against the
-  // old process and add noise.
   await new Promise((r) => setTimeout(r, 1200))
-
   for (let i = 0; i < 60; i++) {
     try {
       const rt = await apiFetch<{ loaded_at_ms: number }>("/api/runtime-config")
       if (rt.loaded_at_ms > prevLoadedAtMs) return
     } catch {
-      // socket-closed during exec is expected — swallow and retry.
+      // expected during exec
     }
     await new Promise((r) => setTimeout(r, 1000))
   }
-  // Fall through silently. The page-level invalidate will still refresh
-  // whatever state we can reach.
 }
 
-function CountersGrid({
-  metrics,
-  keys,
-}: {
-  metrics: Record<string, number>
-  keys: string[]
-}) {
-  return (
-    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3 md:grid-cols-4">
-      {keys.map((k) => {
-        const v = metrics[k]
-        return (
-          <span key={k} className="inline-flex flex-col">
-            <span className="text-muted-foreground">{k}</span>
-            <span className="font-mono">{fmtCounter(v)}</span>
-          </span>
-        )
-      })}
-    </div>
-  )
-}
+// ============================================================================
+// Helpers
+// ============================================================================
 
 function KV({ k, v, mono = false }: { k: string; v: ReactNode; mono?: boolean }) {
   return (
@@ -704,16 +789,6 @@ function buildMetricIndex(
     out.set(p.name, byName)
   }
   return out
-}
-
-function defaultPcap(): CaptureSource {
-  return {
-    type: "pcap",
-    interface: "any",
-    bpf_filter: null,
-    snaplen: DEFAULT_SNAPLEN,
-    source_id: null,
-  }
 }
 
 function errorMessage(e: unknown): string {
@@ -746,4 +821,3 @@ function fmtBytes(n: number | undefined): string {
   if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(2)} KiB`
   return `${n} B`
 }
-

--- a/console/src/pages/settings.tsx
+++ b/console/src/pages/settings.tsx
@@ -1,0 +1,409 @@
+import type { ReactNode } from "react"
+import { Loader2, RefreshCw, Cpu, Network, HardDrive } from "lucide-react"
+import { useRuntimeConfig } from "@/hooks/use-runtime-config"
+import { useInternalMetrics } from "@/hooks/use-internal-metrics"
+import { useCaptureInterfaces } from "@/hooks/use-capture-interfaces"
+import type {
+  AppConfigShape,
+  CaptureInterface,
+  CaptureSource,
+  MetricRecord,
+  PipelineShape,
+} from "@/types/api"
+
+/**
+ * Settings page — read-only view of the capture configuration the running
+ * tokenscope process is using, with live per-pipeline counters merged in.
+ *
+ * Sources are the boot-time `[[pipeline.sources]]` entries. They cannot be
+ * changed without a process restart; edits land in a follow-up phase.
+ */
+export function SettingsPage() {
+  const config = useRuntimeConfig()
+  const metrics = useInternalMetrics()
+  const interfaces = useCaptureInterfaces()
+
+  const isInitialLoad =
+    config.isLoading || (metrics.isLoading && !metrics.data) || interfaces.isLoading
+
+  if (isInitialLoad) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!config.data) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-destructive">
+        Failed to load runtime config: {String(config.error ?? "unknown error")}
+      </div>
+    )
+  }
+
+  const appConfig = config.data.config as AppConfigShape
+  const pipelines = appConfig.pipelines ?? []
+  const metricsByPipeline = buildMetricIndex(metrics.data?.pipelines ?? [])
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* ===== Header ===== */}
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-3">
+        <span className="text-sm font-semibold">Settings</span>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            version <span className="font-mono text-foreground">{config.data.version}</span>
+          </span>
+          <span className="break-all">
+            config <span className="font-mono text-foreground">{config.data.config_path}</span>
+          </span>
+        </div>
+        <button
+          onClick={() => {
+            config.refetch()
+            metrics.refetch()
+            interfaces.refetch()
+          }}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted"
+        >
+          <RefreshCw className={config.isFetching ? "size-3.5 animate-spin" : "size-3.5"} />
+          Refresh
+        </button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Capture sources are configured at process startup. To change interface or BPF
+        filter today, edit{" "}
+        <span className="font-mono text-foreground">{config.data.config_path}</span> and
+        restart tokenscope. An in-app editor is shipping in a follow-up.
+      </p>
+
+      {/* ===== Pipelines ===== */}
+      {pipelines.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+          No pipelines configured. Tokenscope may be running in CLI mode
+          (--pcap-file / -i overrides the config).
+        </div>
+      ) : (
+        pipelines.map((p) => (
+          <PipelineCard
+            key={p.name}
+            pipeline={p}
+            metrics={metricsByPipeline.get(p.name) ?? {}}
+          />
+        ))
+      )}
+
+      {/* ===== Available interfaces ===== */}
+      <InterfacesCard
+        interfaces={interfaces.data?.interfaces ?? []}
+        error={interfaces.error}
+      />
+    </div>
+  )
+}
+
+// ============================================================================
+// PipelineCard
+// ============================================================================
+
+function PipelineCard({
+  pipeline,
+  metrics,
+}: {
+  pipeline: PipelineShape
+  metrics: Record<string, number>
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+        <Cpu className="size-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">{pipeline.name}</span>
+        {pipeline.dispatcher_count !== undefined && (
+          <span className="ml-2 text-xs text-muted-foreground">
+            {pipeline.dispatcher_count} dispatcher · {pipeline.flow_shard_count ?? "?"} flow shards
+          </span>
+        )}
+      </div>
+
+      {/* Sources */}
+      <div className="border-b border-border px-4 py-3">
+        <div className="mb-2 text-xs font-medium text-muted-foreground">Sources</div>
+        {pipeline.sources.length === 0 ? (
+          <div className="text-xs italic text-muted-foreground">no sources</div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {pipeline.sources.map((s, i) => (
+              <SourceRow key={i} source={s} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Live counters — capture stage */}
+      <div className="border-b border-border px-4 py-3">
+        <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <Network className="size-3.5" /> Live capture counters
+        </div>
+        <CountersGrid
+          metrics={metrics}
+          keys={[
+            "pkts_received",
+            "pkts_dropped_kernel",
+            "pkts_truncated",
+            "read_errors",
+            "heartbeats_emitted",
+            "batches_received",
+            "batches_dropped_zmq",
+          ]}
+        />
+      </div>
+
+      {/* pcap_dump */}
+      {pipeline.pcap_dump && (
+        <div className="px-4 py-3">
+          <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <HardDrive className="size-3.5" /> PCAP dump
+          </div>
+          {pipeline.pcap_dump.enabled ? (
+            <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+              <KV k="dir" v={pipeline.pcap_dump.dir} mono />
+              <KV k="compression" v={pipeline.pcap_dump.compression} />
+              {pipeline.pcap_dump.retention && (
+                <>
+                  <KV
+                    k="retention"
+                    v={pipeline.pcap_dump.retention.enabled ? "on" : "off"}
+                  />
+                  <KV
+                    k="max age"
+                    v={fmtHours(pipeline.pcap_dump.retention.max_age_hours)}
+                  />
+                  <KV
+                    k="max size"
+                    v={fmtMiB(pipeline.pcap_dump.retention.max_size_mb)}
+                  />
+                </>
+              )}
+              <KV
+                k="files deleted"
+                v={fmtCounter(metrics["dump_retention_files_deleted"])}
+              />
+              <KV
+                k="bytes deleted"
+                v={fmtBytes(metrics["dump_retention_bytes_deleted"])}
+              />
+              <KV k="dump errors" v={fmtCounter(metrics["dump_errors"])} />
+            </div>
+          ) : (
+            <span className="text-xs italic text-muted-foreground">disabled</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SourceRow({ source }: { source: CaptureSource }) {
+  if (source.type === "pcap") {
+    return (
+      <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
+            pcap
+          </span>
+          <span className="font-mono text-sm">{source.interface}</span>
+          {source.source_id && source.source_id !== source.interface && (
+            <span className="text-muted-foreground">
+              (id <span className="font-mono">{source.source_id}</span>)
+            </span>
+          )}
+        </div>
+        <div className="mt-1 grid grid-cols-1 gap-x-3 gap-y-0.5 text-muted-foreground sm:grid-cols-2">
+          <KV
+            k="BPF"
+            v={source.bpf_filter && source.bpf_filter !== "" ? source.bpf_filter : "(none — all TCP)"}
+            mono
+          />
+          <KV k="snaplen" v={`${source.snaplen.toLocaleString()} B`} />
+        </div>
+      </li>
+    )
+  }
+  if (source.type === "pcap-file") {
+    return (
+      <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
+            pcap-file
+          </span>
+          <span className="break-all font-mono">{source.path}</span>
+          <span className="text-muted-foreground">
+            ({source.realtime ? "realtime replay" : "as-fast-as-possible"})
+          </span>
+        </div>
+      </li>
+    )
+  }
+  return (
+    <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
+          cloud-probe
+        </span>
+        <span className="font-mono">{source.endpoint}</span>
+        <span className="text-muted-foreground">recv_hwm={source.recv_hwm}</span>
+      </div>
+    </li>
+  )
+}
+
+// ============================================================================
+// InterfacesCard
+// ============================================================================
+
+function InterfacesCard({
+  interfaces,
+  error,
+}: {
+  interfaces: CaptureInterface[]
+  error: unknown
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+        <Network className="size-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">Available interfaces</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          enumerated by libpcap on this host
+        </span>
+      </div>
+      {error ? (
+        <div className="px-4 py-3 text-sm text-destructive">{String(error)}</div>
+      ) : interfaces.length === 0 ? (
+        <div className="px-4 py-3 text-sm text-muted-foreground">no interfaces visible</div>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="bg-muted/30 text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2 text-left font-medium">name</th>
+              <th className="px-4 py-2 text-left font-medium">addresses</th>
+              <th className="px-4 py-2 text-left font-medium">flags</th>
+              <th className="px-4 py-2 text-left font-medium">description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {interfaces.map((i) => (
+              <tr key={i.name} className="border-t border-border/60">
+                <td className="px-4 py-1.5 font-mono">{i.name}</td>
+                <td className="px-4 py-1.5 font-mono text-muted-foreground">
+                  {i.addresses.length > 0 ? i.addresses.join(", ") : "—"}
+                </td>
+                <td className="px-4 py-1.5">
+                  <FlagRow iface={i} />
+                </td>
+                <td className="px-4 py-1.5 text-muted-foreground">{i.description ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+function FlagRow({ iface }: { iface: CaptureInterface }) {
+  const flags: { label: string; on: boolean }[] = [
+    { label: "up", on: iface.is_up },
+    { label: "running", on: iface.is_running },
+    { label: "loopback", on: iface.is_loopback },
+    { label: "wireless", on: iface.is_wireless },
+  ]
+  return (
+    <div className="flex flex-wrap gap-1">
+      {flags
+        .filter((f) => f.on)
+        .map((f) => (
+          <span
+            key={f.label}
+            className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+          >
+            {f.label}
+          </span>
+        ))}
+    </div>
+  )
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function KV({ k, v, mono = false }: { k: string; v: ReactNode; mono?: boolean }) {
+  return (
+    <span className="inline-flex gap-1.5">
+      <span className="text-muted-foreground">{k}:</span>
+      <span className={mono ? "font-mono break-all" : ""}>{v}</span>
+    </span>
+  )
+}
+
+function CountersGrid({
+  metrics,
+  keys,
+}: {
+  metrics: Record<string, number>
+  keys: string[]
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3 md:grid-cols-4">
+      {keys.map((k) => {
+        const v = metrics[k]
+        return (
+          <span key={k} className="inline-flex flex-col">
+            <span className="text-muted-foreground">{k}</span>
+            <span className="font-mono">{fmtCounter(v)}</span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+function buildMetricIndex(
+  pipelines: { name: string; metrics: MetricRecord[] }[],
+): Map<string, Record<string, number>> {
+  const out = new Map<string, Record<string, number>>()
+  for (const p of pipelines) {
+    const byName: Record<string, number> = {}
+    for (const m of p.metrics) byName[m.name] = m.value
+    out.set(p.name, byName)
+  }
+  return out
+}
+
+function fmtCounter(n: number | undefined): string {
+  if (n === undefined || n === null || Number.isNaN(n)) return "—"
+  return n.toLocaleString()
+}
+
+function fmtHours(h: number): string {
+  if (h === 0) return "no limit"
+  if (h % 24 === 0) return `${h / 24} d`
+  return `${h} h`
+}
+
+function fmtMiB(mb: number): string {
+  if (mb === 0) return "no limit"
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GiB`
+  return `${mb} MiB`
+}
+
+function fmtBytes(n: number | undefined): string {
+  if (n === undefined || n === null) return "—"
+  if (n >= 1 << 30) return `${(n / (1 << 30)).toFixed(2)} GiB`
+  if (n >= 1 << 20) return `${(n / (1 << 20)).toFixed(2)} MiB`
+  if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(2)} KiB`
+  return `${n} B`
+}

--- a/console/src/pages/settings.tsx
+++ b/console/src/pages/settings.tsx
@@ -1,8 +1,23 @@
+import { useRef, useState } from "react"
 import type { ReactNode } from "react"
-import { Loader2, RefreshCw, Cpu, Network, HardDrive } from "lucide-react"
+import {
+  Loader2,
+  RefreshCw,
+  Cpu,
+  Network,
+  HardDrive,
+  Pencil,
+  Plus,
+  Trash2,
+  AlertCircle,
+  Power,
+} from "lucide-react"
+import { useQueryClient } from "@tanstack/react-query"
 import { useRuntimeConfig } from "@/hooks/use-runtime-config"
 import { useInternalMetrics } from "@/hooks/use-internal-metrics"
 import { useCaptureInterfaces } from "@/hooks/use-capture-interfaces"
+import { useUpdateSources } from "@/hooks/use-update-sources"
+import { apiFetch, ApiError } from "@/lib/api"
 import type {
   AppConfigShape,
   CaptureInterface,
@@ -12,16 +27,26 @@ import type {
 } from "@/types/api"
 
 /**
- * Settings page — read-only view of the capture configuration the running
- * tokenscope process is using, with live per-pipeline counters merged in.
- *
- * Sources are the boot-time `[[pipeline.sources]]` entries. They cannot be
- * changed without a process restart; edits land in a follow-up phase.
+ * Settings page — view the capture configuration the running tokenscope
+ * process is using, with live per-pipeline counters, and edit the source
+ * list. Saving rewrites the on-disk TOML and triggers a self-restart of
+ * the tokenscope process; the page polls /api/health until the new
+ * process comes back, then refetches all queries.
  */
 export function SettingsPage() {
+  const queryClient = useQueryClient()
   const config = useRuntimeConfig()
   const metrics = useInternalMetrics()
   const interfaces = useCaptureInterfaces()
+  const mutate = useUpdateSources()
+
+  const [editing, setEditing] = useState<string | null>(null)
+  const [restartState, setRestartState] = useState<"idle" | "saving" | "restarting">("idle")
+
+  // Snapshot of `loaded_at_ms` when the user triggered the restart, so we
+  // can detect when the new process has come up (its `loaded_at_ms` will
+  // be larger than this).
+  const previousLoadedAtRef = useRef<number | null>(null)
 
   const isInitialLoad =
     config.isLoading || (metrics.isLoading && !metrics.data) || interfaces.isLoading
@@ -45,9 +70,27 @@ export function SettingsPage() {
   const appConfig = config.data.config as AppConfigShape
   const pipelines = appConfig.pipelines ?? []
   const metricsByPipeline = buildMetricIndex(metrics.data?.pipelines ?? [])
+  const availableInterfaces = interfaces.data?.interfaces ?? []
+
+  const onSave = async (pipelineName: string, sources: CaptureSource[]) => {
+    previousLoadedAtRef.current = config.data?.loaded_at_ms ?? null
+    setRestartState("saving")
+    try {
+      await mutate.mutateAsync({ pipeline_name: pipelineName, sources })
+    } catch (e) {
+      setRestartState("idle")
+      throw e
+    }
+    setEditing(null)
+    setRestartState("restarting")
+    // Wait for the new process to come up, then refresh.
+    await waitForRestart(previousLoadedAtRef.current ?? 0)
+    await queryClient.invalidateQueries()
+    setRestartState("idle")
+  }
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="relative flex flex-col gap-4 p-4">
       {/* ===== Header ===== */}
       <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-3">
         <span className="text-sm font-semibold">Settings</span>
@@ -73,10 +116,10 @@ export function SettingsPage() {
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Capture sources are configured at process startup. To change interface or BPF
-        filter today, edit{" "}
+        Saving a new source list rewrites{" "}
         <span className="font-mono text-foreground">{config.data.config_path}</span> and
-        restart tokenscope. An in-app editor is shipping in a follow-up.
+        restarts tokenscope. Pipelines are recreated from scratch — in-flight captures
+        will see a brief gap.
       </p>
 
       {/* ===== Pipelines ===== */}
@@ -91,15 +134,26 @@ export function SettingsPage() {
             key={p.name}
             pipeline={p}
             metrics={metricsByPipeline.get(p.name) ?? {}}
+            interfaces={availableInterfaces}
+            isEditing={editing === p.name}
+            onEditToggle={() =>
+              setEditing((cur) => (cur === p.name ? null : p.name))
+            }
+            onSave={(sources) => onSave(p.name, sources)}
+            saveError={mutate.error}
+            disabled={restartState !== "idle"}
           />
         ))
       )}
 
       {/* ===== Available interfaces ===== */}
       <InterfacesCard
-        interfaces={interfaces.data?.interfaces ?? []}
+        interfaces={availableInterfaces}
         error={interfaces.error}
       />
+
+      {/* ===== Restart overlay ===== */}
+      {restartState !== "idle" && <RestartOverlay state={restartState} />}
     </div>
   )
 }
@@ -111,9 +165,21 @@ export function SettingsPage() {
 function PipelineCard({
   pipeline,
   metrics,
+  interfaces,
+  isEditing,
+  onEditToggle,
+  onSave,
+  saveError,
+  disabled,
 }: {
   pipeline: PipelineShape
   metrics: Record<string, number>
+  interfaces: CaptureInterface[]
+  isEditing: boolean
+  onEditToggle: () => void
+  onSave: (sources: CaptureSource[]) => Promise<void>
+  saveError: unknown
+  disabled: boolean
 }) {
   return (
     <div className="rounded-lg border border-border bg-card">
@@ -125,12 +191,28 @@ function PipelineCard({
             {pipeline.dispatcher_count} dispatcher · {pipeline.flow_shard_count ?? "?"} flow shards
           </span>
         )}
+        <button
+          onClick={onEditToggle}
+          disabled={disabled}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+        >
+          <Pencil className="size-3.5" />
+          {isEditing ? "Cancel" : "Edit sources"}
+        </button>
       </div>
 
       {/* Sources */}
       <div className="border-b border-border px-4 py-3">
         <div className="mb-2 text-xs font-medium text-muted-foreground">Sources</div>
-        {pipeline.sources.length === 0 ? (
+        {isEditing ? (
+          <SourceEditor
+            initial={pipeline.sources}
+            interfaces={interfaces}
+            onCancel={onEditToggle}
+            onSave={onSave}
+            saveError={saveError}
+          />
+        ) : pipeline.sources.length === 0 ? (
           <div className="text-xs italic text-muted-foreground">no sources</div>
         ) : (
           <ul className="flex flex-col gap-2">
@@ -260,7 +342,197 @@ function SourceRow({ source }: { source: CaptureSource }) {
 }
 
 // ============================================================================
-// InterfacesCard
+// SourceEditor
+// ============================================================================
+
+const DEFAULT_SNAPLEN = 262_144
+
+function SourceEditor({
+  initial,
+  interfaces,
+  onCancel,
+  onSave,
+  saveError,
+}: {
+  initial: CaptureSource[]
+  interfaces: CaptureInterface[]
+  onCancel: () => void
+  onSave: (sources: CaptureSource[]) => Promise<void>
+  saveError: unknown
+}) {
+  const [rows, setRows] = useState<CaptureSource[]>(initial.length ? initial : [defaultPcap()])
+  const [saving, setSaving] = useState(false)
+
+  const updateRow = (i: number, patch: Partial<CaptureSource>) => {
+    setRows((r) =>
+      r.map((row, idx) => (idx === i ? ({ ...row, ...patch } as CaptureSource) : row)),
+    )
+  }
+  const removeRow = (i: number) => {
+    setRows((r) => r.filter((_, idx) => idx !== i))
+  }
+  const addPcap = () => setRows((r) => [...r, defaultPcap()])
+
+  const submit = async () => {
+    setSaving(true)
+    try {
+      await onSave(rows)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // Only pcap rows are editable inline. Other rows (pcap-file, cloud-probe)
+  // are shown read-only to preserve them on save.
+  return (
+    <div className="flex flex-col gap-3">
+      <ul className="flex flex-col gap-2">
+        {rows.map((s, i) =>
+          s.type === "pcap" ? (
+            <PcapEditorRow
+              key={i}
+              source={s}
+              interfaces={interfaces}
+              onChange={(p) => updateRow(i, p)}
+              onRemove={() => removeRow(i)}
+              canRemove={rows.length > 1}
+            />
+          ) : (
+            <li
+              key={i}
+              className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
+            >
+              <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+              <div className="flex-1">
+                <SourceRow source={s} />
+                <div className="mt-1 italic">
+                  Non-pcap sources stay as-is; edit via the TOML file directly.
+                </div>
+              </div>
+            </li>
+          ),
+        )}
+      </ul>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={addPcap}
+          disabled={saving}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+        >
+          <Plus className="size-3.5" /> Add pcap source
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={submit}
+          disabled={saving || rows.filter((r) => r.type === "pcap").length === 0}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {saving && <Loader2 className="size-3.5 animate-spin" />}
+          Save &amp; restart
+        </button>
+      </div>
+
+      {saveError ? (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          <div className="flex items-start gap-1.5">
+            <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+            <div>{errorMessage(saveError)}</div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function PcapEditorRow({
+  source,
+  interfaces,
+  onChange,
+  onRemove,
+  canRemove,
+}: {
+  source: Extract<CaptureSource, { type: "pcap" }>
+  interfaces: CaptureInterface[]
+  onChange: (patch: Partial<Extract<CaptureSource, { type: "pcap" }>>) => void
+  onRemove: () => void
+  canRemove: boolean
+}) {
+  return (
+    <li className="rounded-md border border-border/60 bg-background px-3 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
+          pcap
+        </span>
+        <label className="inline-flex items-center gap-1.5">
+          <span className="text-muted-foreground">interface</span>
+          <select
+            value={source.interface}
+            onChange={(e) => onChange({ interface: e.target.value })}
+            className="rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          >
+            {/* Make sure the current interface is selectable even if it
+                isn't in `interfaces` (e.g., enumeration failed). */}
+            {!interfaces.some((i) => i.name === source.interface) && (
+              <option value={source.interface}>{source.interface} (current)</option>
+            )}
+            {interfaces.map((i) => (
+              <option key={i.name} value={i.name}>
+                {i.name}
+                {i.addresses.length > 0 ? `  ·  ${i.addresses[0]}` : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="inline-flex items-center gap-1.5">
+          <span className="text-muted-foreground">snaplen</span>
+          <input
+            type="number"
+            min={64}
+            max={1 << 20}
+            value={source.snaplen}
+            onChange={(e) =>
+              onChange({ snaplen: Number(e.target.value) || DEFAULT_SNAPLEN })
+            }
+            className="w-24 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </label>
+        <div className="flex-1" />
+        {canRemove && (
+          <button
+            onClick={onRemove}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
+            title="Remove this source"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        )}
+      </div>
+      <label className="mt-2 flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">BPF</span>
+        <input
+          type="text"
+          value={source.bpf_filter ?? ""}
+          placeholder="(empty = all TCP)"
+          onChange={(e) =>
+            onChange({ bpf_filter: e.target.value === "" ? null : e.target.value })
+          }
+          className="flex-1 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+        />
+      </label>
+    </li>
+  )
+}
+
+// ============================================================================
+// InterfacesCard (read-only)
 // ============================================================================
 
 function InterfacesCard({
@@ -280,7 +552,7 @@ function InterfacesCard({
         </span>
       </div>
       {error ? (
-        <div className="px-4 py-3 text-sm text-destructive">{String(error)}</div>
+        <div className="px-4 py-3 text-sm text-destructive">{errorMessage(error)}</div>
       ) : interfaces.length === 0 ? (
         <div className="px-4 py-3 text-sm text-muted-foreground">no interfaces visible</div>
       ) : (
@@ -337,16 +609,58 @@ function FlagRow({ iface }: { iface: CaptureInterface }) {
 }
 
 // ============================================================================
-// Helpers
+// Restart overlay + helpers
 // ============================================================================
 
-function KV({ k, v, mono = false }: { k: string; v: ReactNode; mono?: boolean }) {
+function RestartOverlay({ state }: { state: "saving" | "restarting" }) {
   return (
-    <span className="inline-flex gap-1.5">
-      <span className="text-muted-foreground">{k}:</span>
-      <span className={mono ? "font-mono break-all" : ""}>{v}</span>
-    </span>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-8 py-6 shadow-lg">
+        {state === "saving" ? (
+          <>
+            <Loader2 className="size-8 animate-spin text-primary" />
+            <div className="text-sm font-medium">Saving configuration…</div>
+            <div className="text-xs text-muted-foreground">
+              Validating and writing TOML
+            </div>
+          </>
+        ) : (
+          <>
+            <Power className="size-8 animate-pulse text-primary" />
+            <div className="text-sm font-medium">Restarting tokenscope…</div>
+            <div className="text-xs text-muted-foreground">
+              Capture pipeline is being recreated. This usually takes a few seconds.
+            </div>
+          </>
+        )}
+      </div>
+    </div>
   )
+}
+
+/**
+ * Poll /api/health until the running process is the *new* one (its
+ * loaded_at_ms is greater than what we had before the save), capped at
+ * 60 attempts × 1s = 60s in case execv() failed and old process keeps
+ * serving.
+ */
+async function waitForRestart(prevLoadedAtMs: number): Promise<void> {
+  // Give the server its scheduled 500ms restart delay plus a touch more
+  // before the first probe — earlier probes will all succeed against the
+  // old process and add noise.
+  await new Promise((r) => setTimeout(r, 1200))
+
+  for (let i = 0; i < 60; i++) {
+    try {
+      const rt = await apiFetch<{ loaded_at_ms: number }>("/api/runtime-config")
+      if (rt.loaded_at_ms > prevLoadedAtMs) return
+    } catch {
+      // socket-closed during exec is expected — swallow and retry.
+    }
+    await new Promise((r) => setTimeout(r, 1000))
+  }
+  // Fall through silently. The page-level invalidate will still refresh
+  // whatever state we can reach.
 }
 
 function CountersGrid({
@@ -371,6 +685,15 @@ function CountersGrid({
   )
 }
 
+function KV({ k, v, mono = false }: { k: string; v: ReactNode; mono?: boolean }) {
+  return (
+    <span className="inline-flex gap-1.5">
+      <span className="text-muted-foreground">{k}:</span>
+      <span className={mono ? "font-mono break-all" : ""}>{v}</span>
+    </span>
+  )
+}
+
 function buildMetricIndex(
   pipelines: { name: string; metrics: MetricRecord[] }[],
 ): Map<string, Record<string, number>> {
@@ -381,6 +704,22 @@ function buildMetricIndex(
     out.set(p.name, byName)
   }
   return out
+}
+
+function defaultPcap(): CaptureSource {
+  return {
+    type: "pcap",
+    interface: "any",
+    bpf_filter: null,
+    snaplen: DEFAULT_SNAPLEN,
+    source_id: null,
+  }
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof ApiError) return e.message
+  if (e instanceof Error) return e.message
+  return String(e ?? "unknown error")
 }
 
 function fmtCounter(n: number | undefined): string {
@@ -407,3 +746,4 @@ function fmtBytes(n: number | undefined): string {
   if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(2)} KiB`
   return `${n} B`
 }
+

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -361,9 +361,79 @@ export interface RuntimeConfigResponse {
   /** Binary version (env!("CARGO_PKG_VERSION") at compile time). */
   version: string
   /**
-   * The live in-memory `AppConfig`. Shape mirrors the Rust struct but is kept
-   * opaque on the TS side — the page renders it as JSON and there is no other
-   * consumer that needs typed access.
+   * The live in-memory `AppConfig`. The narrow `AppConfigShape` typing is
+   * used by Settings; the debug page still renders the whole thing as JSON
+   * via `unknown` cast.
    */
-  config: unknown
+  config: AppConfigShape
+}
+
+// Narrow typed view of the AppConfig fields the Settings page consumes.
+// Everything else stays untyped — extend as needed.
+
+export type CaptureSource =
+  | {
+      type: "pcap"
+      interface: string
+      bpf_filter: string | null
+      snaplen: number
+      source_id: string | null
+    }
+  | {
+      type: "pcap-file"
+      path: string
+      realtime: boolean
+      source_id: string | null
+    }
+  | {
+      type: "cloud-probe"
+      endpoint: string
+      recv_hwm: number
+    }
+
+export interface PcapDumpRetention {
+  enabled: boolean
+  check_interval_secs: number
+  max_age_hours: number
+  max_size_mb: number
+}
+
+export interface PcapDumpConfig {
+  enabled: boolean
+  dir: string
+  compression: "none" | "snappy"
+  retention?: PcapDumpRetention
+}
+
+export interface PipelineShape {
+  name: string
+  dispatcher_count?: number
+  flow_shard_count?: number
+  sources: CaptureSource[]
+  pcap_dump?: PcapDumpConfig
+}
+
+export interface AppConfigShape {
+  pipelines?: PipelineShape[]
+  // Other AppConfig top-levels exist (storage, api, internal_metrics, …)
+  // but Settings does not consume them.
+  [k: string]: unknown
+}
+
+// ============================================================================
+// /api/capture/interfaces
+// ============================================================================
+
+export interface CaptureInterface {
+  name: string
+  description: string | null
+  addresses: string[]
+  is_up: boolean
+  is_running: boolean
+  is_loopback: boolean
+  is_wireless: boolean
+}
+
+export interface CaptureInterfacesResponse {
+  interfaces: CaptureInterface[]
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 
 # Config
 config = { version = "0.15", features = ["toml"] }
+toml_edit = "0.22"
 
 # Logging
 tracing = "0.1"

--- a/server/config/default.toml
+++ b/server/config/default.toml
@@ -27,8 +27,19 @@
 #
 # [[pipeline.sources]]
 # type = "pcap"
-# interface = "eth0"
-# bpf_filter = "tcp port 8080"
+# interface = "any"
+# # Default capture targets the common LLM-serving ports out of the box.
+# # Edit through the Settings UI (preferred) or trim/extend this list:
+# #   1234   LM Studio
+# #   4000   LiteLLM proxy default
+# #   4200   LiteLLM alt
+# #   8000   vLLM default
+# #   8001   vLLM alt
+# #   8080   common HTTP backend (OpenAI-compatible servers)
+# #   9000   generic / SGLang internal
+# #   11434  Ollama default
+# #   30000  SGLang default
+# bpf_filter = "tcp port 1234 or tcp port 4000 or tcp port 4200 or tcp port 8000 or tcp port 8001 or tcp port 8080 or tcp port 9000 or tcp port 11434 or tcp port 30000"
 # snaplen = 262144
 #
 # [[pipeline.sources]]

--- a/server/ts-api/Cargo.toml
+++ b/server/ts-api/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+ts-capture.workspace = true
 ts-common.workspace = true
 ts-llm.workspace = true
 ts-storage.workspace = true

--- a/server/ts-api/src/lib.rs
+++ b/server/ts-api/src/lib.rs
@@ -17,7 +17,7 @@ pub mod routes;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use axum::routing::get;
+use axum::routing::{get, put};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
@@ -104,10 +104,17 @@ pub fn router(
         )
         .with_state(metrics);
 
+    // Settings/runtime-config routes share the same context (config_path
+    // + AppConfig snapshot). GET is read-only; PUT rewrites the on-disk
+    // TOML and self-restarts.
     let runtime_config_routes = Router::new()
         .route(
             "/api/runtime-config",
             get(routes::runtime_config::runtime_config),
+        )
+        .route(
+            "/api/capture/sources",
+            put(routes::capture_sources::update),
         )
         .with_state(runtime_config);
 

--- a/server/ts-api/src/lib.rs
+++ b/server/ts-api/src/lib.rs
@@ -137,6 +137,11 @@ pub fn router(
         )
         .with_state(agent_turns_state);
 
+    let capture_routes = Router::new().route(
+        "/api/capture/interfaces",
+        get(routes::capture_interfaces::interfaces),
+    );
+
     Router::new()
         .route("/api/filters/wire-apis", get(routes::filters::wire_apis))
         .route("/api/filters/models", get(routes::filters::models))
@@ -174,5 +179,6 @@ pub fn router(
         .merge(health_routes)
         .merge(pcap_extract_routes)
         .merge(agent_turns_routes)
+        .merge(capture_routes)
         .layer(CorsLayer::permissive())
 }

--- a/server/ts-api/src/routes/capture_interfaces.rs
+++ b/server/ts-api/src/routes/capture_interfaces.rs
@@ -1,0 +1,23 @@
+//! `GET /api/capture/interfaces` — local pcap-visible network interfaces.
+//!
+//! Reads the same list `PcapLiveSource` would consult at startup, so the
+//! Settings UI can offer a dropdown that exactly matches what capture can
+//! actually open. Returns 500 if libpcap itself fails to enumerate (rare —
+//! usually means CAP_NET_RAW is missing).
+
+use axum::response::IntoResponse;
+use serde::Serialize;
+use ts_capture::interfaces::{list_interfaces, CaptureInterface};
+
+use crate::response::{ApiError, ApiResponse};
+
+#[derive(Serialize)]
+struct InterfacesResponse {
+    interfaces: Vec<CaptureInterface>,
+}
+
+pub async fn interfaces() -> Result<impl IntoResponse, ApiError> {
+    let interfaces = list_interfaces()
+        .map_err(|e| ApiError::Internal(format!("failed to list interfaces: {e}")))?;
+    Ok(ApiResponse::ok(InterfacesResponse { interfaces }))
+}

--- a/server/ts-api/src/routes/capture_sources.rs
+++ b/server/ts-api/src/routes/capture_sources.rs
@@ -1,0 +1,125 @@
+//! `PUT /api/capture/sources` — replace the source list for one
+//! `[[pipeline]]` in the on-disk config, then self-restart so the new
+//! sources actually take effect.
+//!
+//! Wire:
+//!
+//! 1. Validate every Pcap source (interface visible to libpcap + BPF
+//!    compiles).
+//! 2. Patch the TOML file at `ApiRuntimeConfigContext.config_path` via
+//!    `toml_edit` (preserves comments outside the rewritten array, atomic
+//!    write via tmp + rename).
+//! 3. Respond `{ restart_in_ms }` to the client.
+//! 4. Spawn a delayed task that re-execs the current binary with the same
+//!    argv. Capture is reopened from scratch, in-memory state (active turns,
+//!    queues) is reset — same effect as `kill -TERM` + `nohup … &`.
+//!
+//! Not authenticated. Same trust model as the rest of the API: assumed to
+//! be bound to a trusted network.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use ts_common::config::CaptureSourceConfig;
+use ts_common::config_edit::patch_pipeline_sources;
+
+use crate::response::{ApiError, ApiResponse};
+use crate::ApiRuntimeConfigContext;
+
+#[derive(Deserialize)]
+pub struct UpdateSourcesRequest {
+    pub pipeline_name: String,
+    pub sources: Vec<CaptureSourceConfig>,
+}
+
+#[derive(Serialize)]
+struct UpdateSourcesResponse {
+    /// Milliseconds the server will wait between sending this response and
+    /// re-execing itself. Lets clients show a "restarting…" overlay and
+    /// poll `/api/health` for the new uptime.
+    restart_in_ms: u64,
+}
+
+const RESTART_DELAY: Duration = Duration::from_millis(500);
+
+pub async fn update(
+    State(ctx): State<ApiRuntimeConfigContext>,
+    Json(req): Json<UpdateSourcesRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if req.pipeline_name.is_empty() {
+        return Err(ApiError::InvalidParam(
+            "pipeline_name is required".to_string(),
+        ));
+    }
+    if req.sources.is_empty() {
+        return Err(ApiError::InvalidParam(
+            "at least one source is required (refusing to disarm capture)".to_string(),
+        ));
+    }
+
+    // Validate every pcap source. Other source kinds are accepted as-is —
+    // pcap-file gets path-checked in run_pipeline, cloud-probe needs nothing
+    // beyond a parseable endpoint.
+    for s in &req.sources {
+        if let CaptureSourceConfig::Pcap {
+            interface,
+            bpf_filter,
+            ..
+        } = s
+        {
+            ts_capture::interfaces::validate_pcap_source(interface, bpf_filter.as_deref())
+                .map_err(|e| ApiError::InvalidParam(format!("invalid pcap source: {e}")))?;
+        }
+    }
+
+    // Write TOML
+    let path = PathBuf::from(&ctx.config_path);
+    patch_pipeline_sources(&path, &req.pipeline_name, &req.sources).map_err(|e| match e {
+        ts_common::config_edit::ConfigEditError::PipelineNotFound(_) => {
+            ApiError::NotFound(format!(
+                "pipeline '{}' is not declared in the config file (running in CLI mode?)",
+                req.pipeline_name
+            ))
+        }
+        other => ApiError::Internal(format!("config write failed: {other}")),
+    })?;
+
+    tracing::warn!(
+        config_path = %ctx.config_path,
+        pipeline = %req.pipeline_name,
+        sources = req.sources.len(),
+        "Settings: capture sources updated; self-restart scheduled in {:?}",
+        RESTART_DELAY,
+    );
+
+    // Schedule self-restart after the response is on the wire.
+    tokio::spawn(async {
+        tokio::time::sleep(RESTART_DELAY).await;
+        do_self_restart();
+    });
+
+    Ok(ApiResponse::ok(UpdateSourcesResponse {
+        restart_in_ms: RESTART_DELAY.as_millis() as u64,
+    }))
+}
+
+fn do_self_restart() {
+    use std::os::unix::process::CommandExt;
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "cannot resolve current_exe(); aborting restart");
+            return;
+        }
+    };
+    tracing::warn!(exe = %exe.display(), "Settings: execv'ing self");
+    let err = std::process::Command::new(&exe)
+        .args(std::env::args_os().skip(1))
+        .exec();
+    // exec() only returns on failure (otherwise the process image was replaced).
+    tracing::error!(error = %err, "execv failed; process continues with previous config");
+}

--- a/server/ts-api/src/routes/capture_sources.rs
+++ b/server/ts-api/src/routes/capture_sources.rs
@@ -109,6 +109,8 @@ pub async fn update(
 
 fn do_self_restart() {
     use std::os::unix::process::CommandExt;
+    use std::path::PathBuf;
+
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
@@ -116,10 +118,35 @@ fn do_self_restart() {
             return;
         }
     };
+
+    // /proc/self/exe reports `/path/to/binary (deleted)` when the running
+    // binary's inode was replaced (cargo build does this on every release
+    // rebuild). std::env::current_exe() passes that suffix through verbatim,
+    // and execv() then bombs with ENOENT. Strip it — the bare path resolves
+    // to whatever's on disk now, which is exactly the new binary we want.
+    let exe = strip_deleted_suffix(exe);
+
+    if !exe.exists() {
+        tracing::error!(
+            exe = %exe.display(),
+            "self-restart target does not exist; aborting"
+        );
+        return;
+    }
+
     tracing::warn!(exe = %exe.display(), "Settings: execv'ing self");
     let err = std::process::Command::new(&exe)
         .args(std::env::args_os().skip(1))
         .exec();
     // exec() only returns on failure (otherwise the process image was replaced).
     tracing::error!(error = %err, "execv failed; process continues with previous config");
+
+    fn strip_deleted_suffix(p: PathBuf) -> PathBuf {
+        let s = p.to_string_lossy();
+        if let Some(base) = s.strip_suffix(" (deleted)") {
+            PathBuf::from(base)
+        } else {
+            p
+        }
+    }
 }

--- a/server/ts-api/src/routes/mod.rs
+++ b/server/ts-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_sessions;
 pub mod agent_turns;
+pub mod capture_interfaces;
 pub mod filters;
 pub mod health;
 pub mod http_exchanges;

--- a/server/ts-api/src/routes/mod.rs
+++ b/server/ts-api/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_sessions;
 pub mod agent_turns;
 pub mod capture_interfaces;
+pub mod capture_sources;
 pub mod filters;
 pub mod health;
 pub mod http_exchanges;

--- a/server/ts-capture/Cargo.toml
+++ b/server/ts-capture/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
+serde.workspace = true
 snap = "1"
 
 [dev-dependencies]

--- a/server/ts-capture/src/interfaces.rs
+++ b/server/ts-capture/src/interfaces.rs
@@ -1,0 +1,66 @@
+//! Enumerate local pcap-visible interfaces for the Settings UI.
+//!
+//! Thin serializable wrapper around `pcap::Device::list()` — same source
+//! `PcapLiveSource` consults at startup. Used by `GET /api/capture/interfaces`.
+
+use std::net::IpAddr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureInterface {
+    pub name: String,
+    pub description: Option<String>,
+    pub addresses: Vec<String>,
+    pub is_up: bool,
+    pub is_running: bool,
+    pub is_loopback: bool,
+    pub is_wireless: bool,
+}
+
+pub fn list_interfaces() -> Result<Vec<CaptureInterface>, pcap::Error> {
+    let devices = pcap::Device::list()?;
+    let mut out: Vec<CaptureInterface> = devices
+        .into_iter()
+        .map(|d| {
+            let flags = &d.flags;
+            CaptureInterface {
+                name: d.name,
+                description: d.desc.filter(|s| !s.is_empty()),
+                addresses: d
+                    .addresses
+                    .into_iter()
+                    .map(|a| match a.addr {
+                        IpAddr::V4(v) => v.to_string(),
+                        IpAddr::V6(v) => v.to_string(),
+                    })
+                    .collect(),
+                is_up: flags.is_up(),
+                is_running: flags.is_running(),
+                is_loopback: flags.is_loopback(),
+                is_wireless: flags.is_wireless(),
+            }
+        })
+        .collect();
+
+    // libpcap returns the magic "any" pseudo-device on Linux. It's always
+    // safe to capture on (matches the current production config) but is
+    // missing from the kernel's netdev list, so it lacks addresses/flags.
+    // Make sure it shows up first so users can recognize it as the
+    // default-recommended choice.
+    if !out.iter().any(|i| i.name == "any") {
+        out.insert(
+            0,
+            CaptureInterface {
+                name: "any".to_string(),
+                description: Some("pseudo-device — capture on all interfaces".to_string()),
+                addresses: Vec::new(),
+                is_up: true,
+                is_running: true,
+                is_loopback: false,
+                is_wireless: false,
+            },
+        );
+    }
+    Ok(out)
+}

--- a/server/ts-capture/src/interfaces.rs
+++ b/server/ts-capture/src/interfaces.rs
@@ -64,3 +64,39 @@ pub fn list_interfaces() -> Result<Vec<CaptureInterface>, pcap::Error> {
     }
     Ok(out)
 }
+
+/// Quick validation of a `pcap` capture source for the Settings save path:
+///
+/// * `interface`: must be present in `Device::list()` OR equal `"any"`
+///   (Linux pseudo-device that's always valid even though libpcap omits it
+///   from `Device::list` on some kernels).
+/// * `bpf_filter`: must compile via `pcap_compile()` against the Ethernet
+///   linktype (matches what `PcapLiveSource` would request — all real
+///   captures live and read traffic decapsulated to Ethernet).
+///
+/// The validator never opens the real interface, so it is safe to call
+/// from a non-privileged API handler thread.
+pub fn validate_pcap_source(
+    interface: &str,
+    bpf_filter: Option<&str>,
+) -> Result<(), String> {
+    if interface.is_empty() {
+        return Err("interface name is empty".to_string());
+    }
+    if interface != "any" {
+        let devices = pcap::Device::list()
+            .map_err(|e| format!("libpcap enumeration failed: {e}"))?;
+        if !devices.iter().any(|d| d.name == interface) {
+            return Err(format!(
+                "interface '{interface}' is not visible to libpcap on this host"
+            ));
+        }
+    }
+    if let Some(bpf) = bpf_filter.filter(|s| !s.trim().is_empty()) {
+        let dead = pcap::Capture::dead(pcap::Linktype::ETHERNET)
+            .map_err(|e| format!("failed to create dead pcap for BPF check: {e}"))?;
+        dead.compile(bpf, true)
+            .map_err(|e| format!("BPF compile failed: {e}"))?;
+    }
+    Ok(())
+}

--- a/server/ts-capture/src/lib.rs
+++ b/server/ts-capture/src/lib.rs
@@ -16,6 +16,7 @@
 mod cloud_probe;
 mod factory;
 pub mod heartbeat;
+pub mod interfaces;
 mod packet;
 mod pcap_dump;
 mod pcap_file;

--- a/server/ts-common/Cargo.toml
+++ b/server/ts-common/Cargo.toml
@@ -10,4 +10,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+toml_edit = { workspace = true }
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/server/ts-common/src/config_edit.rs
+++ b/server/ts-common/src/config_edit.rs
@@ -1,0 +1,193 @@
+//! Surgical TOML rewrites for the Settings UI.
+//!
+//! Patches a specific `[[pipeline]]`'s `[[pipeline.sources]]` array in the
+//! on-disk config without rewriting unrelated sections. `toml_edit` preserves
+//! comments and ordering outside the rewritten array; comments *inside* the
+//! sources array are dropped (acceptable — users edit through the UI, not
+//! by hand, after this hits production).
+
+use std::path::Path;
+
+use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table};
+
+use crate::config::CaptureSourceConfig;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigEditError {
+    #[error("read config file: {0}")]
+    Read(std::io::Error),
+    #[error("parse TOML: {0}")]
+    Parse(toml_edit::TomlError),
+    #[error("write config file: {0}")]
+    Write(std::io::Error),
+    #[error("pipeline '{0}' not found in config")]
+    PipelineNotFound(String),
+    #[error("config root has no [[pipeline]] array (config-mode disabled?)")]
+    NoPipelineArray,
+}
+
+/// Replace `[[pipeline.sources]]` for the pipeline named `pipeline_name`.
+/// All existing source entries for that pipeline are dropped; the new list
+/// is written in order.
+///
+/// Atomic via write-tmp + rename: a partially-written config cannot ever
+/// be observed by the loader on the next start.
+pub fn patch_pipeline_sources(
+    path: &Path,
+    pipeline_name: &str,
+    sources: &[CaptureSourceConfig],
+) -> Result<(), ConfigEditError> {
+    let toml = std::fs::read_to_string(path).map_err(ConfigEditError::Read)?;
+    let mut doc: DocumentMut = toml.parse().map_err(ConfigEditError::Parse)?;
+
+    let pipelines = doc
+        .get_mut("pipeline")
+        .and_then(|i| i.as_array_of_tables_mut())
+        .ok_or(ConfigEditError::NoPipelineArray)?;
+
+    let mut found = false;
+    for pipeline in pipelines.iter_mut() {
+        let name_matches = pipeline
+            .get("name")
+            .and_then(|i| i.as_str())
+            .map(|n| n == pipeline_name)
+            .unwrap_or(false);
+        if !name_matches {
+            continue;
+        }
+        // Remove existing sources entirely (both [[pipeline.sources]] AOT
+        // and any inline `sources = [...]` form).
+        pipeline.remove("sources");
+        let mut aot = ArrayOfTables::new();
+        for s in sources {
+            aot.push(source_to_table(s));
+        }
+        pipeline.insert("sources", Item::ArrayOfTables(aot));
+        found = true;
+        break;
+    }
+    if !found {
+        return Err(ConfigEditError::PipelineNotFound(pipeline_name.to_string()));
+    }
+
+    // Atomic write: tmp file in the same dir → rename. Same-dir rename is
+    // atomic on POSIX, so a crash mid-write leaves the original intact.
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = dir.join(format!(
+        ".{}.tmp",
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("tokenscope-config")
+    ));
+    std::fs::write(&tmp, doc.to_string()).map_err(ConfigEditError::Write)?;
+    std::fs::rename(&tmp, path).map_err(ConfigEditError::Write)?;
+    Ok(())
+}
+
+fn source_to_table(s: &CaptureSourceConfig) -> Table {
+    let mut t = Table::new();
+    match s {
+        CaptureSourceConfig::Pcap {
+            interface,
+            bpf_filter,
+            snaplen,
+            source_id,
+        } => {
+            t["type"] = value("pcap");
+            t["interface"] = value(interface.as_str());
+            if let Some(bpf) = bpf_filter {
+                t["bpf_filter"] = value(bpf.as_str());
+            }
+            t["snaplen"] = value(i64::from(*snaplen));
+            if let Some(id) = source_id {
+                t["source_id"] = value(id.as_str());
+            }
+        }
+        CaptureSourceConfig::PcapFile {
+            path,
+            realtime,
+            source_id,
+        } => {
+            t["type"] = value("pcap-file");
+            t["path"] = value(path.as_str());
+            t["realtime"] = value(*realtime);
+            if let Some(id) = source_id {
+                t["source_id"] = value(id.as_str());
+            }
+        }
+        CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => {
+            t["type"] = value("cloud-probe");
+            t["endpoint"] = value(endpoint.as_str());
+            t["recv_hwm"] = value(i64::from(*recv_hwm));
+        }
+    }
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CaptureSourceConfig;
+
+    fn write_tmp(content: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn rewrites_sources_preserves_other_fields() {
+        let input = r#"# top comment
+[[pipeline]]
+name = "local"
+dispatcher_count = 2
+flow_shard_count = 4
+
+[[pipeline.sources]]
+type = "pcap"
+interface = "eth0"
+snaplen = 65535
+
+[pipeline.turn]
+idle_timeout_secs = 600
+
+[storage]
+backend = "duckdb"
+"#;
+        let f = write_tmp(input);
+        let new = vec![CaptureSourceConfig::Pcap {
+            interface: "any".to_string(),
+            bpf_filter: Some("tcp port 4210".to_string()),
+            snaplen: 262_144,
+            source_id: None,
+        }];
+        patch_pipeline_sources(f.path(), "local", &new).unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        // dispatcher_count + pipeline.turn + storage are still there
+        assert!(out.contains("dispatcher_count = 2"), "out:\n{out}");
+        assert!(out.contains("[pipeline.turn]"), "out:\n{out}");
+        assert!(out.contains("backend = \"duckdb\""), "out:\n{out}");
+        // sources have been replaced
+        assert!(out.contains("interface = \"any\""), "out:\n{out}");
+        assert!(
+            out.contains("bpf_filter = \"tcp port 4210\""),
+            "out:\n{out}"
+        );
+        assert!(!out.contains("interface = \"eth0\""), "out:\n{out}");
+    }
+
+    #[test]
+    fn unknown_pipeline_errors() {
+        let input = r#"
+[[pipeline]]
+name = "local"
+[[pipeline.sources]]
+type = "pcap"
+interface = "eth0"
+"#;
+        let f = write_tmp(input);
+        let err = patch_pipeline_sources(f.path(), "nope", &[]).unwrap_err();
+        assert!(matches!(err, ConfigEditError::PipelineNotFound(_)));
+    }
+}

--- a/server/ts-common/src/config_edit.rs
+++ b/server/ts-common/src/config_edit.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table};
+use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
 
 use crate::config::CaptureSourceConfig;
 

--- a/server/ts-common/src/lib.rs
+++ b/server/ts-common/src/lib.rs
@@ -12,6 +12,7 @@
 //! compile-time coupling surface small.
 
 pub mod config;
+pub mod config_edit;
 pub mod error;
 pub mod internal_metrics;
 pub mod path;


### PR DESCRIPTION
## Summary

Adds a Settings page that lets operators view and edit tokenscope's capture
sources from the web UI instead of by hand-editing the TOML and restarting
the binary.

- **`GET /api/capture/interfaces`** — enumerates libpcap-visible NICs (with
  flags + addresses), plus a back-filled `any` pseudo-device row.
- **`PUT /api/capture/sources`** — validates each pcap source (interface
  exists or is `any`; BPF compiles against a dead pcap), atomically
  rewrites the on-disk TOML via `toml_edit` (preserves comments outside
  the rewritten array), then re-execs the running process with the same
  argv so the new config takes effect. PID is preserved because `exec()`
  replaces the image. Subverts `/proc/self/exe`'s `(deleted)` sentinel
  after a fresh `cargo build` so post-build self-restart works.
- **Settings page** (`/settings`) — three per-type sections (Live captures
  / ZMQ receivers / PCAP replay) with independent Add buttons. Live
  capture form uses a structured ports/hosts editor that synthesises BPF
  underneath (with a 14-test round-trip lib); falls back to a raw-BPF
  textarea when an existing filter is more complex than the structured
  shape can express. Interface dropdown groups 'Recommended' first and
  collapses `veth* / vnet* / docker / br-… / cni…` into 'Virtual (40+)'.
- **Default BPF for new live-capture rows** covers the well-known LLM-
  serving ports: 1234 (LM Studio), 4000/4200 (LiteLLM), 8000/8001/8080
  (vLLM common), 9000 (SGLang internal), 11434 (Ollama), 30000 (SGLang).
  Same default lands in `server/config/default.toml`.
- **Inline two-step save confirmation** plus a restart overlay that polls
  `/api/runtime-config.loaded_at_ms` until the new process is serving.

CLI mode (`-i any --bpf-filter ''`) intentionally keeps the no-filter
default; the new LLM-ports default only fires through Settings + the
shipped TOML so debugging flows aren't surprised.

## Test plan

- [x] Console build + 111 unit tests (incl. 14 round-trip BPF tests in
      `console/src/lib/bpf.test.ts`)
- [x] Rust full workspace tests (62 ts-common + others all green) +
      integration tests (`config_edit` ones in particular)
- [x] Manual end-to-end on wuneng:
  - Hit ` GET /api/capture/interfaces` → 58 interfaces enumerated;
    `any` is back-filled first when libpcap omits it
  - Send valid `PUT` → 200 with `restart_in_ms`, then PID preserved,
    `loaded_at_ms` advances, new BPF in effect (verified via
    `pcap-live: BPF filter set: …` log line)
  - Send bad interface → 400 with clear validator message
  - Send bad BPF (`'this is not valid'`) → 400 from libpcap compile
  - Send unknown pipeline name → 404, TOML untouched
- [ ] Reviewer manual: open `/settings`, click Edit sources, change a
      port chip, hit Save, watch restart overlay, verify Performance
      page continues to render after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)