### PR TITLE
fix(console/agent-sessions): keep prior data during refetch (no flash)

### DIFF
--- a/console/src/hooks/use-agent-sessions.ts
+++ b/console/src/hooks/use-agent-sessions.ts
@@ -31,6 +31,12 @@ export function useAgentSessions({ agentKind, pageSize = DEFAULT_PAGE_SIZE }: Us
         cursor: pageParam || undefined,
       }),
     getNextPageParam: (last) => last.next_cursor ?? undefined,
+    // Keep the previously-loaded pages visible while a background
+    // refetch (auto-refresh, window-focus, query-key churn) is in
+    // flight. Every other list hook in the app does this — without
+    // it the Sessions page blanks out and re-renders the whole list
+    // each refresh tick, while other pages do a frame-perfect swap.
+    placeholderData: (prev) => prev,
   })
 }
 
@@ -42,6 +48,7 @@ export function useAgentSessionDetail(sourceId: string | null, sessionId: string
         `/api/agent-sessions/${encodeURIComponent(sourceId!)}/${encodeURIComponent(sessionId!)}`,
       ),
     enabled: sourceId != null && sessionId != null,
+    placeholderData: (prev) => prev,
   })
 }
 
@@ -63,5 +70,6 @@ export function useSessionTurns(
         },
       ),
     getNextPageParam: (last) => last.next_cursor ?? undefined,
+    placeholderData: (prev) => prev,
   })
 }


### PR DESCRIPTION
## Summary

Add `placeholderData: (prev) => prev` to the three Agent Session list hooks so the Sessions page does an in-place swap on refetch — same behavior as Agent Turns / LLM Calls / Metrics / every other list page.

## Why

User report: \"Agent Session 界面每次刷新都会重刷整个页面，而不是像其他页面一样看上去重刷幅度很小\".

Every other list hook in the app sets `placeholderData: (prev) => prev`. The Agent Session hooks didn't — so every auto-refresh tick / toolbar key change wiped the cache to `undefined`, the page rendered its loading skeleton, then the new data dropped in. The user saw a full-page flash where every other page did a smooth swap.

## Files

- `console/src/hooks/use-agent-sessions.ts` — three hooks (`useAgentSessions`, `useAgentSessionDetail`, `useSessionTurns`) each get the same one-liner.

## Test plan

- [x] `bun test` — 111 pass
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)