### PR TITLE
feat(dashboard): Active TCP Connections + Active Agent Turns charts

### DIFF
--- a/console/src/components/charts/active-gauge-chart.tsx
+++ b/console/src/components/charts/active-gauge-chart.tsx
@@ -1,0 +1,48 @@
+import { TimeseriesLineChart } from "@/components/charts/timeseries-line-chart"
+import { formatNumber } from "@/lib/format"
+import type {
+  InternalMetricsSeriesResponse,
+  TimeseriesData,
+} from "@/types/api"
+
+interface Props {
+  /** Backend metric short name, e.g. `"flows_active"`. */
+  metric: string
+  /** Human-readable line label in the legend / tooltip. */
+  label: string
+  /** Line color. */
+  color: string
+  /** Full series response from `/api/internal-metrics/series`. */
+  data: InternalMetricsSeriesResponse | undefined
+  height?: number
+}
+
+/**
+ * Single-line chart fed by `/api/internal-metrics/series`. The endpoint
+ * returns unix-ms timestamps; the underlying `TimeseriesLineChart`
+ * expects unix-seconds, so we divide here.
+ */
+export function ActiveGaugeChart({ metric, label, color, data, height = 200 }: Props) {
+  const entry = data?.series.find((s) => s.name === metric)
+  const ts: TimeseriesData | null = entry && entry.points.length > 0
+    ? {
+        timestamps: entry.points.map((p) => Math.floor(p.t / 1000)),
+        series: [
+          {
+            name: metric,
+            group: entry.group,
+            values: entry.points.map((p) => p.v),
+          },
+        ],
+      }
+    : null
+
+  return (
+    <TimeseriesLineChart
+      data={ts}
+      series={[{ key: metric, label, color }]}
+      yFormatter={(v) => formatNumber(Math.round(v))}
+      height={height}
+    />
+  )
+}

--- a/console/src/hooks/use-internal-metrics.ts
+++ b/console/src/hooks/use-internal-metrics.ts
@@ -1,7 +1,10 @@
 import { useQuery } from "@tanstack/react-query"
 import { apiFetch } from "@/lib/api"
 import { usePipelineHealthStore } from "@/stores/pipeline-health"
-import type { InternalMetricsResponse } from "@/types/api"
+import type {
+  InternalMetricsResponse,
+  InternalMetricsSeriesResponse,
+} from "@/types/api"
 
 /**
  * Poll /api/internal-metrics. Cadence comes from the store; `null` pauses.
@@ -19,6 +22,38 @@ export function useInternalMetrics() {
     refetchIntervalInBackground: false,
     // Keep the previous frame visible during refetches so the page doesn't
     // flicker, and so consumers can compute (current - previous) deltas.
+    placeholderData: (prev) => prev,
+    retry: 1,
+  })
+}
+
+interface SeriesOptions {
+  /** Unix epoch ms cutoff (omit / 0 ⇒ full ring). */
+  sinceMs?: number
+  /** Short metric names to fetch (e.g. ["flows_active", "turns_active"]). */
+  metrics?: string[]
+  /** Poll interval; `null` to pause. Default 10s — matches the backend recorder cadence. */
+  intervalMs?: number | null
+}
+
+/**
+ * Poll `/api/internal-metrics/series` for gauge time-series (flows_active,
+ * turns_active). The backend holds a 24h in-memory ring; this hook just
+ * keeps the latest snapshot fresh.
+ */
+export function useInternalMetricsSeries(opts: SeriesOptions = {}) {
+  const { sinceMs, metrics, intervalMs = 10_000 } = opts
+  const params = new URLSearchParams()
+  if (sinceMs && sinceMs > 0) params.set("since", String(sinceMs))
+  if (metrics?.length) params.set("metrics", metrics.join(","))
+  const qs = params.toString()
+  const url = qs ? `/api/internal-metrics/series?${qs}` : "/api/internal-metrics/series"
+
+  return useQuery({
+    queryKey: ["internal-metrics-series", qs],
+    queryFn: () => apiFetch<InternalMetricsSeriesResponse>(url),
+    refetchInterval: intervalMs ?? false,
+    refetchIntervalInBackground: false,
     placeholderData: (prev) => prev,
     retry: 1,
   })

--- a/console/src/pages/overview.tsx
+++ b/console/src/pages/overview.tsx
@@ -2,10 +2,13 @@ import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { formatMs, formatNumber } from "@/lib/format"
 import { useMetricsSummary, useTimeseries, useModels } from "@/hooks/use-metrics"
+import { useInternalMetricsSeries } from "@/hooks/use-internal-metrics"
+import { useToolbarStore } from "@/stores/toolbar"
 import { RequestVolumeChart } from "@/components/charts/request-volume-chart"
 import { LatencyOverviewChart } from "@/components/charts/latency-overview-chart"
 import { ModelBreakdownChart } from "@/components/charts/model-breakdown-chart"
 import { ErrorByModelChart } from "@/components/charts/error-by-model-chart"
+import { ActiveGaugeChart } from "@/components/charts/active-gauge-chart"
 
 function KpiCard({
   title,
@@ -47,6 +50,12 @@ export function OverviewPage() {
   const { data: volumeTs } = useTimeseries("call_count", { groupBy: "wire_api" })
   const { data: latencyTs } = useTimeseries("ttft_avg,ttft_p95,e2e_avg,e2e_p95")
   const { data: modelsData } = useModels()
+  // Toolbar exposes `start` as unix-seconds; convert to ms for the series API.
+  const start = useToolbarStore((s) => s.start)
+  const { data: gauges } = useInternalMetricsSeries({
+    metrics: ["flows_active", "agent_turns_open"],
+    sinceMs: start * 1000,
+  })
 
   if (summaryLoading) {
     return (
@@ -105,6 +114,38 @@ export function OverviewPage() {
         <div className="rounded-lg border border-border bg-card p-4">
           <h3 className="mb-3 text-sm font-medium">Latency Overview</h3>
           <LatencyOverviewChart data={latencyTs ?? null} />
+        </div>
+      </div>
+
+      {/* Active concurrency — live gauges from internal_metrics ring */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <h3 className="mb-3 text-sm font-medium">
+            Active TCP Connections
+            <span className="ml-2 text-xs font-normal text-muted-foreground">
+              tracked flows across all pipelines
+            </span>
+          </h3>
+          <ActiveGaugeChart
+            metric="flows_active"
+            label="Active connections"
+            color="#3b82f6"
+            data={gauges}
+          />
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <h3 className="mb-3 text-sm font-medium">
+            Active Agent Turns
+            <span className="ml-2 text-xs font-normal text-muted-foreground">
+              in-progress agent turns (registry size)
+            </span>
+          </h3>
+          <ActiveGaugeChart
+            metric="agent_turns_open"
+            label="Open turns"
+            color="#10b981"
+            data={gauges}
+          />
         </div>
       </div>
 

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -350,6 +350,29 @@ export interface InternalMetricsResponse {
 }
 
 // ============================================================================
+// /api/internal-metrics/series
+// ============================================================================
+
+/** One point in an internal-metrics time series. `t` is unix epoch ms. */
+export interface InternalSeriesPoint {
+  t: number
+  v: number
+}
+
+/** One series in the response — typically one per requested metric. */
+export interface InternalSeriesEntry {
+  name: string
+  group: MetricGroup
+  points: InternalSeriesPoint[]
+}
+
+export interface InternalMetricsSeriesResponse {
+  /** Server wall-clock at response time, unix epoch ms. */
+  ts: number
+  series: InternalSeriesEntry[]
+}
+
+// ============================================================================
 // /api/runtime-config
 // ============================================================================
 

--- a/server/app/tokenscope/src/main.rs
+++ b/server/app/tokenscope/src/main.rs
@@ -15,7 +15,9 @@ use tokio_util::sync::CancellationToken;
 use ts_common::config::{
     config_search_paths, discover_config_path, AppConfig, CaptureSourceConfig, PipelineDef,
 };
-use ts_common::internal_metrics::{Metric, MetricsReporter, MetricsSystem};
+use ts_common::internal_metrics::{
+    AggregateHistory, HistoryRecorder, Metric, MetricsReporter, MetricsSystem,
+};
 use tokenscope::create_backend;
 
 mod cmd;
@@ -517,6 +519,20 @@ async fn run_pipeline(cli: Cli) {
         // finalized ones without DB write amplification.
         let active_turns = ts_turn::new_active_turn_registry();
 
+        // Process-wide gauge for the dashboard "Active Agent Turns" chart:
+        // size of the in-progress turn registry at sample time. Registered on
+        // the global svc (not per-pipeline) because the registry is shared —
+        // a per-pipeline probe would multiply the reading by N pipelines.
+        {
+            let registry_for_probe = active_turns.clone();
+            shared_metrics.register_queue_probe(Metric::TurnRegistryActive, move || {
+                registry_for_probe
+                    .read()
+                    .map(|m| m.len() as u64)
+                    .unwrap_or(0)
+            });
+        }
+
         let Pipeline {
             pipeline_txs,
             pipeline_sources,
@@ -586,6 +602,38 @@ async fn run_pipeline(cli: Cli) {
             })
         };
 
+        // In-memory time-series ring for the "active" gauges shown on the
+        // dashboard (Active TCP Connections / Active Agent Sessions). The
+        // recorder samples every per-pipeline svc + the global svc once per
+        // `interval_secs` and pushes one summed frame. Ring sized for ~24h
+        // of retention at the configured interval (clamped >=1).
+        let (history_ctx, history_recorder_handle) = if reporter_enabled {
+            let interval_secs = config.internal_metrics.interval_secs.max(1);
+            let capacity = ((24 * 3600) / interval_secs as usize).max(1);
+            let history = AggregateHistory::new(
+                vec![Metric::FlowsActive, Metric::TurnRegistryActive],
+                capacity,
+            );
+            let mut svcs: Vec<_> = api_pipeline_metrics
+                .iter()
+                .map(|(_, svc)| svc.clone())
+                .collect();
+            svcs.push(api_global_metrics.clone());
+            let handle = HistoryRecorder::start(
+                svcs,
+                history.clone(),
+                Duration::from_secs(interval_secs),
+            );
+            tracing::info!(
+                "internal metrics history recorder started (interval={}s, capacity={})",
+                interval_secs,
+                capacity
+            );
+            (Some(history), Some(handle))
+        } else {
+            (None, None)
+        };
+
         // Now that every per-pipeline + global `MetricsSvc` exists, spawn the
         // API server with a fully populated `ApiMetricsContext`. We assign to
         // the previously-declared `mut api_handle` (no `let`) so the shutdown
@@ -603,6 +651,7 @@ async fn run_pipeline(cli: Cli) {
                 let api_metrics = ts_api::ApiMetricsContext {
                     pipelines: api_pipeline_metrics,
                     global: api_global_metrics.clone(),
+                    history: history_ctx.clone(),
                 };
                 let api_runtime_config = runtime_config_ctx.clone();
                 let api_health = ts_api::ApiHealthContext {
@@ -769,6 +818,10 @@ async fn run_pipeline(cli: Cli) {
             let _ = handle.stop_tx.send(());
             let _ = handle.join.await;
         }
+        if let Some(handle) = history_recorder_handle {
+            let _ = handle.stop_tx.send(());
+            let _ = handle.join.await;
+        }
 
         // Park on a shutdown signal so the API/console stays available for
         // post-drain inspection — unless the user opted into batch mode with
@@ -811,6 +864,7 @@ async fn run_pipeline(cli: Cli) {
                     let api_metrics = ts_api::ApiMetricsContext {
                         pipelines: Vec::new(),
                         global: empty_global,
+                        history: None,
                     };
                     let api_runtime_config = runtime_config_ctx.clone();
                     let api_health = ts_api::ApiHealthContext {

--- a/server/ts-api/src/lib.rs
+++ b/server/ts-api/src/lib.rs
@@ -23,7 +23,7 @@ use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use ts_common::config::{ApiConfig, AppConfig};
 use ts_common::error::{AppError, Result};
-use ts_common::internal_metrics::MetricsSvc;
+use ts_common::internal_metrics::{AggregateHistory, MetricsSvc};
 use ts_pcap_extract::PipelineRoot;
 use ts_storage::StorageBackend;
 use ts_turn::ActiveTurnRegistry;
@@ -31,10 +31,17 @@ use ts_turn::ActiveTurnRegistry;
 /// Carriers for `/api/internal-metrics` — every per-pipeline `MetricsSvc`
 /// plus the cross-pipeline (storage) one. Build this in `main.rs` after
 /// `MetricsSystem::start()`.
+///
+/// `history` is the optional in-memory time-series ring populated by
+/// `HistoryRecorder` (set when `internal_metrics.enabled` is true). The
+/// `/api/internal-metrics/series` endpoint reads it; the rest of the
+/// internal-metrics routes don't need it. `None` ⇒ the series route
+/// reports an empty series rather than 503'ing.
 #[derive(Clone)]
 pub struct ApiMetricsContext {
     pub pipelines: Vec<(String, Arc<MetricsSvc>)>,
     pub global: Arc<MetricsSvc>,
+    pub history: Option<Arc<AggregateHistory>>,
 }
 
 /// Carrier for `/api/runtime-config` — the live in-memory `AppConfig`
@@ -101,6 +108,10 @@ pub fn router(
         .route(
             "/api/internal-metrics",
             get(routes::internal_metrics::internal_metrics),
+        )
+        .route(
+            "/api/internal-metrics/series",
+            get(routes::internal_metrics::series),
         )
         .with_state(metrics);
 

--- a/server/ts-api/src/routes/internal_metrics.rs
+++ b/server/ts-api/src/routes/internal_metrics.rs
@@ -1,12 +1,18 @@
 //! `GET /api/internal-metrics` — current snapshot of every registered
 //! internal metric across all pipelines plus the global (storage) view.
+//!
+//! `GET /api/internal-metrics/series` — short-window time-series for the
+//! handful of gauges the `AggregateHistory` ring is tracking (currently
+//! `flows_active` and `turns_active`). Used by the dashboard's
+//! "Active TCP Connections" / "Active Agent Sessions" charts.
 
+use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::response::IntoResponse;
-use serde::Serialize;
-use ts_common::internal_metrics::{MetricKind, MetricsSvc};
+use serde::{Deserialize, Serialize};
+use ts_common::internal_metrics::{Metric, MetricKind, MetricsSvc};
 
 use crate::response::ApiResponse;
 use crate::ApiMetricsContext;
@@ -88,13 +94,115 @@ pub async fn internal_metrics(State(ctx): State<ApiMetricsContext>) -> impl Into
     })
 }
 
+// ---------------------------------------------------------------------------
+// /api/internal-metrics/series
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct SeriesQuery {
+    /// Optional unix-ms cutoff: only return points with `ts_ms >= since`.
+    /// Defaults to 0 (return everything in the ring).
+    #[serde(default)]
+    pub since: Option<i64>,
+    /// Comma-separated short metric names (e.g. `"flows_active,turns_active"`).
+    /// Defaults to whatever the ring is tracking — typically all of them.
+    #[serde(default)]
+    pub metrics: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SeriesPoint {
+    /// Unix epoch milliseconds.
+    t: i64,
+    /// Gauge value at that instant (summed across all contributor svcs).
+    v: u64,
+}
+
+#[derive(Serialize)]
+struct SeriesResponse {
+    ts: i64,
+    /// One entry per requested metric. Empty array if the history ring is
+    /// not initialized (i.e. internal_metrics disabled).
+    series: Vec<SeriesEntry>,
+}
+
+#[derive(Serialize)]
+struct SeriesEntry {
+    name: &'static str,
+    group: &'static str,
+    points: Vec<SeriesPoint>,
+}
+
+fn resolve_metric(short: &str) -> Option<Metric> {
+    Metric::ALL
+        .iter()
+        .copied()
+        .find(|m| m.spec().short_name == short)
+}
+
+pub async fn series(
+    State(ctx): State<ApiMetricsContext>,
+    Query(q): Query<SeriesQuery>,
+) -> impl IntoResponse {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+
+    let Some(history) = ctx.history.as_ref() else {
+        return ApiResponse::ok(SeriesResponse {
+            ts,
+            series: Vec::new(),
+        });
+    };
+
+    let since = q.since.unwrap_or(0);
+    let requested: Vec<Metric> = match q.metrics.as_deref() {
+        Some(csv) => csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .filter_map(resolve_metric)
+            .filter(|m| history.tracked().contains(m))
+            .collect(),
+        None => history.tracked().to_vec(),
+    };
+
+    // De-dup while preserving order so `metrics=a,a,b` doesn't return two
+    // identical series entries.
+    let mut seen: BTreeMap<Metric, ()> = BTreeMap::new();
+    let series = requested
+        .into_iter()
+        .filter(|m| seen.insert(*m, ()).is_none())
+        .map(|m| {
+            let pts = history
+                .series(m, since)
+                .into_iter()
+                .map(|p| SeriesPoint {
+                    t: p.ts_ms,
+                    v: p.value,
+                })
+                .collect();
+            let spec = m.spec();
+            SeriesEntry {
+                name: spec.short_name,
+                group: spec.group.as_str(),
+                points: pts,
+            }
+        })
+        .collect();
+
+    ApiResponse::ok(SeriesResponse { ts, series })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::body::to_bytes;
     use axum::http::StatusCode;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
-    use ts_common::internal_metrics::{Metric, MetricsSystem};
+    use ts_common::internal_metrics::{AggregateHistory, Metric, MetricsSystem};
 
     fn build_pipeline_svc() -> Arc<MetricsSvc> {
         let mut sys = MetricsSystem::new();
@@ -123,6 +231,7 @@ mod tests {
         let ctx = ApiMetricsContext {
             pipelines: vec![("default".to_string(), build_pipeline_svc())],
             global: build_global_svc(),
+            history: None,
         };
         let resp = internal_metrics(State(ctx)).await.into_response();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -166,6 +275,7 @@ mod tests {
         let ctx = ApiMetricsContext {
             pipelines: vec![],
             global: build_global_svc(),
+            history: None,
         };
         let resp = internal_metrics(State(ctx)).await.into_response();
         let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
@@ -175,5 +285,122 @@ mod tests {
             .as_array()
             .unwrap()
             .is_empty());
+    }
+
+    fn build_history(tracked: Vec<Metric>) -> Arc<AggregateHistory> {
+        let history = AggregateHistory::new(tracked.clone(), 16);
+        for (ts, vals) in [
+            (1_000i64, &[(Metric::FlowsActive, 3u64), (Metric::TurnActive, 1)][..]),
+            (2_000, &[(Metric::FlowsActive, 5), (Metric::TurnActive, 2)]),
+            (3_000, &[(Metric::FlowsActive, 4), (Metric::TurnActive, 2)]),
+        ] {
+            let mut frame: BTreeMap<Metric, u64> = BTreeMap::new();
+            for (m, v) in vals {
+                if tracked.contains(m) {
+                    frame.insert(*m, *v);
+                }
+            }
+            history.push(ts, frame);
+        }
+        history
+    }
+
+    fn ctx_with_history(history: Arc<AggregateHistory>) -> ApiMetricsContext {
+        ApiMetricsContext {
+            pipelines: vec![],
+            global: build_global_svc(),
+            history: Some(history),
+        }
+    }
+
+    #[tokio::test]
+    async fn series_returns_tracked_metrics_by_default() {
+        let history = build_history(vec![Metric::FlowsActive, Metric::TurnActive]);
+        let resp = series(
+            State(ctx_with_history(history)),
+            Query(SeriesQuery {
+                since: None,
+                metrics: None,
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let series = v["data"]["series"].as_array().unwrap();
+        assert_eq!(series.len(), 2);
+
+        let flows = series
+            .iter()
+            .find(|s| s["name"] == "flows_active")
+            .unwrap();
+        let pts = flows["points"].as_array().unwrap();
+        assert_eq!(pts.len(), 3);
+        assert_eq!(pts[0]["t"], 1000);
+        assert_eq!(pts[0]["v"], 3);
+        assert_eq!(pts[2]["v"], 4);
+    }
+
+    #[tokio::test]
+    async fn series_honors_since_cutoff() {
+        let history = build_history(vec![Metric::FlowsActive, Metric::TurnActive]);
+        let resp = series(
+            State(ctx_with_history(history)),
+            Query(SeriesQuery {
+                since: Some(2_500),
+                metrics: Some("flows_active".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let series = v["data"]["series"].as_array().unwrap();
+        assert_eq!(series.len(), 1);
+        let pts = series[0]["points"].as_array().unwrap();
+        assert_eq!(pts.len(), 1);
+        assert_eq!(pts[0]["t"], 3000);
+    }
+
+    #[tokio::test]
+    async fn series_filters_to_tracked_only_and_dedups() {
+        let history = build_history(vec![Metric::FlowsActive]);
+        let resp = series(
+            State(ctx_with_history(history)),
+            Query(SeriesQuery {
+                since: None,
+                metrics: Some("flows_active,turns_active,flows_active".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let series = v["data"]["series"].as_array().unwrap();
+        assert_eq!(series.len(), 1, "untracked + dup should both be dropped");
+        assert_eq!(series[0]["name"], "flows_active");
+    }
+
+    #[tokio::test]
+    async fn series_without_history_yields_empty_array() {
+        let ctx = ApiMetricsContext {
+            pipelines: vec![],
+            global: build_global_svc(),
+            history: None,
+        };
+        let resp = series(
+            State(ctx),
+            Query(SeriesQuery {
+                since: None,
+                metrics: None,
+            }),
+        )
+        .await
+        .into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], 0);
+        assert_eq!(v["data"]["series"].as_array().unwrap().len(), 0);
     }
 }

--- a/server/ts-api/tests/duckdb_routes.rs
+++ b/server/ts-api/tests/duckdb_routes.rs
@@ -20,6 +20,7 @@ fn test_metrics_context() -> ApiMetricsContext {
     ApiMetricsContext {
         pipelines: vec![],
         global: sys.start(),
+        history: None,
     }
 }
 

--- a/server/ts-common/src/internal_metrics.rs
+++ b/server/ts-common/src/internal_metrics.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -195,7 +195,14 @@ define_metrics! {
     TurnDiscardedNoUserStart => { kind: Counter, group: Turn, short: "turns_discarded_no_user_start" },
     TurnHeartbeatsReceived   => { kind: Counter, group: Turn, short: "turn_heartbeats_received"      },
     TurnHeartbeatsDropped    => { kind: Counter, group: Turn, short: "turn_heartbeats_dropped"       },
-    TurnActive               => { kind: Gauge,   group: Turn, short: "turns_active"                  },
+    TurnActive               => { kind: Gauge,   group: Turn, short: "turn_calls_buffered"           },
+    // Process-wide registry of in-progress agent turns (size of
+    // ActiveTurnRegistry). Distinct from `turn_calls_buffered`, which sums
+    // pending LLM calls inside per-session turn buffers — that gauge counts
+    // calls, not conversations. `agent_turns_open` is the truthful
+    // "concurrent in-flight agent turns" signal and is what the dashboard
+    // "Active Agent Turns" chart reads.
+    TurnRegistryActive       => { kind: Gauge,   group: Turn, short: "agent_turns_open"              },
 
     // -- Metrics aggregation --
     // Start/Complete are kept under the `llm_events_*` family because the
@@ -682,6 +689,158 @@ impl MetricsReporter {
 }
 
 // ---------------------------------------------------------------------------
+// AggregateHistory — in-memory time-series ring for selected gauges
+// ---------------------------------------------------------------------------
+
+/// One sample in the in-memory history ring.
+#[derive(Debug, Clone, Copy)]
+pub struct HistoryPoint {
+    /// Wall-clock unix timestamp in milliseconds (when the sample was taken).
+    pub ts_ms: i64,
+    /// Aggregated value at that instant (summed across the contributing svcs
+    /// the recorder was given — typically all per-pipeline `MetricsSvc`s plus
+    /// the global one).
+    pub value: u64,
+}
+
+struct HistoryFrame {
+    ts_ms: i64,
+    values: BTreeMap<Metric, u64>,
+}
+
+/// Bounded in-memory ring of timestamped gauge samples, sampled by
+/// [`HistoryRecorder`] at a fixed interval. Reads are cheap (single
+/// `RwLock` shared read), writes are amortized O(1) (`VecDeque` push back,
+/// pop front when at capacity).
+///
+/// Capacity is computed by the caller from retention / interval (e.g. 24h
+/// at 10s ⇒ 8640 frames). At < 64 bytes / frame including the per-metric
+/// `BTreeMap` entries, a 24h ring for two gauges fits in ~500 KB — small
+/// enough to ignore.
+///
+/// History is gone on process restart; this is by design (gauges are
+/// "active now" signals — the cross-restart story isn't useful here).
+pub struct AggregateHistory {
+    tracked: Vec<Metric>,
+    capacity: usize,
+    samples: RwLock<VecDeque<HistoryFrame>>,
+}
+
+impl AggregateHistory {
+    /// Create a new history ring for the given tracked metrics.
+    pub fn new(tracked: Vec<Metric>, capacity: usize) -> Arc<Self> {
+        let cap = capacity.max(1);
+        Arc::new(Self {
+            tracked,
+            capacity: cap,
+            samples: RwLock::new(VecDeque::with_capacity(cap)),
+        })
+    }
+
+    /// Metrics this ring records (subset of `Metric::ALL`).
+    pub fn tracked(&self) -> &[Metric] {
+        &self.tracked
+    }
+
+    /// Push a frame, evicting the oldest if at capacity.
+    pub fn push(&self, ts_ms: i64, values: BTreeMap<Metric, u64>) {
+        let mut buf = self.samples.write().expect("history lock poisoned");
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(HistoryFrame { ts_ms, values });
+    }
+
+    /// Return all samples for `metric` with `ts_ms >= since_ms`.
+    ///
+    /// If the ring is empty or the metric was never tracked, returns an
+    /// empty vector.
+    pub fn series(&self, metric: Metric, since_ms: i64) -> Vec<HistoryPoint> {
+        let buf = self.samples.read().expect("history lock poisoned");
+        buf.iter()
+            .filter(|f| f.ts_ms >= since_ms)
+            .map(|f| HistoryPoint {
+                ts_ms: f.ts_ms,
+                value: f.values.get(&metric).copied().unwrap_or(0),
+            })
+            .collect()
+    }
+
+    /// Number of samples currently held (test/diag helper).
+    pub fn len(&self) -> usize {
+        self.samples
+            .read()
+            .expect("history lock poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Periodic recorder that samples every contributor `MetricsSvc` and pushes
+/// one summed frame into the shared [`AggregateHistory`].
+///
+/// Drives independent of [`MetricsReporter`] so it can keep ticking when the
+/// reporter is disabled (`internal_metrics.enabled = false` in config), and
+/// so the recorder cadence does not have to equal the log cadence — though
+/// for v1 they share `internal_metrics.interval_secs`.
+pub struct HistoryRecorder;
+
+impl HistoryRecorder {
+    /// Spawn the recorder task. `svcs` is the set of `MetricsSvc`s whose
+    /// values are summed at every tick (typically per-pipeline svcs + the
+    /// global one). The handle works the same way as [`MetricsReporter`]'s.
+    pub fn start(
+        svcs: Vec<Arc<MetricsSvc>>,
+        history: Arc<AggregateHistory>,
+        interval: Duration,
+    ) -> ReporterHandle {
+        let (stop_tx, mut stop_rx) = watch::channel(());
+
+        let join = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.tick().await; // first tick is immediate, skip
+
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => Self::record(&svcs, &history),
+                    _ = stop_rx.changed() => {
+                        Self::record(&svcs, &history);
+                        break;
+                    }
+                }
+            }
+        });
+
+        ReporterHandle { stop_tx, join }
+    }
+
+    /// Take one synchronous sample. Pub for unit-test reuse — production
+    /// callers should let [`start`](Self::start)'s tokio task drive this.
+    pub fn record(svcs: &[Arc<MetricsSvc>], history: &AggregateHistory) {
+        let mut sum: BTreeMap<Metric, u64> =
+            history.tracked().iter().map(|&m| (m, 0u64)).collect();
+        for svc in svcs {
+            svc.sample_probes();
+            for &m in history.tracked() {
+                if let Some(v) = svc.aggregate(m) {
+                    if let Some(slot) = sum.get_mut(&m) {
+                        *slot = slot.saturating_add(v);
+                    }
+                }
+            }
+        }
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        history.push(ts, sum);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -877,5 +1036,79 @@ mod tests {
         depth.store(5, Ordering::Relaxed);
         svc.sample_probes();
         assert_eq!(svc.aggregate(Metric::QueueDepthRaw), Some(5));
+    }
+
+    #[test]
+    fn aggregate_history_ring_evicts_oldest() {
+        let history = AggregateHistory::new(vec![Metric::FlowsActive], 3);
+        for (ts, v) in [(1, 10u64), (2, 20), (3, 30), (4, 40)] {
+            let mut frame = BTreeMap::new();
+            frame.insert(Metric::FlowsActive, v);
+            history.push(ts, frame);
+        }
+        assert_eq!(history.len(), 3, "ring should evict to capacity");
+
+        let pts = history.series(Metric::FlowsActive, 0);
+        let values: Vec<u64> = pts.iter().map(|p| p.value).collect();
+        assert_eq!(values, vec![20, 30, 40]);
+        let timestamps: Vec<i64> = pts.iter().map(|p| p.ts_ms).collect();
+        assert_eq!(timestamps, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn aggregate_history_series_since_filter() {
+        let history = AggregateHistory::new(vec![Metric::TurnActive], 10);
+        for (ts, v) in [(100, 1u64), (200, 2), (300, 3), (400, 4)] {
+            let mut frame = BTreeMap::new();
+            frame.insert(Metric::TurnActive, v);
+            history.push(ts, frame);
+        }
+        let pts = history.series(Metric::TurnActive, 250);
+        let values: Vec<u64> = pts.iter().map(|p| p.value).collect();
+        assert_eq!(values, vec![3, 4]);
+    }
+
+    #[test]
+    fn aggregate_history_untracked_metric_yields_zero() {
+        let history = AggregateHistory::new(vec![Metric::FlowsActive], 10);
+        let mut frame = BTreeMap::new();
+        frame.insert(Metric::FlowsActive, 7);
+        history.push(50, frame);
+
+        // Querying a metric we didn't track should return frames with 0,
+        // not panic — matches the "missing == zero" reader semantics.
+        let pts = history.series(Metric::TurnActive, 0);
+        assert_eq!(pts.len(), 1);
+        assert_eq!(pts[0].value, 0);
+    }
+
+    #[test]
+    fn history_recorder_sums_pipelines_and_global() {
+        let mut sys_a = MetricsSystem::new();
+        sys_a.register_queue_probe(Metric::FlowsActive, || 3);
+        sys_a.register_queue_probe(Metric::TurnActive, || 1);
+        let svc_a = sys_a.start();
+
+        let mut sys_b = MetricsSystem::new();
+        sys_b.register_queue_probe(Metric::FlowsActive, || 5);
+        sys_b.register_queue_probe(Metric::TurnActive, || 2);
+        let svc_b = sys_b.start();
+
+        let history =
+            AggregateHistory::new(vec![Metric::FlowsActive, Metric::TurnActive], 16);
+
+        HistoryRecorder::record(&[svc_a, svc_b], &history);
+        HistoryRecorder::record(&[], &history); // empty svcs should yield 0 frame
+
+        let flows = history.series(Metric::FlowsActive, 0);
+        let turns = history.series(Metric::TurnActive, 0);
+        assert_eq!(flows.len(), 2);
+        assert_eq!(turns.len(), 2);
+        // Frame 1: a(3) + b(5) = 8 flows, a(1) + b(2) = 3 turns.
+        assert_eq!(flows[0].value, 8);
+        assert_eq!(turns[0].value, 3);
+        // Frame 2: no contributors → 0.
+        assert_eq!(flows[1].value, 0);
+        assert_eq!(turns[1].value, 0);
     }
 }

--- a/server/ts-turn/src/stage.rs
+++ b/server/ts-turn/src/stage.rs
@@ -36,8 +36,12 @@ pub fn spawn_turn_stage(
     );
 
     // Per-shard gauges updated after every tracker mutation. The probe sums
-    // across shards to report total in-flight turns; max would hide shards
-    // with many open sessions behind a single dominant shard.
+    // across shards to report `turn_calls_buffered` — total in-flight LLM
+    // calls sitting in per-session turn buffers waiting to be grouped into
+    // a finalized turn. NOTE: this counts CALLS, not open turns; a single
+    // conversation with N concurrent calls contributes N. For the "open
+    // agent turns" signal the dashboard uses, see `agent_turns_open`
+    // (registered on the global svc against ActiveTurnRegistry).
     let active_gauges: Vec<Arc<AtomicU64>> = (0..shard_rxs.len())
         .map(|_| Arc::new(AtomicU64::new(0)))
         .collect();


### PR DESCRIPTION
## Summary

Adds two live "concurrent in-flight" gauge charts to the overview dashboard:

- **Active TCP Connections** — current `flows_active` (sum of per-shard tracked TCP flows)
- **Active Agent Turns** — current `agent_turns_open` (size of `ActiveTurnRegistry`)

Both are fed by a new in-memory time-series ring sampled at the configured `internal_metrics.interval_secs` (default 10s) and retained for 24h. The dashboard's toolbar `preset` (5m / 15m / 1h / 24h) is now honored for these charts — preset narrows the X-axis.

## Motivation

User wanted to see live concurrency on the dashboard. While reviewing for accuracy, found that the existing `Metric::TurnActive` (short name `turns_active`) was misleadingly named: `tracker.active_count()` sums *pending LLM calls inside per-session turn buffers*, not open turns. A single turn with 5 concurrent calls contributes 5. Renaming clarifies the distinction.

## Changes

### Backend

- **ts-common**: `AggregateHistory` (bounded `VecDeque` ring) + `HistoryRecorder` (tokio task that samples every contributor `MetricsSvc` on a tick and pushes one summed frame).
- **ts-api**: `GET /api/internal-metrics/series` with `since` (epoch ms) and `metrics` (csv) query params.
- **main.rs**: wires `HistoryRecorder` over `[pipeline_svcs..., global_svc]`, attaches the history `Arc` to `ApiMetricsContext`, joins on shutdown.

### New gauge `agent_turns_open`

- Process-wide probe over `ActiveTurnRegistry.read().len()` registered on the **global** `MetricsSvc` (not per-pipeline — the registry is shared, a per-pipeline probe would multiply the reading).
- Old `Metric::TurnActive` short name renamed: `"turns_active"` → `"turn_calls_buffered"` to admit what it measures. Comment in `stage.rs` updated to disambiguate.

### Frontend

- `ActiveGaugeChart` wrapping `TimeseriesLineChart` (single-series, ms→s conversion).
- `useInternalMetricsSeries` hook honors toolbar `start` so preset switches narrow the chart's range.
- Overview adds a 2-up row above the existing Model Breakdown / Error by Model row.

## Tests

- ts-common: `aggregate_history_ring_evicts_oldest`, `aggregate_history_series_since_filter`, `aggregate_history_untracked_metric_yields_zero`, `history_recorder_sums_pipelines_and_global` (4 new).
- ts-api: `series_returns_tracked_metrics_by_default`, `series_honors_since_cutoff`, `series_filters_to_tracked_only_and_dedups`, `series_without_history_yields_empty_array` (4 new). Existing 2 InternalMetrics tests updated for the new `history` field.
- Full workspace `cargo test`: passes.
- Console `bun test`: 97 pass, 0 fail.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cd console && bun test && bun run build`
- [ ] Deploy to wuneng, confirm `agent_turns_open` and `flows_active` lines on `/api/internal-metrics/series`
- [ ] Open Dashboard, verify both charts populate within 10s and narrow when toolbar preset switches
- [ ] Verify the renamed `turn_calls_buffered` still shows in log lines