### PR TITLE
fix(pr-review): never APPROVE on agent failure / unstructured body

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -100,6 +100,17 @@ jobs:
       - name: Fetch base for diff
         run: git fetch origin "${{ steps.pr.outputs.base_ref }}" --depth 200
 
+      - name: Overlay reviewer scripts from default branch
+        # PRs older than the AI-reviewer feature don't carry
+        # scripts/pr-review/ on their head. Always overlay the latest
+        # reviewer scripts from the default branch so we run a single
+        # canonical reviewer regardless of PR vintage. The PR head's
+        # source tree is left otherwise untouched — the agent still
+        # sees the code under review, not main's code.
+        run: |
+          git fetch origin "${{ github.event.repository.default_branch }}" --depth 1
+          git checkout "origin/${{ github.event.repository.default_branch }}" -- scripts/pr-review
+
       - name: Run review agent
         id: review
         env:

--- a/scripts/pr-review/post_review.py
+++ b/scripts/pr-review/post_review.py
@@ -62,11 +62,27 @@ def pick_event(body: str) -> str:
     """Choose the gh-review event from section presence.
 
     Priority:
+      * agent run failed OR body has no markdown structure → COMMENT
+        (never approve a failed run)
       * agent explicitly said "REQUEST_CHANGES" / "APPROVE" / "COMMENT"
         in the Summary → trust the agent
       * else: Blocking → REQUEST_CHANGES; Suggestions/Questions only →
         COMMENT; nothing → APPROVE.
     """
+    # Hard guard: if the agent itself bailed out (workflow step failed)
+    # or wrote a bare ERROR line, do NOT issue an APPROVE — the body
+    # may not have any of the structured sections below and would
+    # otherwise fall through to the default-APPROVE branch.
+    if AGENT_EXIT == "failure":
+        return "COMMENT"
+    stripped = body.lstrip()
+    if stripped.startswith("ERROR:") or stripped.startswith("ERROR "):
+        return "COMMENT"
+    if "### " not in body:
+        # No markdown headings at all — treat as a free-form note,
+        # not a verdict.
+        return "COMMENT"
+
     summary_pat = re.compile(
         r"^###\s+Summary\s*\n(.*?)(?=^###\s+|\Z)",
         re.MULTILINE | re.DOTALL,

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -35,8 +35,11 @@ envsubst < "$WORKDIR/prompt.md" > "$PROMPT"
 if ! curl -fsS --max-time 5 \
     -H "Authorization: Bearer ${ANTHROPIC_API_KEY:-}" \
     "${ANTHROPIC_BASE_URL:-}/v1/models" >/dev/null 2>&1; then
-  echo "ERROR: LiteLLM unreachable or auth failed at ${ANTHROPIC_BASE_URL:-<unset>}" \
-    | tee "$OUT" >&2
+  # Keep the LLM-endpoint URL out of the PR-visible OUT file; full
+  # details are in the workflow log.
+  echo "ERROR: LiteLLM unreachable or auth failed (see workflow log)" \
+    > "$OUT"
+  echo "pre-flight: LiteLLM unreachable at ${ANTHROPIC_BASE_URL:-<unset>}" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- Re-running the AI reviewer against old PRs surfaced two bugs:
  1. \`pick_event\` defaulted to \`APPROVE\` when the agent body had no \`### Blocking\` / \`### Suggestions\` / \`### Questions\` section. A pre-flight failure that wrote a bare \`ERROR: ...\` line therefore posted as \`--approve\` and (worse) would trigger auto-merge for trusted authors.
  2. The pre-flight error message included the LiteLLM base URL, leaking an internal IP into PR-visible review bodies.
- Fix: \`pick_event\` returns \`COMMENT\` if \`AGENT_EXIT=failure\`, body starts with \`ERROR:\`, or body has no markdown headings. \`run_review.sh\` writes a sanitized message to the OUT file; full URL stays in the workflow log only.

## Test plan
- [ ] Merge.
- [ ] Re-dispatch pr-review on all open PRs; verify any failure path posts as \`COMMENT\`, not \`APPROVE\`.
- [ ] Dismiss bogus APPROVED reviews on #29 and #23.