### PR TITLE
fix(ts-llm/chat-sse): capture delta.reasoning_content + delta.reasoning

### DIFF
--- a/console/src/components/call-renderers/openai-chat.tsx
+++ b/console/src/components/call-renderers/openai-chat.tsx
@@ -280,7 +280,7 @@ function MessageRow({ msg, index, overlay }: { msg: OpenAiChatMessage; index: nu
               tool_call_id: <span className="font-mono">{msg.tool_call_id}</span>
             </div>
           )}
-          <MessageContent content={msg.content} isUserText={msg.role === "user"} overlay={overlay} />
+          {/* Reasoning trace renders before the content it produced. */}
           {msg.reasoning_content && (
             <div className="rounded bg-purple-50/60 border border-purple-200 dark:bg-purple-900/10 dark:border-purple-900/40 p-2 text-[11px]">
               <div className="font-mono text-[9px] uppercase tracking-wider text-purple-700/80 dark:text-purple-400/80">reasoning_content</div>
@@ -289,6 +289,7 @@ function MessageRow({ msg, index, overlay }: { msg: OpenAiChatMessage; index: nu
               </pre>
             </div>
           )}
+          <MessageContent content={msg.content} isUserText={msg.role === "user"} overlay={overlay} />
           {msg.tool_calls && msg.tool_calls.map((tc, i) => <ToolCallView key={i} tc={tc} />)}
           {msg.refusal && (
             <div className="rounded border border-red-300 bg-red-50 p-2 text-[11px] text-red-700 dark:bg-red-900/20 dark:text-red-300">
@@ -540,7 +541,9 @@ function ChoiceCard({ choice, ctx }: { choice: OpenAiChatChoice; ctx?: OutputCtx
         <FinishReasonBadge reason={typeof choice.finish_reason === "string" ? choice.finish_reason : null} />
       </div>
       <div className="space-y-2">
-        <MessageContent content={choice.message.content} isUserText={false} />
+        {/* Render reasoning before content: the model thinks first, then
+            answers. The stored field order is not load-bearing — what
+            matters is matching the temporal flow of the response. */}
         {choice.message.reasoning_content && (
           <div className="rounded bg-purple-50/60 border border-purple-200 dark:bg-purple-900/10 dark:border-purple-900/40 p-2 text-[11px]">
             <div className="font-mono text-[9px] uppercase tracking-wider text-purple-700/80 dark:text-purple-400/80">reasoning_content</div>
@@ -549,6 +552,7 @@ function ChoiceCard({ choice, ctx }: { choice: OpenAiChatChoice; ctx?: OutputCtx
             </pre>
           </div>
         )}
+        <MessageContent content={choice.message.content} isUserText={false} />
         {choice.message.tool_calls?.map((tc, i) => <ToolCallView key={i} tc={tc} ctx={ctx} />)}
         {choice.message.refusal && (
           <div className="rounded border border-red-300 bg-red-50 p-2 text-[11px] text-red-700 dark:bg-red-900/20 dark:text-red-300">

--- a/server/ts-llm/src/wire_apis/openai/chat.rs
+++ b/server/ts-llm/src/wire_apis/openai/chat.rs
@@ -157,6 +157,17 @@ fn extract_sse(events: &[SseEventData]) -> (ResponseInfo, ParsedJson) {
     let mut model: Option<String> = None;
     let mut finish_reason: Option<String> = None;
     let mut content = String::new();
+    // Reasoning trace channels. Most reasoning-capable backends emit one of:
+    //   * `delta.reasoning_content` — DeepSeek-R1, Qwen3, Qwen3.5/3.6 with
+    //     `--reasoning-parser qwen3` on vLLM ≤ 0.16, SGLang.
+    //   * `delta.reasoning`         — vLLM ≥ 0.17 (field rename), some GLM
+    //     deployments.
+    // We accumulate them into separate buffers and emit both into the
+    // synthetic final message so `collect_chat_assistant_text` /
+    // `estimate_output_tokens` / the console renderer all see what the
+    // model actually sent.
+    let mut reasoning_content = String::new();
+    let mut reasoning = String::new();
     let mut tool_calls: BTreeMap<u64, (String, String, String)> = BTreeMap::new();
     let mut input_tokens: Option<u32> = None;
     let mut output_tokens: Option<u32> = None;
@@ -192,6 +203,12 @@ fn extract_sse(events: &[SseEventData]) -> (ResponseInfo, ParsedJson) {
             if let Some(delta) = choice.get("delta") {
                 if let Some(c) = delta.get("content").and_then(|v| v.as_str()) {
                     content.push_str(c);
+                }
+                if let Some(r) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
+                    reasoning_content.push_str(r);
+                }
+                if let Some(r) = delta.get("reasoning").and_then(|v| v.as_str()) {
+                    reasoning.push_str(r);
                 }
                 if let Some(tcs) = delta.get("tool_calls").and_then(|v| v.as_array()) {
                     for tc in tcs {
@@ -243,6 +260,8 @@ fn extract_sse(events: &[SseEventData]) -> (ResponseInfo, ParsedJson) {
         Some(build_synthetic_body(
             model.as_deref(),
             &content,
+            &reasoning_content,
+            &reasoning,
             tool_calls,
             finish_reason.as_deref(),
             input_tokens,
@@ -279,6 +298,8 @@ fn extract_sse(events: &[SseEventData]) -> (ResponseInfo, ParsedJson) {
 fn build_synthetic_body(
     model: Option<&str>,
     content: &str,
+    reasoning_content: &str,
+    reasoning: &str,
     tool_calls: BTreeMap<u64, (String, String, String)>,
     finish_reason: Option<&str>,
     input_tokens: Option<u32>,
@@ -289,6 +310,16 @@ fn build_synthetic_body(
     let mut message = json!({ "role": "assistant" });
     if !content.is_empty() {
         message["content"] = Value::String(content.to_string());
+    }
+    // Preserve both reasoning channels separately. Some backends emit one,
+    // some the other, a few echo both with identical text; `token_estimator`
+    // already dedupes when both are present, and the console renderer keys
+    // off `reasoning_content` first.
+    if !reasoning_content.is_empty() {
+        message["reasoning_content"] = Value::String(reasoning_content.to_string());
+    }
+    if !reasoning.is_empty() {
+        message["reasoning"] = Value::String(reasoning.to_string());
     }
     if !tool_calls.is_empty() {
         let tc_array: Vec<Value> = tool_calls
@@ -670,6 +701,115 @@ mod tests {
         assert_eq!(v["model"], "gpt-4");
         assert_eq!(v["choices"][0]["message"]["content"], "Hello world");
         assert_eq!(v["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn synthetic_body_captures_streamed_reasoning_content() {
+        // DeepSeek-R1 / Qwen3 native shape: reasoning trace arrives in
+        // `delta.reasoning_content`, then the final answer in `delta.content`.
+        let events = vec![
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Let me think"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"reasoning_content":" about this..."}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"content":"42"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            ),
+        ];
+        let (info, _body) = extract_sse(&events);
+        let body = info.response_body.expect("response_body");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        let msg = &v["choices"][0]["message"];
+        assert_eq!(msg["content"], "42");
+        assert_eq!(msg["reasoning_content"], "Let me think about this...");
+        assert!(msg.get("reasoning").is_none(), "should not invent a reasoning field");
+    }
+
+    #[test]
+    fn synthetic_body_captures_streamed_reasoning_alias() {
+        // vLLM ≥ 0.17 renamed the streaming field to `delta.reasoning`.
+        let events = vec![
+            make_sse(
+                "",
+                r#"{"model":"glm-5","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"step one,"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"glm-5","choices":[{"index":0,"delta":{"reasoning":" step two"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"glm-5","choices":[{"index":0,"delta":{"content":"done"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"glm-5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            ),
+        ];
+        let (info, _body) = extract_sse(&events);
+        let body = info.response_body.expect("response_body");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        let msg = &v["choices"][0]["message"];
+        assert_eq!(msg["content"], "done");
+        assert_eq!(msg["reasoning"], "step one, step two");
+        assert!(msg.get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn synthetic_body_streamed_reasoning_inflates_output_tokens() {
+        // Without server-reported usage, estimate_output_tokens walks the
+        // synthetic message — it must see reasoning_content, otherwise the
+        // total_output_tokens metric undercounts reasoning models.
+        use crate::token_estimator::TokenEstimator;
+        struct CharLen;
+        impl TokenEstimator for CharLen {
+            fn count_text(&self, s: &str) -> u32 { s.chars().count() as u32 }
+        }
+        let events_with = vec![
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"reasoning_content":"abcdefghij"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"content":"42"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            ),
+        ];
+        let (info_with, _) = extract_sse(&events_with);
+        let v_with: Value = serde_json::from_str(&info_with.response_body.unwrap()).unwrap();
+        let with_n = estimate_output_tokens(&v_with, &CharLen);
+
+        let events_without = vec![
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{"content":"42"}}]}"#,
+            ),
+            make_sse(
+                "",
+                r#"{"model":"qwen3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            ),
+        ];
+        let (info_without, _) = extract_sse(&events_without);
+        let v_without: Value = serde_json::from_str(&info_without.response_body.unwrap()).unwrap();
+        let plain_n = estimate_output_tokens(&v_without, &CharLen);
+
+        assert!(
+            with_n > plain_n,
+            "streamed reasoning_content must inflate output tokens (with={with_n} plain={plain_n})"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix a silent data loss in the SSE assembler for OpenAI Chat Completions: streaming reasoning-model responses had their chain-of-thought trace dropped on the floor.

## Background

`extract_sse` in `server/ts-llm/src/wire_apis/openai/chat.rs` walks each chunk's `choices[0].delta` and accumulates two fields — `content` and `tool_calls`. The synthetic `message` it builds at the end therefore *only* contained those two. Anything the model streamed via `delta.reasoning_content` (DeepSeek-R1 / Qwen3 / Qwen3.5 / Qwen3.6 with `--reasoning-parser qwen3` on vLLM ≤ 0.16, SGLang's `--reasoning-parser glm45`) or `delta.reasoning` (vLLM ≥ 0.17 field rename, some GLM deployments) was silently discarded.

Two downstream consequences:

1. **Console LLM Call detail page**: the purple `reasoning_content` panel that `openai-chat.tsx` renders stayed empty for streamed reasoning calls, making it look like the model never thought — when really it did, we just dropped it.
2. **`total_output_tokens` undercount**: when upstream doesn't include `usage.completion_tokens` (some sglang versions, certain GLM deployments), `estimate_output_tokens` walks the synthetic body to compute a token estimate. With reasoning text missing, every reasoning-model stream call's output count was systematically too low.

Non-streaming responses preserved reasoning verbatim (the body is stored as-is from the upstream JSON) so the bug was streaming-only.

## Changes

- `extract_sse`: two new string buffers (`reasoning_content`, `reasoning`) that absorb the corresponding `delta.*` fields each chunk.
- `build_synthetic_body`: two new parameters; emits `reasoning_content` / `reasoning` as separate fields on the final assistant message. Existing dedupe in `token_estimator::collect_chat_assistant_text` already handles servers that echo both with identical text.

## Tests

- `synthetic_body_captures_streamed_reasoning_content` — DeepSeek/Qwen3 native shape (`delta.reasoning_content`).
- `synthetic_body_captures_streamed_reasoning_alias` — vLLM ≥ 0.17 / GLM rename (`delta.reasoning`).
- `synthetic_body_streamed_reasoning_inflates_output_tokens` — regression for the token-undercount path.

Full ts-llm chat tests pass (33/33). Workspace `cargo test`: all green.

## Live verification

Deployed to wuneng and triggered a streaming GLM-5 call (`POST :9000/v1/chat/completions` with `stream=true`). Before this fix the stored `choices[0].message` was `{role:"assistant", content:""}`. After the fix:

```json
{
  "role": "assistant",
  "reasoning_content": "The user wants to know the product of 7 and 8.\nI need to calculate $7 \\times 8$..."
}
```

## Test plan

- [ ] `cargo test --workspace`
- [ ] Trigger a streaming reasoning call against any vLLM/SGLang deployment with a reasoning parser enabled
- [ ] Open the call in `/llm-calls/{id}` and verify the purple `reasoning_content` panel renders
- [ ] Confirm `output_tokens` for that call is meaningfully higher than just the `content` length