### PR TITLE
ci: opt all JS actions into Node.js 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
   test:
     runs-on: [self-hosted, tokenscope]
     timeout-minutes: 25
+    env:
+      # actions/checkout@v4 ships Node 20; GitHub is deprecating
+      # Node 20 on runners. Opt JS actions into Node 24 so each run
+      # doesn't annotate with the deprecation warning.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-review-probe.yml
+++ b/.github/workflows/pr-review-probe.yml
@@ -17,6 +17,7 @@ jobs:
       ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
       ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
       ANTHROPIC_MODEL: claude-3-5-sonnet-20241022
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Configure no_proxy for LiteLLM
         # Runner ships with http_proxy=<internal egress proxy> baked

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -55,6 +55,11 @@ jobs:
       ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
       ANTHROPIC_API_KEY: ${{ secrets.LITELLM_API_KEY }}
       ANTHROPIC_MODEL: claude-3-5-sonnet-20241022
+      # actions/checkout@v4 ships a Node 20 runtime; GitHub is
+      # deprecating Node 20 on runners. Opt the JS actions into the
+      # Node 24 runtime so the workflow doesn't annotate every run
+      # with a deprecation warning.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Configure no_proxy for LiteLLM
         # See pr-review-probe.yml. We keep the cloud-init-installed


### PR DESCRIPTION
Already done in release.yml — propagate `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to ci.yml + both pr-review workflows so PR check listings stop showing the Node 20 deprecation annotation.