### PR TITLE
feat(console/list-pages): persist selected item id in URL

### DIFF
--- a/console/src/pages/agent-turns.tsx
+++ b/console/src/pages/agent-turns.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useCallback } from "react"
 import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight, Loader2, Filter } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAgentTurns } from "@/hooks/use-agent-turns"
@@ -93,7 +93,7 @@ export function AgentTurnsPage() {
   const statusFilter = statusStr ? statusStr.split(",") : []
   const agentKindFilter = agentKindStr ? agentKindStr.split(",") : []
 
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useSearchParamState("selected", "")
 
   const { data, isLoading, isError, error } = useAgentTurns({
     page,
@@ -283,7 +283,7 @@ export function AgentTurnsPage() {
 
       {/* Slide-over detail panel */}
       {selectedId && (
-        <AgentTurnDetailPanel id={selectedId} onClose={() => setSelectedId(null)} />
+        <AgentTurnDetailPanel id={selectedId} onClose={() => setSelectedId("")} />
       )}
     </div>
   )

--- a/console/src/pages/http-exchanges.tsx
+++ b/console/src/pages/http-exchanges.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useCallback } from "react"
 import {
   ArrowUpDown,
   ArrowUp,
@@ -131,8 +131,7 @@ export function HttpExchangesPage() {
   const statusFilter = statusStr ? statusStr.split(",") : []
   const isSse = sseStr === "true" ? true : sseStr === "false" ? false : undefined
 
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const [selectedId, setSelectedId] = useSearchParamState("selected", "")
 
   const { data, isLoading, isError, error } = useHttpExchanges({
     page,
@@ -166,26 +165,33 @@ export function HttpExchangesPage() {
     [sortBy, sortOrder, setSortBy, setSortOrder, setPageStr],
   )
 
-  const handleRowClick = useCallback((id: string, index: number) => {
-    setSelectedId(id)
-    setSelectedIndex(index)
-  }, [])
+  // Index derived from id so the selection survives URL paste / refresh:
+  // we own only one source of truth (the URL), and prev/next still works
+  // as long as the selected id is on the current page.
+  const selectedIndex = selectedId
+    ? items.findIndex((i) => i.id === selectedId)
+    : -1
+
+  const handleRowClick = useCallback(
+    (id: string, _index: number) => {
+      setSelectedId(id)
+    },
+    [setSelectedId],
+  )
 
   const handleNavigate = useCallback(
     (direction: "prev" | "next") => {
       const newIndex = direction === "prev" ? selectedIndex - 1 : selectedIndex + 1
       if (newIndex >= 0 && newIndex < items.length) {
-        setSelectedIndex(newIndex)
         setSelectedId(items[newIndex].id)
       }
     },
-    [selectedIndex, items],
+    [selectedIndex, items, setSelectedId],
   )
 
   const handleClose = useCallback(() => {
-    setSelectedId(null)
-    setSelectedIndex(-1)
-  }, [])
+    setSelectedId("")
+  }, [setSelectedId])
 
   return (
     <div className="relative flex h-full flex-col">

--- a/console/src/pages/llm-calls.tsx
+++ b/console/src/pages/llm-calls.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight, Loader2, Filter } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useLlmCalls } from "@/hooks/use-llm-calls"
@@ -145,8 +145,7 @@ export function LlmCallsPage() {
       .map(([label, options]) => ({ label, options: [...options].sort() }))
   }, [finishReasonsData])
 
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const [selectedId, setSelectedId] = useSearchParamState("selected", "")
 
   const { data, isLoading, isError, error } = useLlmCalls({
     page,
@@ -179,26 +178,33 @@ export function LlmCallsPage() {
     [sortBy, sortOrder, setSortBy, setSortOrder, setPageStr],
   )
 
-  const handleRowClick = useCallback((id: string, index: number) => {
-    setSelectedId(id)
-    setSelectedIndex(index)
-  }, [])
+  // Index derived from id so the selection survives URL paste / refresh:
+  // we own only one source of truth (the URL), and prev/next still works
+  // as long as the selected id is on the current page.
+  const selectedIndex = selectedId
+    ? items.findIndex((i) => i.id === selectedId)
+    : -1
+
+  const handleRowClick = useCallback(
+    (id: string, _index: number) => {
+      setSelectedId(id)
+    },
+    [setSelectedId],
+  )
 
   const handleNavigate = useCallback(
     (direction: "prev" | "next") => {
       const newIndex = direction === "prev" ? selectedIndex - 1 : selectedIndex + 1
       if (newIndex >= 0 && newIndex < items.length) {
-        setSelectedIndex(newIndex)
         setSelectedId(items[newIndex].id)
       }
     },
-    [selectedIndex, items],
+    [selectedIndex, items, setSelectedId],
   )
 
   const handleClose = useCallback(() => {
-    setSelectedId(null)
-    setSelectedIndex(-1)
-  }, [])
+    setSelectedId("")
+  }, [setSelectedId])
 
   return (
     <div className="relative flex h-full flex-col">


### PR DESCRIPTION
## Summary

Agent Turns, LLM Calls, and HTTP Exchanges keep the slide-over detail's open id in **React state**, so copying the URL or hitting refresh drops the selection and reopens the list with no panel. Every other filter on those pages already round-trips through the URL via \`useSearchParamState\`; this is the one holdout.

Move the selected id onto a \`?selected=<id>\` query param backed by the same hook. Now:

* **Copy URL** lands a recipient on the same row with the panel open.
* **Refresh / back-forward** restores the panel.
* **Close panel** removes the param (empty string is the default → the hook drops the key).

## Implementation detail

LLM Calls and HTTP Exchanges also tracked \`selectedIndex\` (for the panel's prev/next buttons). That state was redundant — the index is now **derived** from \`items.findIndex(i => i.id === selectedId)\`. One source of truth (the URL); prev/next still works as long as the selected id is on the current page.

If the URL points to an id that isn't on the visible page (e.g. someone pasted a link with a different filter or stale time range), the prev/next buttons naturally disable (\`index = -1\`) but the detail still loads — the panel queries by id rather than indexing into the list.

## Verification

* \`bun test\` — 97 pass
* \`npm run build\` — green
* Deployed to wuneng (new bundle index-_yoJkBO2.js); panel opens / closes / survives refresh on all three pages

## Test plan

- [ ] Open a row in Agent Turns → URL gains \`?selected=<turn_id>\`
- [ ] Copy URL into a new tab → list opens with that row's detail panel
- [ ] Refresh while the panel is open → panel stays open on the same row
- [ ] Close the panel → \`selected\` param disappears from the URL
- [ ] Same flow on LLM Calls and HTTP Exchanges
- [ ] On LLM Calls, prev/next buttons still work; disable correctly at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)