### PR TITLE
pair_sweeper: CHECKPOINT after each batch + reopen on FATAL

### DIFF
--- a/server/ts-storage-duckdb/src/lib.rs
+++ b/server/ts-storage-duckdb/src/lib.rs
@@ -49,6 +49,9 @@ pub struct DuckDbBackend {
     pub(crate) write_metrics_conn: Arc<StdMutex<Connection>>,
     pub(crate) write_exchanges_conn: Arc<StdMutex<Connection>>,
     pub(crate) read_pool: ReadPool,
+    /// Kept so we can re-`Connection::open` a poisoned writer in place.
+    /// See `reopen_turns_writer`.
+    pub(crate) db_path: String,
 }
 
 impl DuckDbBackend {
@@ -100,6 +103,7 @@ impl DuckDbBackend {
             write_metrics_conn: Arc::new(StdMutex::new(metrics_writer)),
             write_exchanges_conn: Arc::new(StdMutex::new(exchanges_writer)),
             read_pool: ReadPool::new(readers),
+            db_path: path.to_string(),
         })
     }
 
@@ -285,5 +289,39 @@ impl StorageBackend for DuckDbBackend {
         patch: serde_json::Value,
     ) -> Result<()> {
         DuckDbBackend::update_turn_metadata(self, turn_id, patch).await
+    }
+
+    async fn checkpoint_turns_writer(&self) -> Result<()> {
+        let conn = self.write_turns_conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn
+                .lock()
+                .map_err(|e| AppError::Storage(format!("lock turns writer: {e}")))?;
+            conn.execute_batch("CHECKPOINT")
+                .map_err(|e| AppError::Storage(format!("CHECKPOINT failed: {e}")))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
+    }
+
+    async fn reopen_turns_writer(&self) -> Result<()> {
+        let path = self.db_path.clone();
+        let conn_arc = self.write_turns_conn.clone();
+        tokio::task::spawn_blocking(move || {
+            // Try to reach the existing DB file. If the on-disk DB is
+            // also unhealthy we'll surface that error to the caller and
+            // it'll just retry on the next sweep.
+            let fresh = Connection::open(&path)
+                .map_err(|e| AppError::Storage(format!("reopen duckdb: {e}")))?;
+            let mut guard = conn_arc
+                .lock()
+                .map_err(|e| AppError::Storage(format!("lock turns writer: {e}")))?;
+            *guard = fresh;
+            info!("reopened agent_turns writer after FATAL invalidation");
+            Ok(())
+        })
+        .await
+        .map_err(|e| AppError::Storage(format!("spawn_blocking failed: {e}")))?
     }
 }

--- a/server/ts-storage/src/backend.rs
+++ b/server/ts-storage/src/backend.rs
@@ -202,4 +202,24 @@ pub trait StorageBackend: Send + Sync {
     ) -> Result<()> {
         Ok(())
     }
+
+    /// Compact pending MVCC tombstones on the agent_turns writer.
+    /// Called by the pair sweeper after each batch of
+    /// `update_turn_metadata` so the version chain stays short —
+    /// high-frequency UPDATEs on an indexed table (PRIMARY KEY on
+    /// `turn_id`) without checkpoints can hit a "Failed to delete all
+    /// rows from index" FATAL inside DuckDB that poisons the entire
+    /// process's connection. Default no-op for mock backends.
+    async fn checkpoint_turns_writer(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Replace the agent_turns writer connection with a freshly-opened
+    /// one. Called by the pair sweeper after a sweep failure that
+    /// looks like the DuckDB "database has been invalidated" FATAL —
+    /// without this, every subsequent query in the process returns
+    /// 500 until external restart. Default no-op for mock backends.
+    async fn reopen_turns_writer(&self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/server/ts-storage/src/pair_sweeper.rs
+++ b/server/ts-storage/src/pair_sweeper.rs
@@ -78,8 +78,40 @@ pub fn spawn_pair_sweeper(
         // service start (the DB may still be empty / cold).
         tokio::time::sleep(cfg.interval).await;
         loop {
-            if let Err(e) = sweep_once(&storage, cfg.lookback).await {
-                tracing::warn!(error = %e, "pair-sweeper: sweep failed; continuing");
+            match sweep_once(&storage, cfg.lookback).await {
+                Ok(_) => {
+                    // CHECKPOINT after each successful batch so the
+                    // MVCC tombstone chain doesn't grow into the
+                    // DuckDB "Failed to delete all rows from index"
+                    // FATAL trap. Cheap when nothing to compact.
+                    if let Err(e) = storage.checkpoint_turns_writer().await {
+                        tracing::warn!(error = %e, "pair-sweeper: post-sweep CHECKPOINT failed");
+                    }
+                }
+                Err(e) => {
+                    let msg = format!("{e}");
+                    tracing::warn!(error = %e, "pair-sweeper: sweep failed; continuing");
+                    // The DuckDB invalidation FATAL is global to the
+                    // connection — every subsequent query in the
+                    // process returns 500 until the connection is
+                    // dropped. Detect by message substring (DuckDB
+                    // doesn't surface a typed code) and swap the
+                    // writer in place so the rest of the process
+                    // recovers without an external restart.
+                    if msg.contains("database has been invalidated")
+                        || msg.contains("must be restarted prior to being used")
+                    {
+                        match storage.reopen_turns_writer().await {
+                            Ok(()) => tracing::info!(
+                                "pair-sweeper: reopened agent_turns writer after invalidation"
+                            ),
+                            Err(re) => tracing::error!(
+                                error = %re,
+                                "pair-sweeper: failed to reopen turns writer after invalidation"
+                            ),
+                        }
+                    }
+                }
             }
             tokio::time::sleep(cfg.interval).await;
         }


### PR DESCRIPTION
## Summary

Companion to #47 — addresses a **second, independent** way `/api/agent-turns` reliably 500s on the wuneng deployment.

Periodically the log shows:

```
WARN ts_storage::pair_sweeper: pair-sweeper: sweep failed; continuing
  error=storage error: query pair candidates: FATAL Error:
  Failed: database has been invalidated because of a previous fatal error.
  The database must be restarted prior to being used again.

Original error: Invalid Input Error:
  Failed to delete all rows from index. Only deleted 643 out of 782 rows.
```

After that, **every** subsequent query in the process returns 500 — the DuckDB connection is globally poisoned and the only recovery is a full `tokenscope` restart. The trigger is the high-frequency `UPDATE agent_turns SET metadata` the pair sweeper issues every 2 s, which hits a DuckDB MVCC tombstone race on the primary-key index.

## Fix (two layers, both small)

1. **`StorageBackend::checkpoint_turns_writer`** — `pair_sweeper` calls it after each successful sweep so the MVCC tombstone chain stays short. Same pattern `retention.rs:95` already uses after its DELETE batch.
2. **`StorageBackend::reopen_turns_writer`** — `DuckDbBackend` now keeps `db_path`, so on the invalidation FATAL we can `Connection::open(path)` a fresh writer and atomically swap it into the `Arc<Mutex<>>`. `pair_sweeper` detects the FATAL by message substring (DuckDB doesn't expose a typed error code) and calls reopen — service recovers within one sweep interval instead of needing an operator restart.

Both new trait methods get default no-op impls, so existing mocks (`CountingBackend`, `StubStorage`, the per-test backend in `ts-storage/src/pair_sweeper.rs` tests) compile and behave unchanged.

## Why not stop the sweeper on FATAL

The sweeper is also what fixes the upstream UPDATE that started the cycle — disabling it would freeze proxy-pair metadata permanently. Reopen-and-keep-going restores the steady state.

## Test plan

- [x] `cargo check -p ts-storage -p ts-storage-duckdb -p tokenscope` green
- [x] `cargo test -p ts-storage pair_sweeper` — 4 existing tests still pass
- [ ] After merge: rebuild on wuneng, restart, leave it for an hour, confirm /api/agent-turns stays 200 across multiple sweep cycles