### PR TITLE
wiwi: clear extraheader before push so PAT (workflow scope) wins

### DIFF
--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -73,6 +73,22 @@ jobs:
             echo "::warning::AGENT_GH_TOKEN is not set; wiwi pushes will use GITHUB_TOKEN and downstream workflows will be suppressed by GitHub's anti-recursion rule." >&2
             exit 0
           fi
+          # actions/checkout writes
+          #   http.https://github.com/.extraheader = AUTHORIZATION: basic <base64(x-access-token:GITHUB_TOKEN)>
+          # as part of its persist-credentials path. That header is
+          # sent on every subsequent git operation against github.com
+          # — INCLUDING `git push`, even after we override the push
+          # URL with a PAT-embedded URL. When the request lands at
+          # GitHub the extraheader's GITHUB_TOKEN (a GitHub App
+          # token without `workflows` permission) is picked over the
+          # URL-embedded PAT, and any push that touches a file under
+          # `.github/workflows/` is rejected with:
+          #   refusing to allow a GitHub App to create or update workflow
+          #   <path> without `workflows` permission
+          # Clearing the extraheader here lets the URL-embedded PAT
+          # (which DOES have `workflow` scope) be the sole credential
+          # on push.
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url --push origin \
             "https://x-access-token:${AGENT_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 


### PR DESCRIPTION
## Summary

wiwi run #49 v2 (run id 26466455693) successfully implemented the
full Heron Phase 1 rebrand in 41 min — branch created, 6 edits
committed, `cargo build --release -p heron` green — but the final
`git push` was rejected by GitHub:

```
remote rejected: refusing to allow a GitHub App to create or update
workflow .github/workflows/release.yml without `workflows` permission
```

even though `AGENT_GH_TOKEN` is a classic PAT with the `workflow`
scope, and PR#54 sets the push URL with that PAT embedded.

## Root cause

`actions/checkout@v4` writes its credentials into the git config as:

```
http.https://github.com/.extraheader = AUTHORIZATION: basic <base64(x-access-token:GITHUB_TOKEN)>
```

This header is sent on **every** subsequent git operation against
`github.com` — including `git push`, even after we override the push
URL with a PAT-embedded URL. GitHub receives both auth surfaces on
the push, picks the extraheader's GITHUB_TOKEN (a GitHub App token
without `workflows` permission) over the URL-embedded PAT, and
rejects any push touching `.github/workflows/`.

## Fix

Drop the extraheader after actions/checkout so the URL-embedded PAT
is the sole credential on push. The fix lives inside the existing
"Use AGENT_GH_TOKEN for `git push`" step, gated on AGENT_GH_TOKEN
being set, so behaviour stays unchanged when the PAT isn't
configured.

## Test plan

- [ ] After merge, re-toggle `agent:try` on issue #49 → wiwi
      run reaches `git push` step → push succeeds → draft PR
      opens within ~30 s.
- [ ] If wiwi modifies a `.github/workflows/*.yml` as part of the
      implementation (issue #49 does this for release.yml), the
      push still goes through (this PR's specific regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)