### PR TITLE
agent-bot: use AGENT_GH_TOKEN for the agent:try label fan-out

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -47,7 +47,12 @@ jobs:
           ISSUE_TITLE:  ${{ github.event.issue.title }}
           ISSUE_BODY:   ${{ github.event.issue.body }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          # Default token: posts the triage comment as github-actions[bot].
           GH_TOKEN:     ${{ secrets.GITHUB_TOKEN }}
+          # PAT used ONLY to add the `agent:try` label on verdict=do.
+          # GitHub suppresses labeled events emitted under GITHUB_TOKEN,
+          # which would block issue-implement.yml from firing.
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
         run: bash scripts/agent-bot/run_triage.sh
 
       - name: Cleanup transient files

--- a/scripts/agent-bot/run_triage.sh
+++ b/scripts/agent-bot/run_triage.sh
@@ -75,7 +75,20 @@ fi
 
 case "$VERDICT" in
   do)
-    gh issue edit "$ISSUE_NUMBER" --add-label "agent:try"
+    # Add the `agent:try` label using AGENT_GH_TOKEN (a PAT) rather
+    # than the default GITHUB_TOKEN. GitHub deliberately suppresses
+    # `labeled` events emitted by GITHUB_TOKEN to prevent recursive
+    # workflow chains — meaning issue-implement.yml would never fire.
+    # The PAT belongs to a real user, so its label edit fans out to
+    # downstream workflows normally. If AGENT_GH_TOKEN is missing we
+    # still label (with GITHUB_TOKEN) but the dev agent won't auto-start;
+    # an operator can re-toggle the label by hand.
+    if [ -n "${AGENT_GH_TOKEN:-}" ]; then
+      GH_TOKEN="$AGENT_GH_TOKEN" gh issue edit "$ISSUE_NUMBER" --add-label "agent:try"
+    else
+      echo "warning: AGENT_GH_TOKEN unset; labeling under GITHUB_TOKEN — wiwi will NOT auto-start" >&2
+      gh issue edit "$ISSUE_NUMBER" --add-label "agent:try"
+    fi
     gh issue comment "$ISSUE_NUMBER" --body "🤖 Triage: **${VERDICT}** — scope: ${SCOPE}
 
 ${REASON}


### PR DESCRIPTION
## Summary

- After triage verdict=`do`, swap to **`AGENT_GH_TOKEN`** when adding the
  `agent:try` label so the resulting `labeled` event fans out to
  `issue-implement.yml` (wiwi).
- Default `GITHUB_TOKEN` stays for the triage comment.
- Falls back to `GITHUB_TOKEN` with a stderr warning if
  `AGENT_GH_TOKEN` isn't configured.

## Why

GitHub deliberately suppresses `labeled` (and several other) events
emitted by `GITHUB_TOKEN` to prevent recursive workflow chains. So:

| Workflow | Triggered by | Reaction |
|----------|--------------|----------|
| `issue-triage.yml` | human adds `agent:assess` | ✅ runs |
| `issue-implement.yml` (wiwi) | `github-actions[bot]` adds `agent:try` (via `GITHUB_TOKEN`) | ❌ event suppressed |
| `issue-implement.yml` (wiwi) | real user adds `agent:try` (via PAT) | ✅ runs |

Reproduced on issues #49 and #50: triage returned verdict=`do`,
`agent:try` got labelled by `github-actions[bot]`, no implement
workflow ran for that event — only the prior `agent:assess` event
triggered the (correctly) skipped `issue-implement` run, then nothing.

This is the same pattern PR #46 used to fix `gh pr merge --admin` —
`AGENT_GH_TOKEN` is already wired as a repo / org secret, no new
secret needed.

## Scope

- `scripts/agent-bot/run_triage.sh` — guard the single `gh issue edit
  --add-label` call. Comment-posting stays on `GITHUB_TOKEN`.
- `.github/workflows/issue-triage.yml` — pass `AGENT_GH_TOKEN` into the
  Triage step env.

## Test plan

- [ ] After merge, re-toggle `agent:assess` on issue #49 or #50; verify
      a fresh `issue-triage` run fires and `issue-implement` (wiwi)
      starts within ~30s of the verdict.
- [ ] On a fork without `AGENT_GH_TOKEN`, confirm triage still labels
      the issue and the stderr warning appears in the workflow log
      (graceful degradation — labels but doesn't auto-start wiwi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)