### PR TITLE
Fix generic agent turn grouping

### DIFF
--- a/server/ts-llm/src/agents/generic.rs
+++ b/server/ts-llm/src/agents/generic.rs
@@ -1,7 +1,6 @@
-//! Generic agent profile — synthesizes a session id from the request /
-//! response payload alone, so TokenScope produces `AgentTurn`s for header-less
-//! LLM traffic across all three supported wire APIs (Anthropic Messages,
-//! OpenAI Chat Completions, OpenAI Responses).
+//! Generic agent profile — synthesizes a session id from request / response
+//! payload tool-call anchors, so TokenScope can still produce `AgentTurn`s for
+//! header-less tool-using LLM traffic across supported wire APIs.
 //!
 //! `agent_kind == "generic"` is wire-api-agnostic; downstream consumers read
 //! `wire_api` separately. Per-shape parsing lives in `wire_apis::{anthropic,
@@ -12,10 +11,85 @@ use crate::profile::{AgentProfile, CallCtx, SessionIdExtraction};
 use crate::wire_api_registry::WireApiRegistry;
 use crate::wire_apis as wa;
 
-use super::session_id::{compose_session_id_tracked, synth_helper_session_id};
+use super::session_id::compose_session_id_tracked;
 use crate::wire_apis::AssistantSig;
 
 pub struct GenericProfile;
+
+fn extract_tool_anchored_sig(ctx: &CallCtx<'_>) -> Option<(String, AssistantSig)> {
+    let req = ctx.req?;
+    // Track three pieces per wire api:
+    //   * user_text   — first user message; required to compose stable
+    //                   tool-call session ids.
+    //   * sig_in_req  — Some(sig) if an assistant message already lives
+    //                   inside `req.messages[*]` / `req.input[*]`. This
+    //                   tells us the call belongs to a multi-turn
+    //                   conversation; the caller has already established
+    //                   a stable anchor we can hash.
+    //   * sig_in_resp — Some(sig) only when sig_in_req is None and the
+    //                   response carries the assistant turn for the
+    //                   first user message.
+    let (user_text, sig_in_req, sig_in_resp) = match ctx.call.wire_api {
+        wa::ANTHROPIC => {
+            let user_text = wa::anthropic::first_user_text(req)?;
+            let sig_in_req = wa::anthropic::first_assistant_sig_from_request(req);
+            let sig_in_resp = if sig_in_req.is_none() {
+                ctx.resp
+                    .and_then(wa::anthropic::first_assistant_sig_from_response_value)
+            } else {
+                None
+            };
+            (user_text, sig_in_req, sig_in_resp)
+        }
+        wa::OPENAI_CHAT => {
+            let user_text = wa::openai::chat::first_user_text(req)?;
+            let sig_in_req = wa::openai::chat::first_assistant_sig_from_request(req);
+            let sig_in_resp = if sig_in_req.is_none() {
+                ctx.resp
+                    .and_then(wa::openai::chat::first_assistant_sig_from_response_value)
+            } else {
+                None
+            };
+            (user_text, sig_in_req, sig_in_resp)
+        }
+        wa::OPENAI_RESPONSES => {
+            let (user_text, sig_in_req) = match req.get("input")? {
+                serde_json::Value::Array(items) => (
+                    wa::openai::responses::first_user_text(items),
+                    wa::openai::responses::first_assistant_sig_from_input(items),
+                ),
+                serde_json::Value::String(s) if !s.trim().is_empty() => (Some(s.clone()), None),
+                _ => (None, None),
+            };
+            let user_text = user_text?;
+            let sig_in_resp = if sig_in_req.is_none() {
+                ctx.resp
+                    .and_then(wa::openai::responses::first_assistant_sig_from_response_value)
+            } else {
+                None
+            };
+            (user_text, sig_in_req, sig_in_resp)
+        }
+        wa::GEMINI_AISTUDIO => {
+            let user_text = wa::gemini_aistudio::first_user_text(req)?;
+            let sig_in_req = wa::gemini_aistudio::first_assistant_sig_from_request(req);
+            let sig_in_resp = if sig_in_req.is_none() {
+                ctx.resp
+                    .and_then(wa::gemini_aistudio::first_assistant_sig_from_response_value)
+            } else {
+                None
+            };
+            (user_text, sig_in_req, sig_in_resp)
+        }
+        _ => return None,
+    };
+
+    let sig = sig_in_req.or(sig_in_resp)?;
+    if !matches!(sig, AssistantSig::ToolId(_)) {
+        return None;
+    }
+    Some((user_text, sig))
+}
 
 impl AgentProfile for GenericProfile {
     fn name(&self) -> &'static str {
@@ -26,105 +100,11 @@ impl AgentProfile for GenericProfile {
         matches!(
             ctx.call.wire_api,
             wa::ANTHROPIC | wa::OPENAI_CHAT | wa::OPENAI_RESPONSES | wa::GEMINI_AISTUDIO
-        )
+        ) && extract_tool_anchored_sig(ctx).is_some()
     }
 
     fn extract_session_id(&self, ctx: &CallCtx<'_>) -> Option<SessionIdExtraction> {
-        let req = ctx.req?;
-        // Track three pieces per wire api:
-        //   * user_text   — first user message (used for the conversation
-        //                   text-hash path; required for everything below).
-        //   * sig_in_req  — Some(sig) if an assistant message already lives
-        //                   inside `req.messages[*]` / `req.input[*]`. This
-        //                   tells us the call belongs to a multi-turn
-        //                   conversation; the caller has already established
-        //                   a stable anchor we can hash.
-        //   * sig_in_resp — Some(sig) only when sig_in_req is None and the
-        //                   response carries the assistant turn for the
-        //                   first user message. Used both for text-hash
-        //                   fallback and for routing helper-shape one-shots
-        //                   to the system+time bucket.
-        //   * system_text — first system message; the only signal a
-        //                   helper-shape one-shot ever has that's stable
-        //                   across replays of the same helper sub-agent.
-        let (user_text, sig_in_req, sig_in_resp, system_text) = match ctx.call.wire_api {
-            wa::ANTHROPIC => {
-                let user_text = wa::anthropic::first_user_text(req)?;
-                let sig_in_req = wa::anthropic::first_assistant_sig_from_request(req);
-                let sig_in_resp = if sig_in_req.is_none() {
-                    ctx.resp
-                        .and_then(wa::anthropic::first_assistant_sig_from_response_value)
-                } else {
-                    None
-                };
-                let system_text = wa::anthropic::first_system_text(req);
-                (user_text, sig_in_req, sig_in_resp, system_text)
-            }
-            wa::OPENAI_CHAT => {
-                let user_text = wa::openai::chat::first_user_text(req)?;
-                let sig_in_req = wa::openai::chat::first_assistant_sig_from_request(req);
-                let sig_in_resp = if sig_in_req.is_none() {
-                    ctx.resp
-                        .and_then(wa::openai::chat::first_assistant_sig_from_response_value)
-                } else {
-                    None
-                };
-                let system_text = wa::openai::chat::first_system_text(req);
-                (user_text, sig_in_req, sig_in_resp, system_text)
-            }
-            wa::OPENAI_RESPONSES => {
-                let (user_text, sig_in_req) = match req.get("input")? {
-                    serde_json::Value::Array(items) => (
-                        wa::openai::responses::first_user_text(items),
-                        wa::openai::responses::first_assistant_sig_from_input(items),
-                    ),
-                    serde_json::Value::String(s) if !s.trim().is_empty() => (Some(s.clone()), None),
-                    _ => (None, None),
-                };
-                let user_text = user_text?;
-                let sig_in_resp = if sig_in_req.is_none() {
-                    ctx.resp
-                        .and_then(wa::openai::responses::first_assistant_sig_from_response_value)
-                } else {
-                    None
-                };
-                let system_text = wa::openai::responses::first_system_text(req);
-                (user_text, sig_in_req, sig_in_resp, system_text)
-            }
-            wa::GEMINI_AISTUDIO => {
-                let user_text = wa::gemini_aistudio::first_user_text(req)?;
-                let sig_in_req = wa::gemini_aistudio::first_assistant_sig_from_request(req);
-                let sig_in_resp = if sig_in_req.is_none() {
-                    ctx.resp
-                        .and_then(wa::gemini_aistudio::first_assistant_sig_from_response_value)
-                } else {
-                    None
-                };
-                let system_text = wa::gemini_aistudio::first_system_text(req);
-                (user_text, sig_in_req, sig_in_resp, system_text)
-            }
-            _ => return None,
-        };
-
-        // Helper-shape one-shot detection: the request has no assistant turn
-        // baked in (`sig_in_req` is None) AND the response side is plain
-        // text rather than a tool call (a tool id would already be a
-        // perfectly stable session anchor on its own). Hash the system
-        // prompt + a coarse time bucket so all replays of the same helper
-        // sub-agent within one agent run collapse into one session_id.
-        if sig_in_req.is_none() {
-            if let (Some(AssistantSig::Text(_)), Some(sys)) = (&sig_in_resp, &system_text) {
-                if !sys.is_empty() {
-                    let session_id = synth_helper_session_id(sys, ctx.call.request_time);
-                    return Some(SessionIdExtraction {
-                        session_id: format!("gen-{session_id}"),
-                        tool_id_canonicalized: false,
-                    });
-                }
-            }
-        }
-
-        let sig = sig_in_req.or(sig_in_resp)?;
+        let (user_text, sig) = extract_tool_anchored_sig(ctx)?;
         let (session_id, tool_id_canonicalized) = compose_session_id_tracked(&user_text, sig);
         Some(SessionIdExtraction {
             session_id,
@@ -258,16 +238,41 @@ mod tests {
     // ── Cross-wire-api: matches() ───────────────────────────────────────────
 
     #[test]
-    fn matches_all_supported_wire_apis() {
-        for &wire in &[
-            wa::ANTHROPIC,
-            wa::OPENAI_CHAT,
-            wa::OPENAI_RESPONSES,
-            wa::GEMINI_AISTUDIO,
-        ] {
-            let c = call_with(wire, vec![], None, None);
+    fn matches_supported_wire_apis_with_tool_anchor() {
+        let cases = [
+            (
+                wa::ANTHROPIC,
+                r#"{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}"#,
+                r#"{"content":[{"type":"tool_use","id":"toolu_a","name":"Read","input":{}}]}"#,
+            ),
+            (
+                wa::OPENAI_CHAT,
+                r#"{"messages":[{"role":"user","content":"hi"}]}"#,
+                r#"{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call_a","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}"#,
+            ),
+            (
+                wa::OPENAI_RESPONSES,
+                r#"{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}"#,
+                r#"{"output":[{"type":"function_call","name":"f","arguments":"{}","call_id":"fc_a"}]}"#,
+            ),
+            (
+                wa::GEMINI_AISTUDIO,
+                r#"{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}"#,
+                r#"{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"f","args":{}}}]}}]}"#,
+            ),
+        ];
+        for &(wire, req, resp) in &cases {
+            let c = call_with(wire, vec![], Some(req), Some(resp));
             assert!(GenericProfile.matches(&c.ctx()), "should match {wire}");
         }
+    }
+
+    #[test]
+    fn does_not_match_plain_text_openai_chat() {
+        let req = r#"{"messages":[{"role":"user","content":"hi"}]}"#;
+        let resp = r#"{"choices":[{"message":{"role":"assistant","content":"hello"}}]}"#;
+        let c = call_with(wa::OPENAI_CHAT, vec![], Some(req), Some(resp));
+        assert!(!GenericProfile.matches(&c.ctx()));
     }
 
     // ───────────────────── Gemini AI Studio (gemini-aistudio) ──────────────
@@ -297,7 +302,10 @@ mod tests {
             }"#;
             let c = g(Some(req), None);
             let extracted = GenericProfile.extract_session_id(&c.ctx());
-            assert!(extracted.is_some(), "should extract session_id from request history");
+            assert!(
+                extracted.is_some(),
+                "should extract session_id from request history"
+            );
         }
 
         #[test]
@@ -388,11 +396,8 @@ mod tests {
         // What matters: identical bytes for the same content across calls.
         // The real pcap also carries a 24KB systemInstruction (Gemini CLI
         // persona). We include a non-empty system here on every request so
-        // the test exercises the helper-shape one-shot gate in
-        // `extract_session_id` — historically that gate triggered
-        // incorrectly on call 1 (sig_in_req=None + sig_in_resp=Text +
-        // system non-empty), splitting the session and producing
-        // 1+6 / 1+3+3 turn breakdowns instead of 4+3.
+        // call 1 must still anchor on the response-side functionCall instead
+        // of being mistaken for a plain text one-shot.
         const SYSTEM_PROMPT: &str = "You are an interactive CLI agent.";
         const SESSION_CTX: &str = "<session_context>scaffold";
         const ORIGINAL_PROMPT: &str = "original prompt about ts-turn";
@@ -685,15 +690,15 @@ mod tests {
                     .map(|x| x.session_id)
                     .unwrap_or_else(|| panic!("call {} should produce a session_id", i + 1));
                 session_ids.push(sid);
-                user_starts
-                    .push(GenericProfile.is_user_turn_start(&c.ctx()).unwrap_or(false));
+                user_starts.push(GenericProfile.is_user_turn_start(&c.ctx()).unwrap_or(false));
                 terminals.push(GenericProfile.is_turn_terminal(&c.ctx(), &wires));
             }
 
             // (1) All 7 calls land in the same session.
             for (i, sid) in session_ids.iter().enumerate().skip(1) {
                 assert_eq!(
-                    sid, &session_ids[0],
+                    sid,
+                    &session_ids[0],
                     "call {} session_id diverged from call 1",
                     i + 1,
                 );
@@ -736,16 +741,14 @@ mod tests {
         }
 
         #[test]
-        fn extract_session_id_call_n_with_text_only_history() {
+        fn extract_session_id_none_for_text_only_history() {
             let req = r#"{"messages":[
                 {"role":"user","content":[{"type":"text","text":"hi"}]},
                 {"role":"assistant","content":[{"type":"text","text":"hello there"}]},
                 {"role":"user","content":[{"type":"text","text":"more"}]}
             ]}"#;
             let c = ant(vec![], Some(req), None);
-            let ids = GenericProfile.extract_session_id(&c.ctx()).unwrap();
-            assert!(ids.session_id.starts_with("gen-"));
-            assert_eq!(ids.session_id.len(), "gen-".len() + 16);
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
         #[test]
@@ -759,12 +762,11 @@ mod tests {
         }
 
         #[test]
-        fn extract_session_id_call_1_text_in_response() {
+        fn extract_session_id_none_for_call_1_text_response() {
             let req = r#"{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}"#;
             let resp = r#"{"content":[{"type":"text","text":"hello there"}]}"#;
             let c = ant(vec![], Some(req), Some(resp));
-            let ids = GenericProfile.extract_session_id(&c.ctx()).unwrap();
-            assert!(ids.session_id.starts_with("gen-"));
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
         #[test]
@@ -896,41 +898,28 @@ mod tests {
         }
 
         #[test]
-        fn extract_session_id_call_n_with_text_only_history() {
+        fn extract_session_id_none_for_text_only_history() {
             let req = r#"{"messages":[
                 {"role":"user","content":"hi"},
                 {"role":"assistant","content":"hello"},
                 {"role":"user","content":"more"}
             ]}"#;
             let c = oai(Some(req), None);
-            let ids = GenericProfile.extract_session_id(&c.ctx()).unwrap();
-            assert!(ids.session_id.starts_with("gen-"));
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
         #[test]
-        fn extract_session_id_call_1_text_in_response() {
+        fn extract_session_id_none_for_call_1_text_response() {
             let req = r#"{"messages":[{"role":"user","content":"hi"}]}"#;
             let resp = r#"{"choices":[{"message":{"role":"assistant","content":"hello"}}]}"#;
             let c = oai(Some(req), Some(resp));
-            assert!(GenericProfile
-                .extract_session_id(&c.ctx())
-                .unwrap()
-                .session_id
-                .starts_with("gen-"));
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
-        /// Helper-shape one-shot calls (request = [system, user] only, response
-        /// = assistant text) coming from a Claude-Agent-SDK helper sub-agent
-        /// like the Bash permission gate or path-extractor: each call has the
-        /// SAME system message but a DIFFERENT user message (different
-        /// command being checked). Without a system+time fallback, every
-        /// call gets a unique gen-<hash> id and the agent_turns view shows
-        /// each helper as its own 1-call turn.
-        ///
-        /// With the fallback, all helpers within the time-bucket window share
-        /// a session_id and group into a single agent_turn.
+        /// Helper-shape one-shots have no tool-call anchor. They should stay
+        /// visible as LLM calls but must not become synthetic generic turns.
         #[test]
-        fn extract_session_id_helper_oneshots_share_session_id_via_system_msg() {
+        fn extract_session_id_none_for_helper_oneshots() {
             let sys = "You are a Claude agent built on Anthropic's Claude Agent SDK. \
                        Your task is to process Bash commands.";
             let resp = r#"{"choices":[{"message":{"role":"assistant","content":"allow"}}]}"#;
@@ -956,63 +945,25 @@ mod tests {
                 make("Command: rm temp.log", bucket_start + 30_000_000),
                 make("Command: grep error log", bucket_start + 55_000_000),
             ];
-            let ids: Vec<String> = calls
-                .iter()
-                .map(|c| {
-                    GenericProfile
-                        .extract_session_id(&c.ctx())
-                        .unwrap()
-                        .session_id
-                })
-                .collect();
-            // All 5 must share the same session_id (they're the same helper
-            // sub-agent firing repeatedly within one agent run).
-            let first = &ids[0];
-            for (i, id) in ids.iter().enumerate() {
-                assert_eq!(
-                    id, first,
-                    "call {} session_id={} differs from first={}; all helpers must share id",
-                    i, id, first
-                );
+            for c in &calls {
+                assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
             }
-            // Sanity: still a `gen-` synthesised id (not a tool id leak).
-            assert!(first.starts_with("gen-"));
         }
 
-        /// Two helper batches separated by a long idle gap (> bucket window)
-        /// must split into two distinct session_ids — otherwise running the
-        /// same agent twice in a day collapses both runs' helpers into one
-        /// turn.
         #[test]
-        fn extract_session_id_helper_oneshots_split_across_idle_gap() {
+        fn extract_session_id_none_for_plain_openai_python_call() {
             let sys = "You are a Claude agent. Your task is to process Bash commands.";
             let resp = r#"{"choices":[{"message":{"role":"assistant","content":"allow"}}]}"#;
-            let make = |user: &str, ts_us: i64| {
-                let req = serde_json::json!({
-                    "messages": [
-                        {"role": "system", "content": sys},
-                        {"role": "user", "content": user},
-                    ],
-                })
-                .to_string();
-                let mut tc = oai(Some(&req), Some(resp));
-                tc.call.request_time = ts_us;
-                tc
-            };
-            let early = make("Command: ls", 1_000_000_000);
-            let late = make("Command: ls", 1_000_000_000 + 5 * 60_000_000);
-            let id1 = GenericProfile
-                .extract_session_id(&early.ctx())
-                .unwrap()
-                .session_id;
-            let id2 = GenericProfile
-                .extract_session_id(&late.ctx())
-                .unwrap()
-                .session_id;
-            assert_ne!(
-                id1, id2,
-                "calls 5 minutes apart on same helper must be different sessions"
-            );
+            let req = serde_json::json!({
+                "messages": [
+                    {"role": "system", "content": sys},
+                    {"role": "user", "content": "Choose one candidate."},
+                ],
+                "model": "qwen3.5-35b"
+            })
+            .to_string();
+            let c = oai(Some(&req), Some(resp));
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
         #[test]
@@ -1109,14 +1060,13 @@ mod tests {
         }
 
         #[test]
-        fn extract_session_id_call_n_with_text_only_assistant() {
+        fn extract_session_id_none_for_text_only_assistant() {
             let req = r#"{"input":[
                 {"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
                 {"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}
             ]}"#;
             let c = resp(Some(req), None);
-            let ids = GenericProfile.extract_session_id(&c.ctx()).unwrap();
-            assert!(ids.session_id.starts_with("gen-"));
+            assert!(GenericProfile.extract_session_id(&c.ctx()).is_none());
         }
 
         #[test]

--- a/server/ts-llm/src/agents/hermes.rs
+++ b/server/ts-llm/src/agents/hermes.rs
@@ -17,10 +17,9 @@
 //!
 //! Hermes's chat-title-generation call (system: "Generate a short,
 //! descriptive title…") carries no `tools` and no Hermes markers; it does
-//! NOT match this profile and falls through to `GenericProfile`. That is
-//! by design — title generation is a standalone turn from the wire's
-//! perspective, and conflating it into the parent turn would mis-shape
-//! the per-call data.
+//! NOT match this profile. Generic fallback also ignores text-only calls, so
+//! title generation remains visible as an LLM call without creating a
+//! synthetic agent turn.
 
 use crate::profile::{AgentProfile, CallCtx, SessionIdExtraction};
 use crate::wire_api_registry::WireApiRegistry;
@@ -306,7 +305,7 @@ mod tests {
 
     #[test]
     fn does_not_match_title_generation_call() {
-        // No tools array at all → must not match. Falls through to generic.
+        // No tools array at all → must not match.
         let c = call(wa::OPENAI_CHAT, Some(HERMES_TITLE_GEN), None);
         assert!(!HermesProfile.matches(&c.ctx()));
     }

--- a/server/ts-llm/src/agents/mod.rs
+++ b/server/ts-llm/src/agents/mod.rs
@@ -131,6 +131,30 @@ mod priority_tests {
       ]
     }"#;
 
+    const GENERIC_ANT_TOOL_HISTORY: &str = r#"{
+      "messages":[
+        {"role":"user","content":[{"type":"text","text":"hi"}]},
+        {"role":"assistant","content":[{"type":"tool_use","id":"toolu_generic","name":"Read","input":{}}]},
+        {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_generic","content":"ok"}]}
+      ]
+    }"#;
+
+    const GENERIC_OAI_CHAT_TOOL_HISTORY: &str = r#"{
+      "messages":[
+        {"role":"user","content":"hi"},
+        {"role":"assistant","content":null,"tool_calls":[{"id":"call_generic","type":"function","function":{"name":"f","arguments":"{}"}}]},
+        {"role":"tool","tool_call_id":"call_generic","content":"ok"}
+      ]
+    }"#;
+
+    const GENERIC_RESPONSES_TOOL_HISTORY: &str = r#"{
+      "input":[
+        {"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+        {"type":"function_call","name":"f","arguments":"{}","call_id":"fc_generic"},
+        {"type":"function_call_output","call_id":"fc_generic","output":"ok"}
+      ]
+    }"#;
+
     #[test]
     fn claude_cli_wins_over_generic_for_anthropic() {
         let reg = build_default_registry();
@@ -147,9 +171,10 @@ mod priority_tests {
     #[test]
     fn generic_catches_no_ua_anthropic() {
         let reg = build_default_registry();
-        let c = call_with(
+        let c = call_with_body(
             wa::ANTHROPIC,
             vec![("User-Agent", "python/3.12 anthropic/0.40")],
+            Some(GENERIC_ANT_TOOL_HISTORY),
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -159,11 +184,12 @@ mod priority_tests {
         // UA-spoofing or header-stripping: looks like claude-cli but the
         // session header is absent. ClaudeCliProfile must NOT claim it
         // (otherwise extract_session_id would return None with no fallback) —
-        // GenericProfile picks it up and synthesizes a session anchor.
+        // GenericProfile picks it up when the body has a tool-call anchor.
         let reg = build_default_registry();
-        let c = call_with(
+        let c = call_with_body(
             wa::ANTHROPIC,
             vec![("User-Agent", "claude-cli/2.1.98 (cli)")],
+            Some(GENERIC_ANT_TOOL_HISTORY),
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -199,9 +225,10 @@ mod priority_tests {
     #[test]
     fn generic_catches_no_codex_metadata_responses() {
         let reg = build_default_registry();
-        let c = call_with(
+        let c = call_with_body(
             wa::OPENAI_RESPONSES,
             vec![("User-Agent", "OpenAI/Python 1.50")],
+            Some(GENERIC_RESPONSES_TOOL_HISTORY),
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -211,11 +238,12 @@ mod priority_tests {
         // UA-spoofing or header-stripping: looks like codex but the
         // turn-metadata header is absent. CodexCliProfile must NOT claim it
         // (otherwise extract_session_id would return None with no fallback) —
-        // GenericProfile picks it up and synthesizes a session anchor.
+        // GenericProfile picks it up when the body has a tool-call anchor.
         let reg = build_default_registry();
-        let c = call_with(
+        let c = call_with_body(
             wa::OPENAI_RESPONSES,
             vec![("User-Agent", "codex-tui/0.118.0")],
+            Some(GENERIC_RESPONSES_TOOL_HISTORY),
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -223,7 +251,11 @@ mod priority_tests {
     #[test]
     fn generic_catches_openai_chat() {
         let reg = build_default_registry();
-        let c = call_with(wa::OPENAI_CHAT, vec![("User-Agent", "OpenAI/JS 6.26.0")]);
+        let c = call_with_body(
+            wa::OPENAI_CHAT,
+            vec![("User-Agent", "OpenAI/JS 6.26.0")],
+            Some(GENERIC_OAI_CHAT_TOOL_HISTORY),
+        );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
 
@@ -247,14 +279,15 @@ mod priority_tests {
     fn generic_catches_old_opencode_without_session_header() {
         // Pre-1.14.x opencode lacks x-session-affinity. OpencodeProfile must
         // NOT claim it (no fallback for session_id), so the call falls
-        // through to GenericProfile which can synthesize from the body.
+        // through to GenericProfile when the body has a tool-call anchor.
         let reg = build_default_registry();
-        let c = call_with(
+        let c = call_with_body(
             wa::OPENAI_CHAT,
             vec![(
                 "User-Agent",
                 "opencode/1.1.31 ai-sdk/provider-utils/3.0.20 runtime/bun/1.3.5",
             )],
+            Some(GENERIC_OAI_CHAT_TOOL_HISTORY),
         );
         assert_eq!(find_kind(&reg, &c), Some("generic"));
     }
@@ -306,10 +339,15 @@ mod priority_tests {
 
     #[test]
     fn generic_still_wins_for_non_openclaw_anthropic() {
-        // Body lacks OpenClaw marker tools → falls through to generic.
+        // Body lacks OpenClaw marker tools but has a tool-call anchor →
+        // falls through to generic.
         let reg = build_default_registry();
         let body = r#"{
-          "messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],
+          "messages":[
+            {"role":"user","content":[{"type":"text","text":"hi"}]},
+            {"role":"assistant","content":[{"type":"tool_use","id":"toolu_generic","name":"Read","input":{}}]},
+            {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_generic","content":"ok"}]}
+          ],
           "tools":[{"name":"Read"},{"name":"Edit"}]
         }"#;
         let c = call_with_body(
@@ -324,7 +362,11 @@ mod priority_tests {
     fn generic_still_wins_for_non_openclaw_openai_chat() {
         let reg = build_default_registry();
         let body = r#"{
-          "messages":[{"role":"user","content":"hi"}],
+          "messages":[
+            {"role":"user","content":"hi"},
+            {"role":"assistant","content":null,"tool_calls":[{"id":"call_generic","type":"function","function":{"name":"calculator","arguments":"{}"}}]},
+            {"role":"tool","tool_call_id":"call_generic","content":"ok"}
+          ],
           "tools":[{"type":"function","function":{"name":"calculator"}}]
         }"#;
         let c = call_with_body(
@@ -368,19 +410,17 @@ mod priority_tests {
     }
 
     #[test]
-    fn hermes_title_gen_falls_through_to_generic() {
+    fn hermes_title_gen_has_no_agent_profile() {
         // Hermes's chat-title-generation call carries no tools and no
-        // Hermes markers, so HermesProfile must NOT match it. The call
-        // is correctly classified as generic — and it correctly remains
-        // its own AgentTurn from the wire's perspective (separate
-        // session, fresh user-start, finish_reason=stop).
+        // Hermes markers, so HermesProfile must NOT match it. Generic
+        // fallback also ignores text-only calls, so it stays call-only.
         let reg = build_default_registry();
         let c = call_with_body(
             wa::OPENAI_CHAT,
             vec![("User-Agent", "OpenAI/Python 2.33.0")],
             Some(HERMES_TITLE_GEN),
         );
-        assert_eq!(find_kind(&reg, &c), Some("generic"));
+        assert_eq!(find_kind(&reg, &c), None);
     }
 
     #[test]

--- a/server/ts-turn/tests/integration.rs
+++ b/server/ts-turn/tests/integration.rs
@@ -710,18 +710,15 @@ async fn openclaw_anthropic_parallel_tool_use_inputs_intact() {
 /// `cronjob` in `tools[]`).
 ///
 /// The fixture contains one user-facing conversation followed by Hermes's
-/// chat-title-generation one-shot. The two are independent on the wire and
-/// emit as two separate AgentTurns by design (independent session_ids,
-/// independent user-start, independent terminal). Asserts:
-///   1. Exactly two OpenAI Chat turns.
+/// chat-title-generation one-shot. The title one-shot has no tool-call anchor,
+/// so it remains an LLM call and does not become a synthetic generic turn.
+/// Asserts:
+///   1. Exactly one OpenAI Chat turn.
 ///   2. The 4-call main conversation classifies as `hermes`. Its
 ///      `user_input_preview` is the user's prompt verbatim — the title-gen
 ///      prompt MUST NOT leak in here.
-///   3. The 1-call title-generation call falls through to `generic` (no
-///      Hermes tool markers in its body). Its `final_answer_preview`
-///      matches the synthesized title.
 #[tokio::test]
-async fn hermes_openai_expects_hermes_main_and_generic_title_gen() {
+async fn hermes_openai_expects_hermes_main_only() {
     let Some(turns) = run_pcap("hermes-openai.pcap").await else {
         eprintln!("skip: fixture not present");
         return;
@@ -741,16 +738,14 @@ async fn hermes_openai_expects_hermes_main_and_generic_title_gen() {
             t.final_answer_preview.as_deref().unwrap_or(""),
         );
     }
-    assert_eq!(chat.len(), 2, "expected 2 turns; got {}", chat.len());
+    assert_eq!(chat.len(), 1, "expected 1 turn; got {}", chat.len());
     assert!(
         chat.iter().all(|t| t.status == TurnStatus::Complete),
-        "all turns expected Complete (both end with finish_reason=stop)",
+        "main turn expected Complete",
     );
 
-    let main = chat
-        .iter()
-        .find(|t| t.agent_kind == "hermes")
-        .expect("expected one hermes-classified turn (main conversation)");
+    let main = chat[0];
+    assert_eq!(main.agent_kind, "hermes");
     assert_eq!(
         main.call_count, 4,
         "main conversation has 4 LLM calls (3 tool roundtrips + 1 final answer)",
@@ -760,28 +755,6 @@ async fn hermes_openai_expects_hermes_main_and_generic_title_gen() {
         main_user.starts_with("检查当前tokenscope"),
         "hermes turn user_input must be the user's prompt verbatim, got {main_user:?}",
     );
-
-    let title = chat
-        .iter()
-        .find(|t| t.agent_kind == "generic")
-        .expect("title-gen call must fall through to generic (no Hermes markers)");
-    assert_eq!(
-        title.call_count, 1,
-        "title generation is a single one-shot call",
-    );
-    let title_final = title.final_answer_preview.as_deref().unwrap_or_default();
-    assert!(
-        title_final.contains("tokenscope"),
-        "title-gen final_answer must reference the conversation topic, got {title_final:?}",
-    );
-    // The two turns must live in distinct session buckets — that's why
-    // they're separate turns in the first place. If they collapsed into one
-    // session, the tracker would partition them but this assertion guards
-    // against any future session-id heuristic that accidentally fuses them.
-    assert_ne!(
-        main.session_id, title.session_id,
-        "main conversation and title-gen call must occupy distinct session buckets",
-    );
 }
 
 #[tokio::test]
@@ -790,9 +763,7 @@ async fn hermes_openai_pcap_shard_parity() {
         eprintln!("skip: fixture not present");
         return;
     };
-    let multi = run_pcap_sharded("hermes-openai.pcap", 4, 4)
-        .await
-        .unwrap();
+    let multi = run_pcap_sharded("hermes-openai.pcap", 4, 4).await.unwrap();
 
     let single_keys: std::collections::BTreeSet<_> = single
         .iter()
@@ -1022,11 +993,8 @@ async fn generic_profile_anthropic_two_call_session() {
 ///      is emitted at all.
 ///   2. Sig variant correctness: `first_assistant_sig_from_*` must return
 ///      `ToolId(_)` (not `Text(_)`) when the model turn carries any
-///      functionCall, otherwise `generic` profile's helper-shape one-shot
-///      gate spuriously fires on call 1 (sig=Text + system_text non-empty
-///      + no model history) and gives it a `gen-<helper_hash>` session_id
-///      distinct from calls 2..7's `gen-<text_hash>`. The pcap then
-///      shatters into 1 + N turns instead of 4 + 3.
+///      functionCall, otherwise `generic` profile will not associate the
+///      call and the pcap will fail to reconstruct the 4 + 3 turn split.
 #[tokio::test]
 async fn gemini_cli_apikey_expects_two_turns_4_and_3() {
     let Some(turns) = run_pcap("gemini-cli-apikey.pcap").await else {
@@ -1055,8 +1023,7 @@ async fn gemini_cli_apikey_expects_two_turns_4_and_3() {
     );
 
     // All 7 calls must share one session_id — proves the sig algorithm is
-    // stable across the resp/req-history boundary AND the helper-shape
-    // gate is correctly skipped for tools-bearing first calls.
+    // stable across the resp/req-history boundary for tools-bearing calls.
     let sessions: std::collections::BTreeSet<_> =
         gemini.iter().map(|t| t.session_id.as_str()).collect();
     assert_eq!(


### PR DESCRIPTION
Summary:
- require generic agent turn grouping to have an actual tool/function-call anchor
- keep text-only SDK calls on the LLM Calls surface instead of synthetic one-call Agent Turns
- update Hermes/title-generation and generic profile tests

Validation:
- cargo test -p ts-llm agents
- cargo test -p ts-turn --test integration