### PR TITLE
post_review: use ADMIN_GH_TOKEN for the admin-merge fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -126,7 +126,14 @@ jobs:
       - name: Post review
         if: always()
         env:
+          # GITHUB_TOKEN posts the review/comment as the GitHub Actions
+          # bot (preferred — keeps vivi's footer attribution clean).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ADMIN_GH_TOKEN is used ONLY for the auto-merge fallback
+          # inside post_review.py; GITHUB_TOKEN can't `gh pr merge --admin`
+          # because it lacks branch-protection bypass. With AGENT_GH_TOKEN
+          # (a PAT owned by a repo admin) the call succeeds.
+          ADMIN_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           AGENT_EXIT: ${{ steps.review.outcome }}

--- a/scripts/pr-review/post_review.py
+++ b/scripts/pr-review/post_review.py
@@ -159,9 +159,19 @@ def auto_merge(number: str) -> None:
     success. Any failure (merge conflict, branch protection
     surprise, etc.) is logged but doesn't fail the workflow — the
     review is already posted, the operator can finish merging by
-    hand."""
+    hand.
+
+    `--admin` requires a token whose owner has admin rights on the
+    repo; the default GITHUB_TOKEN does NOT and the call errors out
+    with "Required status check 'test' is expected (mergePullRequest)".
+    If ADMIN_GH_TOKEN is set, swap GH_TOKEN to it for this call only.
+    """
     cmd = ["gh", "pr", "merge", number, "--admin", "--squash", "--delete-branch"]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    env = os.environ.copy()
+    admin_tok = os.environ.get("ADMIN_GH_TOKEN", "").strip()
+    if admin_tok:
+        env["GH_TOKEN"] = admin_tok
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if proc.returncode != 0:
         sys.stderr.write(
             f"auto-merge failed (left for manual merge): {proc.stderr}\n"


### PR DESCRIPTION
## Summary

`post_review.py`'s auto-merge path calls `gh pr merge --admin`, which needs admin-bypass on branch protection. The default `GITHUB_TOKEN` doesn't have that — every auto-merge attempt fails with `Required status check "test" is expected (mergePullRequest)`, so vivi APPROVES and the operator finishes the merge by hand.

Fix: read `ADMIN_GH_TOKEN` from the env (we already have one as `AGENT_GH_TOKEN` from PR #45). When set, the auto-merge subprocess uses it; review/comment posting still uses `GITHUB_TOKEN` so attribution stays the GitHub Actions bot.

## Wiring

`pr-review.yml` Post review step now passes:

```yaml
ADMIN_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
```

## Test plan

- [ ] CI green on this PR
- [ ] vivi APPROVE on this PR
- [ ] Workflow log on the next run shows `auto-merged PR #N` instead of `auto-merge failed (...mergePullRequest)`
- [ ] This very PR auto-merges (vader ∈ AUTO_MERGE_AUTHORS)