### PR TITLE
fix(pr-review): keep http_proxy; only set no_proxy

### DIFF
--- a/.github/workflows/pr-review-probe.yml
+++ b/.github/workflows/pr-review-probe.yml
@@ -18,21 +18,20 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
       ANTHROPIC_MODEL: claude-3-5-sonnet-20241022
     steps:
-      - name: Override inherited HTTP proxy
-        # Runner ships with http_proxy=<internal apt proxy> baked into
-        # /etc/environment by cloud-init. curl on Linux honors the
-        # lowercase no_proxy and ignores the GH-Actions-set NO_PROXY
-        # (uppercase); GH Actions deduplicates env keys
-        # case-insensitively, so we can't set both at job level.
-        # Workaround: punch the right values into $GITHUB_ENV from a
-        # setup step. Empty `http_proxy` / `https_proxy` cancels the
-        # inherited proxy; lowercase `no_proxy` is what curl reads.
+      - name: Configure no_proxy for LiteLLM
+        # Runner ships with http_proxy=<internal egress proxy> baked
+        # into /etc/environment by cloud-init — that's required for
+        # the runner and gh CLI to reach api.github.com. We just need
+        # to make sure curl / claude CLI talking to the in-cluster
+        # LiteLLM host bypasses the proxy.
+        #
+        # curl on Linux reads lowercase `no_proxy` and ignores the
+        # GH-Actions-set uppercase NO_PROXY; GH Actions deduplicates
+        # env keys case-insensitively, so we can't set both at job
+        # level. Workaround: punch both case variants into $GITHUB_ENV
+        # from this setup step.
         run: |
           {
-            echo "http_proxy="
-            echo "https_proxy="
-            echo "HTTP_PROXY="
-            echo "HTTPS_PROXY="
             echo "no_proxy=${{ secrets.LITELLM_NO_PROXY }}"
             echo "NO_PROXY=${{ secrets.LITELLM_NO_PROXY }}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -56,18 +56,13 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
       ANTHROPIC_MODEL: claude-3-5-sonnet-20241022
     steps:
-      - name: Override inherited HTTP proxy
-        # See pr-review-probe.yml for the explanation — the runner
-        # has http_proxy baked into /etc/environment by cloud-init,
-        # and GH Actions deduplicates env keys case-insensitively
-        # so we can't set both NO_PROXY + no_proxy at job level.
-        # Punch the right values into $GITHUB_ENV from a setup step.
+      - name: Configure no_proxy for LiteLLM
+        # See pr-review-probe.yml. We keep the cloud-init-installed
+        # http_proxy intact (gh CLI needs it to reach api.github.com)
+        # and only ensure no_proxy lists the in-cluster LiteLLM host
+        # so curl / claude CLI go direct there.
         run: |
           {
-            echo "http_proxy="
-            echo "https_proxy="
-            echo "HTTP_PROXY="
-            echo "HTTPS_PROXY="
             echo "no_proxy=${{ secrets.LITELLM_NO_PROXY }}"
             echo "NO_PROXY=${{ secrets.LITELLM_NO_PROXY }}"
           } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Probe `26157047130` failed at `gh CLI authenticated` with TLS handshake timeout to api.github.com.
- Root cause: my previous fix blanked `http_proxy`/`https_proxy`, but the runner needs the cloud-init proxy to reach the public internet (gh, npm, apt).
- LiteLLM (in-cluster) just needs to be in `no_proxy` — leave `http_proxy` alone.

## Test plan
- [ ] Merge, re-run `pr-review-probe`, expect all 7 steps green.