### PR TITLE
fix(pr-review): brand as "vivi"; never post failures to PR

### DIFF
--- a/scripts/pr-review/post_review.py
+++ b/scripts/pr-review/post_review.py
@@ -158,21 +158,29 @@ def auto_merge(number: str) -> None:
 
 
 def main() -> int:
+    # Agent-failure path: keep failure details out of the PR entirely.
+    # Operators read workflow logs for diagnostics; PR readers should
+    # never see "Agent run failed" / "agent unavailable" / etc. — those
+    # comments are noise to anyone watching the PR and leak nothing
+    # useful to authors.
+    if AGENT_EXIT == "failure":
+        print("agent run failed — not posting to PR (see workflow log)")
+        return 0
+
     body = read_review()
     if not body:
-        if AGENT_EXIT == "failure":
-            body = (
-                "### Summary\n"
-                "Agent run failed before producing output. "
-                f"See [workflow run]({RUN_URL}) for the agent log."
-            )
-        else:
-            print("no review body — skipping post")
-            return 0
+        print("no review body — skipping post")
+        return 0
+
+    # Bare body if it starts with ERROR — that's a pre-flight signal,
+    # also belongs in workflow logs only.
+    if body.lstrip().startswith("ERROR"):
+        print("agent reported pre-flight error — not posting to PR")
+        return 0
 
     footer = (
         "\n\n---\n"
-        "🤖 Reviewed by **glm-5** via LiteLLM • "
+        "🤖 Reviewed by **vivi** • "
         f"[workflow run]({RUN_URL})"
     )
     full = body + footer

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -35,11 +35,15 @@ envsubst < "$WORKDIR/prompt.md" > "$PROMPT"
 if ! curl -fsS --max-time 5 \
     -H "Authorization: Bearer ${ANTHROPIC_API_KEY:-}" \
     "${ANTHROPIC_BASE_URL:-}/v1/models" >/dev/null 2>&1; then
-  # Keep the LLM-endpoint URL out of the PR-visible OUT file; full
-  # details are in the workflow log.
-  echo "ERROR: LiteLLM unreachable or auth failed (see workflow log)" \
-    > "$OUT"
-  echo "pre-flight: LiteLLM unreachable at ${ANTHROPIC_BASE_URL:-<unset>}" >&2
+  # Pre-flight diagnostics MUST stay local — `post_review.py` is
+  # gated to skip posting when the agent exits non-zero, so this
+  # OUT file is consumed only by the workflow log. Endpoint URL +
+  # full curl trace go to the workflow log on the next two lines.
+  echo "ERROR: agent unavailable (pre-flight)" > "$OUT"
+  echo "pre-flight: backend unreachable at ${ANTHROPIC_BASE_URL:-<unset>}" >&2
+  curl -v --max-time 5 \
+    -H "Authorization: Bearer ${ANTHROPIC_API_KEY:-}" \
+    "${ANTHROPIC_BASE_URL:-}/v1/models" >&2 2>&1 || true
   exit 2
 fi
 
@@ -71,10 +75,10 @@ timeout 1800 claude \
   || {
     rc=$?
     echo "ERROR: agent exited with code $rc" >> "$LOG"
-    if [ ! -s "$OUT" ]; then
-      printf '### Summary\nAgent run failed (exit %d). See workflow logs.\n' \
-        "$rc" > "$OUT"
-    fi
+    # Don't synthesize a PR-bound failure summary here — post_review.py
+    # is gated on AGENT_EXIT and will skip the PR entirely on non-zero.
+    # The OUT file is left as-is (possibly empty) for workflow-log
+    # consumption.
     exit "$rc"
   }
 


### PR DESCRIPTION
## Summary
- Rebrand reviewer footer to \`🤖 Reviewed by **vivi**\` — no model name, no backend, no internal host.
- On agent failure (\`AGENT_EXIT=failure\` or pre-flight \`ERROR\`), post NOTHING to the PR; full diagnostics go to the workflow log.

## Test plan
- [ ] Merge.
- [ ] Re-dispatch reviews; success path posts as vivi, failure path leaves the PR untouched.
- [ ] Scrub existing bot review bodies on all PRs to remove any old leaks.