### PR TITLE
wiwi: bump timeout to 120m + stream claude output live

### DIFF
--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -29,7 +29,14 @@ jobs:
   implement:
     if: ${{ github.event.label.name == 'agent:try' }}
     runs-on: [self-hosted, tokenscope]
-    timeout-minutes: 45
+    # 120-minute fence. A clean, well-scoped wiwi run (per the triage
+    # gates: <300 LOC, <10 files) typically completes in 10-25 min; the
+    # 120-min cap absorbs slower LiteLLM ↔ GLM-5 round-trips on busy
+    # days and gives wiwi room to iterate when `cargo build` finds
+    # something it has to fix mid-run. If you ever see this fence
+    # actually hit, the triage gate is probably mis-sized — file an
+    # issue rather than bumping the fence again.
+    timeout-minutes: 120
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
       ANTHROPIC_API_KEY:  ${{ secrets.LITELLM_API_KEY }}

--- a/scripts/agent-bot/run_wiwi.sh
+++ b/scripts/agent-bot/run_wiwi.sh
@@ -45,14 +45,33 @@ the PR body. End it with the literal line:
 Issue title: ${ISSUE_TITLE}
 EOF
 
-claude --print \
+# Stream claude's output to BOTH the workflow log (stdout) and a
+# preserved file. Previously this was `> /tmp/wiwi-run.log 2>&1`,
+# which silenced the GH Actions log entirely for the run — you
+# couldn't tell from outside whether wiwi was making progress,
+# looping, or hung. Streaming is essential when the run can take an
+# hour: a developer watching `gh run watch` should see each tool
+# call land in near-real-time.
+#
+# `stdbuf -oL` forces line-buffered stdout from claude and tee
+# (otherwise the 4KB pipe buffer can hide progress for minutes when
+# claude emits small lines slowly).
+#
+# `tee` always exits 0, so we briefly drop `set -e` and capture
+# claude's actual exit via `${PIPESTATUS[0]}`.
+set +e
+stdbuf -oL claude --print \
   --allowed-tools Bash Read Write Edit Grep Glob \
   --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
-  < "$PROMPT" > /tmp/wiwi-run.log 2>&1 || {
-    echo "wiwi run failed (see /tmp/wiwi-run.log)" >&2
-    gh issue comment "$ISSUE_NUMBER" --body "🤖 wiwi could not complete this task. See workflow log."
-    exit 1
-}
+  < "$PROMPT" 2>&1 | stdbuf -oL tee /tmp/wiwi-run.log
+claude_exit=${PIPESTATUS[0]}
+set -e
+
+if [ "$claude_exit" != "0" ]; then
+  echo "wiwi run failed (claude exit=$claude_exit; see /tmp/wiwi-run.log)" >&2
+  gh issue comment "$ISSUE_NUMBER" --body "🤖 wiwi could not complete this task. See workflow log."
+  exit 1
+fi
 
 if [ -f /tmp/wiwi-abort.txt ]; then
   gh issue comment "$ISSUE_NUMBER" --body "🤖 wiwi aborted: $(cat /tmp/wiwi-abort.txt)"


### PR DESCRIPTION
## Summary

Issue #49 hit the 45-min `timeout-minutes` fence on wiwi's first
real run today (after PR#54 unblocked actions/checkout). 45 min
turned out not to be enough for claude to read repo context, edit
4 files, run `just build`, and open a PR — particularly with
LiteLLM-mediated tool round-trips on the slower end.

## Changes

- `.github/workflows/issue-implement.yml`:
  - `timeout-minutes: 45` → `120`.
  - Comment notes that the new fence is meant as a safety net,
    not a target — if a run actually hits it, the triage gate
    is mis-sized, not the fence.

- `scripts/agent-bot/run_wiwi.sh`:
  - Stream claude's output to **both** the workflow log and the
    preserved `/tmp/wiwi-run.log`. Previously claude wrote only to
    the file, which made the GH Actions log show nothing for the
    entire run — impossible to tell from outside whether wiwi was
    progressing, looping, or hung.
  - Wrap with `stdbuf -oL` on both producer and `tee` so the 4 KB
    pipe buffer can't swallow several minutes of output when
    claude emits small lines slowly.
  - Briefly drop `set -e` around the pipeline and capture claude's
    real exit via `${PIPESTATUS[0]}` (tee always exits 0).

## Test plan

- [ ] After merge, re-toggle `agent:try` on issue #49 → wiwi
      workflow runs to completion within 120 min (or, if it hits
      120 min, that's a separate signal worth investigating).
- [ ] During the run, `gh run watch <id>` shows claude tool calls
      landing in near-real-time, not all-at-once at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)