### PR TITLE
feat(filters): dynamic agent_kind dropdown from actual data in window

### DIFF
--- a/console/src/components/ui/agent-badge.tsx
+++ b/console/src/components/ui/agent-badge.tsx
@@ -3,6 +3,8 @@ import { cn } from "@/lib/utils"
 const COLOUR_BY_AGENT: Record<string, string> = {
   "claude-cli": "bg-emerald-500/20 text-emerald-700 dark:text-emerald-300 border-emerald-700/30",
   "codex-cli": "bg-orange-500/20 text-orange-700 dark:text-orange-300 border-orange-700/30",
+  openclaw: "bg-sky-500/20 text-sky-700 dark:text-sky-300 border-sky-700/30",
+  hermes: "bg-violet-500/20 text-violet-700 dark:text-violet-300 border-violet-700/30",
 }
 
 export function AgentBadge({ agentKind }: { agentKind: string }) {

--- a/console/src/hooks/use-filter-values.ts
+++ b/console/src/hooks/use-filter-values.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { apiFetch } from "@/lib/api"
+import { useToolbarStore } from "@/stores/toolbar"
 
 interface FilterValuesData {
   values: string[]
@@ -37,6 +38,23 @@ export function useModelNames(opts?: Options) {
 
 export function useServerIps(opts?: Options) {
   return useFilterValues("/api/filters/server-ips", opts)
+}
+
+/**
+ * Distinct `agent_kind` values observed in agent_turns inside the
+ * toolbar's current time range. Drives the agent-sessions / agent-turns
+ * filter dropdowns so options stay in sync with what was captured.
+ */
+export function useAgentKinds(opts?: Options) {
+  const start = useToolbarStore((s) => s.start)
+  const end = useToolbarStore((s) => s.end)
+  return useQuery({
+    queryKey: ["filter-values", "/api/filters/agent-kinds", start, end],
+    queryFn: () =>
+      apiFetch<FilterValuesData>("/api/filters/agent-kinds", { start, end }),
+    staleTime: 30_000,
+    enabled: opts?.enabled ?? true,
+  })
 }
 
 /**

--- a/console/src/pages/agent-sessions.tsx
+++ b/console/src/pages/agent-sessions.tsx
@@ -3,12 +3,11 @@ import { Link, useSearchParams } from "react-router"
 import { Loader2, Filter } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAgentSessions } from "@/hooks/use-agent-sessions"
+import { useAgentKinds } from "@/hooks/use-filter-values"
 import { formatNumber, formatDateTime, formatDuration } from "@/lib/format"
 import { FilterDropdown } from "@/components/ui/filter-dropdown"
 import { AgentBadge } from "@/components/ui/agent-badge"
 import type { SessionListItem } from "@/types/api"
-
-const AGENT_KIND_OPTIONS = ["claude-cli", "codex-cli", "generic"]
 
 function SessionRow({ item }: { item: SessionListItem }) {
   const [searchParams] = useSearchParams()
@@ -48,6 +47,8 @@ function SessionRow({ item }: { item: SessionListItem }) {
 
 export function AgentSessionsPage() {
   const [agentKindFilter, setAgentKindFilter] = useState<string[]>([])
+  const agentKindsQuery = useAgentKinds()
+  const agentKindOptions = agentKindsQuery.data?.values ?? []
 
   const { data, isLoading, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useAgentSessions({
@@ -64,7 +65,7 @@ export function AgentSessionsPage() {
         <span className="text-xs text-muted-foreground">Filters:</span>
         <FilterDropdown
           label="Agent kind"
-          options={AGENT_KIND_OPTIONS}
+          options={agentKindOptions}
           selected={agentKindFilter}
           onChange={setAgentKindFilter}
         />

--- a/console/src/pages/agent-turns.tsx
+++ b/console/src/pages/agent-turns.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react"
 import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight, Loader2, Filter } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAgentTurns } from "@/hooks/use-agent-turns"
+import { useAgentKinds } from "@/hooks/use-filter-values"
 import { useSearchParamState } from "@/hooks/use-search-param-state"
 import { formatDateTimeMs, formatNumber, formatDuration } from "@/lib/format"
 import { TurnStatusBadge } from "@/components/ui/turn-status-badge"
@@ -10,7 +11,6 @@ import { AgentTurnDetailPanel } from "./agent-turn-detail-panel"
 import type { AgentTurnListItem } from "@/types/api"
 
 const STATUS_OPTIONS = ["in_progress", "complete", "incomplete"]
-const AGENT_KIND_OPTIONS = ["claude-cli", "codex-cli", "generic"]
 
 const PAGE_SIZES = [20, 50, 100] as const
 
@@ -95,6 +95,9 @@ export function AgentTurnsPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
+  const agentKindsQuery = useAgentKinds()
+  const agentKindOptions = agentKindsQuery.data?.values ?? []
+
   const { data, isLoading, isError, error } = useAgentTurns({
     page,
     pageSize,
@@ -142,7 +145,7 @@ export function AgentTurnsPage() {
         />
         <FilterDropdown
           label="Agent kind"
-          options={AGENT_KIND_OPTIONS}
+          options={agentKindOptions}
           selected={agentKindFilter}
           onChange={(v) => {
             setAgentKindStr(v.join(","))

--- a/server/ts-api/src/lib.rs
+++ b/server/ts-api/src/lib.rs
@@ -142,6 +142,10 @@ pub fn router(
         .route("/api/filters/models", get(routes::filters::models))
         .route("/api/filters/server-ips", get(routes::filters::server_ips))
         .route(
+            "/api/filters/agent-kinds",
+            get(routes::filters::agent_kinds),
+        )
+        .route(
             "/api/filters/finish-reasons",
             get(routes::filters::finish_reasons),
         )

--- a/server/ts-api/src/routes/filters.rs
+++ b/server/ts-api/src/routes/filters.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::response::IntoResponse;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use ts_storage::query::DistinctFinishReason;
 use ts_storage::StorageBackend;
 
+use crate::params::to_time_range;
 use crate::response::{ApiError, ApiResponse};
 
 #[derive(Serialize)]
@@ -36,6 +37,23 @@ pub async fn server_ips(
     State(storage): State<Arc<dyn StorageBackend>>,
 ) -> Result<impl IntoResponse, ApiError> {
     let values = storage.query_distinct_server_ips().await?;
+    Ok(ApiResponse::ok(FilterValues { values }))
+}
+
+#[derive(Deserialize)]
+pub struct AgentKindsQuery {
+    pub start: i64,
+    pub end: i64,
+}
+
+pub async fn agent_kinds(
+    State(storage): State<Arc<dyn StorageBackend>>,
+    Query(params): Query<AgentKindsQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let range = to_time_range(params.start, params.end);
+    let values = storage
+        .query_distinct_agent_kinds(range.start_us, range.end_us)
+        .await?;
     Ok(ApiResponse::ok(FilterValues { values }))
 }
 

--- a/server/ts-storage-duckdb/src/distincts.rs
+++ b/server/ts-storage-duckdb/src/distincts.rs
@@ -2,6 +2,7 @@
 
 use ts_common::error::{AppError, Result};
 
+use crate::util::us_to_timestamp;
 use crate::DuckDbBackend;
 
 impl DuckDbBackend {
@@ -51,6 +52,45 @@ impl DuckDbBackend {
         .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
     }
 
+    pub(crate) async fn query_distinct_agent_kinds(
+        &self,
+        start_us: i64,
+        end_us: i64,
+    ) -> Result<Vec<String>> {
+        let conn = self.read_pool.acquire().await?;
+        tokio::task::spawn_blocking(move || {
+            let start_ts = us_to_timestamp(start_us);
+            let end_ts = us_to_timestamp(end_us);
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT agent_kind FROM agent_turns \
+                     WHERE start_time >= ? AND start_time < ? \
+                     ORDER BY agent_kind",
+                )
+                .map_err(|e| {
+                    AppError::Storage(format!("failed to prepare distinct_agent_kinds query: {e}"))
+                })?;
+            let mut rows = stmt
+                .query(duckdb::params![start_ts, end_ts])
+                .map_err(|e| {
+                    AppError::Storage(format!("failed to execute distinct_agent_kinds query: {e}"))
+                })?;
+            let mut result = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .map_err(|e| AppError::Storage(format!("row error: {e}")))?
+            {
+                let v: String = row
+                    .get(0)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
+                result.push(v);
+            }
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
+    }
+
     pub(crate) async fn query_distinct_server_ips(&self) -> Result<Vec<String>> {
         let conn = self.read_pool.acquire().await?;
         tokio::task::spawn_blocking(move || {
@@ -79,6 +119,7 @@ mod tests {
     use ts_llm::wire_apis as wa;
     use ts_metrics::model::LlmMetric;
     use ts_storage::StorageBackend;
+    use ts_turn::{AgentTurn, TurnStatus};
 
     fn in_memory() -> DuckDbBackend {
         DuckDbBackend::open(":memory:").unwrap()
@@ -205,4 +246,63 @@ mod tests {
         assert_eq!(server_ips, vec!["10.0.0.1", "10.0.0.2"]);
     }
 
+    fn agent_turn(turn_id: &str, agent_kind: &str, start_us: i64) -> AgentTurn {
+        AgentTurn {
+            source_id: String::new(),
+            turn_id: turn_id.into(),
+            session_id: "s".into(),
+            wire_api: wa::OPENAI_CHAT.to_string(),
+            agent_kind: agent_kind.into(),
+            client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
+            server_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
+            start_time_us: start_us,
+            end_time_us: start_us + 1_000_000,
+            duration_ms: 1_000,
+            call_count: 1,
+            models_used: vec!["m".into()],
+            subagents_used: vec![],
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            total_cost_usd: None,
+            status: TurnStatus::Complete,
+            final_finish_reason: None,
+            user_input_preview: None,
+            user_call_id: None,
+            final_answer_preview: None,
+            final_call_id: None,
+            call_ids: vec!["c".into()],
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_query_distinct_agent_kinds_filters_by_time_and_dedupes() {
+        let backend = in_memory();
+        backend.init().await.unwrap();
+
+        backend
+            .write_turns(vec![
+                agent_turn("t1", "claude-cli", 1_700_000_000_000_000),
+                agent_turn("t2", "openclaw", 1_700_000_010_000_000),
+                agent_turn("t3", "claude-cli", 1_700_000_020_000_000), // duplicate kind
+                agent_turn("t4", "codex-cli", 1_600_000_000_000_000), // outside range
+            ])
+            .await
+            .unwrap();
+
+        let kinds = backend
+            .query_distinct_agent_kinds(1_700_000_000_000_000, 1_700_000_100_000_000)
+            .await
+            .unwrap();
+        assert_eq!(kinds, vec!["claude-cli", "openclaw"]);
+
+        // Empty when range excludes all rows.
+        let kinds_empty = backend
+            .query_distinct_agent_kinds(2_000_000_000_000_000, 2_100_000_000_000_000)
+            .await
+            .unwrap();
+        assert!(kinds_empty.is_empty());
+    }
 }

--- a/server/ts-storage-duckdb/src/lib.rs
+++ b/server/ts-storage-duckdb/src/lib.rs
@@ -222,6 +222,14 @@ impl StorageBackend for DuckDbBackend {
         DuckDbBackend::query_distinct_server_ips(self).await
     }
 
+    async fn query_distinct_agent_kinds(
+        &self,
+        start_us: i64,
+        end_us: i64,
+    ) -> Result<Vec<String>> {
+        DuckDbBackend::query_distinct_agent_kinds(self, start_us, end_us).await
+    }
+
     async fn query_distinct_finish_reasons(&self) -> Result<Vec<DistinctFinishReason>> {
         DuckDbBackend::query_distinct_finish_reasons(self).await
     }

--- a/server/ts-storage/src/backend.rs
+++ b/server/ts-storage/src/backend.rs
@@ -95,6 +95,13 @@ pub trait StorageBackend: Send + Sync {
     async fn query_distinct_models(&self) -> Result<Vec<String>>;
     async fn query_distinct_server_ips(&self) -> Result<Vec<String>>;
 
+    /// Distinct `agent_kind` values seen in `agent_turns` whose `start_time`
+    /// falls in `[start_us, end_us)`. Empty range ⇒ empty result. Used by
+    /// the agent-sessions / agent-turns filter dropdowns so options stay in
+    /// sync with what was actually captured in the visible window.
+    async fn query_distinct_agent_kinds(&self, start_us: i64, end_us: i64)
+        -> Result<Vec<String>>;
+
     /// Distinct `(wire_api, finish_reason)` pairs observed in
     /// `llm_finish_metrics`. Excludes the `*` rollup tiers. Used by the calls
     /// page filter dropdown to populate options dynamically — values are raw

--- a/server/ts-storage/src/sink.rs
+++ b/server/ts-storage/src/sink.rs
@@ -360,6 +360,13 @@ mod tests {
         async fn query_distinct_server_ips(&self) -> Result<Vec<String>> {
             Ok(vec![])
         }
+        async fn query_distinct_agent_kinds(
+            &self,
+            _start_us: i64,
+            _end_us: i64,
+        ) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
         async fn query_distinct_finish_reasons(&self) -> Result<Vec<DistinctFinishReason>> {
             Ok(vec![])
         }


### PR DESCRIPTION
## Summary

* Hard-coded \`[\"claude-cli\", \"codex-cli\", \"generic\"]\` in agent-sessions and agent-turns drifted from reality — once \`openclaw\` and \`hermes\` started getting detected, capture showed data the dropdown could not select.
* Replace with a backend distinct-query gated on the toolbar's time window: only kinds with at least one turn whose \`start_time\` falls in \`[start, end)\` appear. New kinds show up the moment they land in \`agent_turns\`; obsolete ones disappear once they age out.

## Changes

| Layer | Change |
|---|---|
| \`ts-storage\` trait | \`query_distinct_agent_kinds(start_us, end_us) -> Vec<String>\` |
| \`ts-storage-duckdb\` | \`SELECT DISTINCT agent_kind FROM agent_turns WHERE start_time >= ? AND start_time < ? ORDER BY agent_kind\` + unit test (time filter + dedupe + empty range) |
| \`ts-api\` | \`GET /api/filters/agent-kinds?start=&end=\` (unix-second params, mirrors existing endpoints) |
| \`console\` | \`useAgentKinds()\` hook subscribed to toolbar; both pages drop the const, use hook |
| \`console\` (palette) | \`AgentBadge\` gains \`openclaw\` (sky) + \`hermes\` (violet) colours |

## Verification

* \`cargo test -p ts-storage-duckdb distincts\` — 4 pass (including new \`test_query_distinct_agent_kinds_filters_by_time_and_dedupes\`)
* \`bun test\` (console) — 97 pass
* Live on wuneng (24h window):
  \`\`\`
  $ curl /api/filters/agent-kinds?start=…&end=…
  {\"code\":0,\"message\":\"ok\",\"data\":{\"values\":[\"claude-cli\",\"generic\",\"hermes\",\"openclaw\"]}}
  \`\`\`
  No \`codex-cli\` because none ever ran here — that's the point.

## Test plan

- [ ] Open \`/agent-sessions\` and \`/agent-turns\` with a recent toolbar range; dropdown shows only kinds that have rows in the window
- [ ] Change toolbar to a range that excludes a kind; that kind disappears from the dropdown
- [ ] Pick a kind, confirm the listing filters to it
- [ ] \`openclaw\` and \`hermes\` rows render with distinct badge colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)