### PR TITLE
fix(pr-review): overlay reviewer scripts from default branch

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -100,6 +100,17 @@ jobs:
       - name: Fetch base for diff
         run: git fetch origin "${{ steps.pr.outputs.base_ref }}" --depth 200
 
+      - name: Overlay reviewer scripts from default branch
+        # PRs older than the AI-reviewer feature don't carry
+        # scripts/pr-review/ on their head. Always overlay the latest
+        # reviewer scripts from the default branch so we run a single
+        # canonical reviewer regardless of PR vintage. The PR head's
+        # source tree is left otherwise untouched — the agent still
+        # sees the code under review, not main's code.
+        run: |
+          git fetch origin "${{ github.event.repository.default_branch }}" --depth 1
+          git checkout "origin/${{ github.event.repository.default_branch }}" -- scripts/pr-review
+
       - name: Run review agent
         id: review
         env:


### PR DESCRIPTION
## Summary
- Old PRs (#19–#29) predate \`scripts/pr-review/\`, so all 10 dispatched pr-review runs failed at \`Run review agent\` with \`No such file or directory\`.
- Fix: after checkout PR head + fetch base, also \`git checkout origin/main -- scripts/pr-review\` to overlay the latest reviewer scripts. PR's source under review stays untouched.

## Test plan
- [ ] Merge.
- [ ] Re-dispatch pr-review on PR #19. Expect "Run review agent" green, an APPROVE / REQUEST_CHANGES verdict posted, auto-merge attempted for vaderyang-authored PRs.