### PR TITLE
agent-bot: tolerate transient LiteLLM outages — pre-flight wait + mid-run retry

### DIFF
--- a/scripts/agent-bot/run_triage.sh
+++ b/scripts/agent-bot/run_triage.sh
@@ -38,6 +38,14 @@ Issue title: ${ISSUE_TITLE}
 Author: ${ISSUE_AUTHOR}
 EOF
 
+# Wait for LiteLLM to be reachable before burning a runner slot
+# inside claude --print. Caps at 30 min by default; configurable
+# via MAX_LITELLM_WAIT_SECONDS. See scripts/lib/litellm-wait.sh.
+LITELLM_WAIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/litellm-wait.sh"
+# shellcheck source=../lib/litellm-wait.sh
+source "$LITELLM_WAIT"
+wait_for_litellm || exit $?
+
 # Run claude in print mode against our LiteLLM-style endpoint.
 claude --print \
   --allowed-tools Bash Read Grep Glob WebFetch \

--- a/scripts/agent-bot/run_triage.sh
+++ b/scripts/agent-bot/run_triage.sh
@@ -47,14 +47,47 @@ source "$LITELLM_WAIT"
 wait_for_litellm || exit $?
 
 # Run claude in print mode against our LiteLLM-style endpoint.
-claude --print \
-  --allowed-tools Bash Read Grep Glob WebFetch \
-  --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
-  < "$PROMPT" > "$OUT" 2> /tmp/triage-stderr.log || {
+# Wrap in a retry loop that catches the specific case "claude
+# crashed because LiteLLM died mid-stream". Up to CLAUDE_RETRY_MAX
+# retries (default 2 → 3 attempts total). Triage is idempotent —
+# the input is just the issue body — so restart from scratch is
+# safe.
+CLAUDE_RETRY_MAX="${CLAUDE_RETRY_MAX:-2}"
+attempt=0
+claude_rc=0
+while true; do
+    set +e
+    claude --print \
+      --allowed-tools Bash Read Grep Glob WebFetch \
+      --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
+      < "$PROMPT" > "$OUT" 2> /tmp/triage-stderr.log
+    claude_rc=$?
+    set -e
+
+    [ "$claude_rc" -eq 0 ] && break
+
+    # claude failed. Was it because LiteLLM is down right now?
+    if ! litellm_appears_down; then
+        # LiteLLM is up; the failure is something else (rate limit,
+        # token budget, claude bug). Don't retry.
+        break
+    fi
+
+    if [ "$attempt" -ge "$CLAUDE_RETRY_MAX" ]; then
+        echo "::error::triage claude died $((attempt+1)) times with LiteLLM down each time; giving up" >&2
+        break
+    fi
+
+    attempt=$((attempt + 1))
+    echo "::warning::triage claude exited $claude_rc with LiteLLM down; waiting + retrying (attempt $((attempt+1))/$((CLAUDE_RETRY_MAX+1)))" >&2
+    wait_for_litellm || break
+done
+
+if [ "$claude_rc" -ne 0 ]; then
     echo "triage agent failed (see workflow log)" >&2
     cat /tmp/triage-stderr.log >&2
     exit 1
-}
+fi
 
 # Strict JSON parse: scan every line, keep ones that are valid JSON AND
 # carry a `verdict` field, take the last. This rejects lines inside

--- a/scripts/agent-bot/run_wiwi.sh
+++ b/scripts/agent-bot/run_wiwi.sh
@@ -46,6 +46,16 @@ You are **wiwi**, the dev agent. Implement the change requested by issue
   the fallback produces a single "wiwi: auto-commit" message that's
   useless to reviewers compared to your own intentional commit
   messages.
+- **You may be a RESUMED run.** If \`git log origin/main..HEAD\` shows
+  existing commits OR \`git status\` shows uncommitted edits when you
+  start, the previous attempt crashed mid-run (typically a LiteLLM /
+  GLM-5 hiccup) and the driver is retrying. Treat that state as your
+  starting point: do NOT redo work that's already committed; do
+  verify the partial state makes sense (read the diffs, build, run
+  tests); then continue toward the issue's acceptance criteria. If
+  the existing state is incoherent and you cannot make sense of it,
+  STOP and write to /tmp/wiwi-abort.txt explaining why so a human
+  can intervene.
 
 When done, write a brief summary to /tmp/wiwi-summary.md (Markdown) for
 the PR body. End it with the literal line:
@@ -79,13 +89,43 @@ wait_for_litellm || exit $?
 #
 # `tee` always exits 0, so we briefly drop `set -e` and capture
 # claude's actual exit via `${PIPESTATUS[0]}`.
-set +e
-stdbuf -oL claude --print \
-  --allowed-tools Bash Read Write Edit Grep Glob \
-  --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
-  < "$PROMPT" 2>&1 | stdbuf -oL tee /tmp/wiwi-run.log
-claude_exit=${PIPESTATUS[0]}
-set -e
+#
+# Retry on transient LiteLLM mid-stream failures: if claude exits
+# non-zero AND the backend now looks down (5xx / connect-refused /
+# timeout — not 4xx, which means LiteLLM is choosing to reject and
+# waiting won't help), wait for LiteLLM to come back and re-run
+# claude from scratch. The prompt above tells claude how to resume
+# from the partial state on disk. Up to CLAUDE_RETRY_MAX retries
+# (default 2 → 3 attempts total).
+CLAUDE_RETRY_MAX="${CLAUDE_RETRY_MAX:-2}"
+attempt=0
+claude_exit=0
+while true; do
+    set +e
+    stdbuf -oL claude --print \
+      --allowed-tools Bash Read Write Edit Grep Glob \
+      --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
+      < "$PROMPT" 2>&1 | stdbuf -oL tee /tmp/wiwi-run.log
+    claude_exit=${PIPESTATUS[0]}
+    set -e
+
+    [ "$claude_exit" -eq 0 ] && break
+
+    if ! litellm_appears_down; then
+        # LiteLLM is up — failure is something else (claude
+        # internal error, prompt issue, token budget). Don't retry.
+        break
+    fi
+
+    if [ "$attempt" -ge "$CLAUDE_RETRY_MAX" ]; then
+        echo "::error::wiwi claude died $((attempt+1)) times with LiteLLM down; giving up" >&2
+        break
+    fi
+
+    attempt=$((attempt + 1))
+    echo "::warning::wiwi claude exited $claude_exit, LiteLLM down; waiting + retrying (attempt $((attempt+1))/$((CLAUDE_RETRY_MAX+1)))" >&2
+    wait_for_litellm || break
+done
 
 if [ "$claude_exit" != "0" ]; then
   echo "wiwi run failed (claude exit=$claude_exit; see /tmp/wiwi-run.log)" >&2

--- a/scripts/agent-bot/run_wiwi.sh
+++ b/scripts/agent-bot/run_wiwi.sh
@@ -55,6 +55,16 @@ the PR body. End it with the literal line:
 Issue title: ${ISSUE_TITLE}
 EOF
 
+# Wait for LiteLLM to be reachable before launching claude. Without
+# this, a transient GLM-5 / LiteLLM restart that happens during the
+# (often-15+ min) self-hosted runner queue wait kills the run
+# immediately and wastes the queue wait + branch-prep work. Caps at
+# 30 min by default; configurable via MAX_LITELLM_WAIT_SECONDS.
+LITELLM_WAIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/litellm-wait.sh"
+# shellcheck source=../lib/litellm-wait.sh
+source "$LITELLM_WAIT"
+wait_for_litellm || exit $?
+
 # Stream claude's output to BOTH the workflow log (stdout) and a
 # preserved file. Previously this was `> /tmp/wiwi-run.log 2>&1`,
 # which silenced the GH Actions log entirely for the run — you

--- a/scripts/lib/litellm-wait.sh
+++ b/scripts/lib/litellm-wait.sh
@@ -1,0 +1,108 @@
+# Shared helper: poll LiteLLM until it answers /v1/models with the
+# configured API key, with exponential backoff. Source from any
+# agent script that's about to invoke `claude --print` (or any
+# OpenAI-compatible client) — the helper makes the agent tolerant of
+# LiteLLM / GLM-5 restarts that happen DURING a workflow's queue
+# time. Without it, a transient backend hiccup causes the run to
+# exit immediately and the work (and 15-min queue wait, on a busy
+# self-hosted runner) is wasted.
+#
+# Usage:
+#   source "$REPO_ROOT/scripts/lib/litellm-wait.sh"
+#   wait_for_litellm || exit $?
+#   claude --print ...
+#
+# Required env:
+#   ANTHROPIC_BASE_URL  full URL (no trailing slash) — e.g.,
+#                       http://172.16.103.81:4000
+#   ANTHROPIC_API_KEY   bearer token; never printed; used only in
+#                       the Authorization header for the probe.
+#
+# Optional env:
+#   MAX_LITELLM_WAIT_SECONDS  total budget before giving up. Default
+#                              1800 (30 min). Workflow timeouts are
+#                              120-360 min so the budget fits.
+#
+# Output:
+#   On success (LiteLLM reachable): no output unless the helper had
+#   to wait, in which case a single "litellm available again after
+#   <N>s wait" line goes to stderr.
+#   On waiting: one ::warning:: line per retry, with elapsed +
+#   next backoff. No secret values ever printed.
+#   On total failure: one ::error:: line and return code 2.
+#
+# Why the helper polls /v1/models specifically: it's a cheap GET
+# that exercises auth (bearer-token check on the proxy) without
+# burning model tokens. A 200 response means "LiteLLM is up AND our
+# key is accepted" — both preconditions for the upcoming agent run.
+
+# Inner probe — returns:
+#   0     2xx (LiteLLM up AND key accepted)
+#   1     4xx (LiteLLM up, auth rejected — don't wait, fail fast)
+#   2     other status (5xx, connect refused, timeout) — retry
+_litellm_probe() {
+    local url="$1" key="$2"
+    # `-o /dev/null -w %{http_code}` captures status without dumping
+    # the body. `--max-time 5` covers cold-cache responses. We do
+    # NOT use `-f` here so we can distinguish 401 from connect-
+    # refused / 5xx.
+    local code
+    code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+        -H "Authorization: Bearer ${key}" \
+        "${url}/v1/models" 2>/dev/null) || code='000'
+    case "$code" in
+        2*)  return 0 ;;
+        4*)  return 1 ;;
+        *)   return 2 ;;
+    esac
+}
+
+wait_for_litellm() {
+    local url="${ANTHROPIC_BASE_URL:?ANTHROPIC_BASE_URL must be set}"
+    local key="${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}"
+    local max="${MAX_LITELLM_WAIT_SECONDS:-1800}"
+
+    # Initial probe — most calls succeed here and the function
+    # returns silently.
+    _litellm_probe "$url" "$key"
+    local rc=$?
+    case $rc in
+        0) return 0 ;;
+        1)
+            echo "::error::litellm reachable but rejected our API key (4xx). Not waiting — check LITELLM_API_KEY secret." >&2
+            return 3
+            ;;
+    esac
+
+    local elapsed=0
+    local backoff=10
+
+    while [ "$elapsed" -lt "$max" ]; do
+        echo "::warning::litellm unreachable; sleeping ${backoff}s before retry (elapsed: ${elapsed}s / ${max}s)" >&2
+        sleep "$backoff"
+        elapsed=$((elapsed + backoff))
+
+        _litellm_probe "$url" "$key"
+        rc=$?
+        case $rc in
+            0)
+                echo "litellm available again after ${elapsed}s wait" >&2
+                return 0
+                ;;
+            1)
+                echo "::error::litellm now responds 4xx — auth rejected after wait. Stopping." >&2
+                return 3
+                ;;
+        esac
+
+        # Exponential backoff, capped at 5 min so we don't sleep
+        # past a recovery window.
+        backoff=$((backoff * 2))
+        if [ "$backoff" -gt 300 ]; then
+            backoff=300
+        fi
+    done
+
+    echo "::error::litellm still unreachable after ${max}s; giving up" >&2
+    return 2
+}

--- a/scripts/lib/litellm-wait.sh
+++ b/scripts/lib/litellm-wait.sh
@@ -106,3 +106,36 @@ wait_for_litellm() {
     echo "::error::litellm still unreachable after ${max}s; giving up" >&2
     return 2
 }
+
+# Returns 0 (true) when the LiteLLM endpoint looks DOWN right now
+# (connect-refused, timeout, or 5xx). Returns 1 (false) when it is
+# serving any response — 2xx OR 4xx. The 4xx case is deliberately
+# treated as "not down": LiteLLM is up and choosing to reject; that
+# is a configuration issue, not a transient outage to wait through.
+#
+# Designed to be called immediately after a `claude --print` failure
+# to decide whether to retry. Pattern in the agent scripts:
+#
+#   while true; do
+#       claude --print ...  ; rc=$?
+#       [ $rc -eq 0 ] && break
+#       litellm_appears_down || break   # not down → real failure
+#       [ $attempt -ge $CLAUDE_RETRY_MAX ] && break
+#       attempt=$((attempt+1))
+#       wait_for_litellm || break        # wait for recovery
+#   done
+#
+# CLAUDE_RETRY_MAX is per-caller; default 2 in the agent scripts
+# (giving 3 attempts total). The retry restarts claude from scratch
+# — for stateful agents (wiwi) any work already committed to the
+# branch is preserved by virtue of being on disk; in-flight, not-yet
+# -committed work is lost. That's an acceptable trade because the
+# alternative (no retry) loses the whole run anyway.
+litellm_appears_down() {
+    _litellm_probe "${ANTHROPIC_BASE_URL:?}" "${ANTHROPIC_API_KEY:?}"
+    local rc=$?
+    case $rc in
+        0|1) return 1 ;;  # up (2xx) or auth-rejecting (4xx) — not "down"
+        *)   return 0 ;;  # 5xx / connect-refused / timeout — looks down
+    esac
+}

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -58,25 +58,56 @@ ALLOWED_TOOLS="$(grep -v '^#' "$WORKDIR/allowed_tools.txt" \
 # right after it gets consumed as an extra tool name and claude then
 # errors with "Input must be provided either through stdin or as a
 # prompt argument when using --print".
-timeout 1800 claude \
-  --print \
-  --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
-  --max-turns 60 \
-  --output-format text \
-  --permission-mode acceptEdits \
-  --allowed-tools "$ALLOWED_TOOLS" \
-  < "$PROMPT" \
-  > "$OUT" \
-  2> "$LOG" \
-  || {
-    rc=$?
-    echo "ERROR: agent exited with code $rc" >> "$LOG"
+#
+# Retry on transient LiteLLM mid-stream failures: if claude exits
+# non-zero AND the backend looks down right now (5xx / connect-
+# refused / timeout — NOT 4xx), wait for LiteLLM and re-run. Review
+# is idempotent (the OUT file just gets overwritten); restart from
+# scratch is safe. Up to CLAUDE_RETRY_MAX retries (default 2).
+CLAUDE_RETRY_MAX="${CLAUDE_RETRY_MAX:-2}"
+attempt=0
+claude_rc=0
+while true; do
+    set +e
+    timeout 1800 claude \
+      --print \
+      --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
+      --max-turns 60 \
+      --output-format text \
+      --permission-mode acceptEdits \
+      --allowed-tools "$ALLOWED_TOOLS" \
+      < "$PROMPT" \
+      > "$OUT" \
+      2> "$LOG"
+    claude_rc=$?
+    set -e
+
+    [ "$claude_rc" -eq 0 ] && break
+
+    if ! litellm_appears_down; then
+        # LiteLLM is up — failure is real (timeout, claude crash,
+        # rate limit, etc). Don't retry.
+        break
+    fi
+
+    if [ "$attempt" -ge "$CLAUDE_RETRY_MAX" ]; then
+        echo "::error::vivi claude died $((attempt+1)) times with LiteLLM down; giving up" >&2
+        break
+    fi
+
+    attempt=$((attempt + 1))
+    echo "::warning::vivi claude exited $claude_rc, LiteLLM down; waiting + retrying (attempt $((attempt+1))/$((CLAUDE_RETRY_MAX+1)))" >&2
+    wait_for_litellm || break
+done
+
+if [ "$claude_rc" -ne 0 ]; then
+    echo "ERROR: agent exited with code $claude_rc" >> "$LOG"
     # Don't synthesize a PR-bound failure summary here — post_review.py
     # is gated on AGENT_EXIT and will skip the PR entirely on non-zero.
     # The OUT file is left as-is (possibly empty) for workflow-log
     # consumption.
-    exit "$rc"
-  }
+    exit "$claude_rc"
+fi
 
 # Sanity: non-empty markdown with at least a `### Summary` heading.
 if ! grep -q '^### Summary' "$OUT"; then

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -29,21 +29,17 @@ BASE_REF="$(gh pr view "$PR_NUMBER" --json baseRefName --jq .baseRefName)"
 export PR_NUMBER HEAD_SHA BASE_REF
 envsubst < "$WORKDIR/prompt.md" > "$PROMPT"
 
-# Pre-flight: verify LiteLLM is reachable AND our API key is
-# accepted. The key check is what tells us the secret is wired
-# correctly before we burn turns on the real agent run.
-if ! curl -fsS --max-time 5 \
-    -H "Authorization: Bearer ${ANTHROPIC_API_KEY:-}" \
-    "${ANTHROPIC_BASE_URL:-}/v1/models" >/dev/null 2>&1; then
-  # Pre-flight diagnostics MUST stay local — `post_review.py` is
-  # gated to skip posting when the agent exits non-zero, so this
-  # OUT file is consumed only by the workflow log. Endpoint URL +
-  # full curl trace go to the workflow log on the next two lines.
+# Pre-flight: wait until LiteLLM is reachable AND our API key is
+# accepted. The wait covers the common case where GLM-5 / LiteLLM
+# is restarting when this workflow fires; if it's still down after
+# 30 min (MAX_LITELLM_WAIT_SECONDS) the function returns 2 and we
+# pass through with the same diagnostic shape as before. Shared
+# helper in scripts/lib/litellm-wait.sh.
+LITELLM_WAIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/litellm-wait.sh"
+# shellcheck source=../lib/litellm-wait.sh
+source "$LITELLM_WAIT"
+if ! wait_for_litellm; then
   echo "ERROR: agent unavailable (pre-flight)" > "$OUT"
-  echo "pre-flight: backend unreachable at ${ANTHROPIC_BASE_URL:-<unset>}" >&2
-  curl -v --max-time 5 \
-    -H "Authorization: Bearer ${ANTHROPIC_API_KEY:-}" \
-    "${ANTHROPIC_BASE_URL:-}/v1/models" >&2 2>&1 || true
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

Two-commit PR that closes the LLM-outage class of agent failures:

1. **Pre-flight wait** (commit `27145c5`) — before launching
   `claude --print`, poll `${ANTHROPIC_BASE_URL}/v1/models` until
   it serves 2xx with our key. Exponential backoff up to 30 min.
   Covers "LiteLLM restarting during runner queue wait".

2. **Mid-run retry** (commit `00041f4`) — if `claude --print`
   exits non-zero AND LiteLLM is down at the moment of exit (5xx /
   connect-refused / timeout — NOT 4xx, which means LiteLLM is up
   and rejecting), wait for backend recovery and restart claude
   from scratch. Up to `CLAUDE_RETRY_MAX` retries (default 2 → 3
   attempts total). Covers "LiteLLM dies mid-conversation".

## Why

Today's session burned hours on agent failures that traced to GLM-5
restarts: vivi PR#59 run 3 silently exited 1 partway through a GLM-5
restart and the workflow's 15-min queue wait was wasted; multiple
wiwi attempts hit the same class.

## Behaviour matrix

When claude exits non-zero, the new `litellm_appears_down` helper
classifies the failure:

| LiteLLM status at exit | Helper verdict | Agent behaviour |
|------------------------|----------------|-----------------|
| 2xx (key OK) | NOT down | Don't retry — claude failed for a non-backend reason (rate limit, claude bug, token budget). Fail as before. |
| 4xx (key wrong) | NOT down | Don't retry — config issue, waiting won't help. Fail fast. |
| 5xx / connect-refused / timeout | Down | Wait via `wait_for_litellm`, then restart claude. Up to `CLAUDE_RETRY_MAX` times. |

## Per-agent specifics

- **`run_triage.sh`** — Idempotent; single JSON verdict per issue.
  Restart from scratch is safe.
- **`run_review.sh`** — Writes to a single OUT file. Restart
  overwrites cleanly.
- **`run_wiwi.sh`** — Stateful: branch + commits + uncommitted edits
  may already exist from a previous attempt. **Prompt updated**
  (commit B) to tell claude about resume semantics:
  > You may be a RESUMED run. If `git log origin/main..HEAD` shows
  > existing commits OR `git status` shows uncommitted edits when you
  > start, the previous attempt crashed mid-run. Treat that state as
  > your starting point: do NOT redo work that's already committed;
  > do verify the partial state makes sense; then continue toward the
  > acceptance criteria. If state is incoherent, write to
  > `/tmp/wiwi-abort.txt` for human intervention.

## Budget

Default budgets — each tunable via env:
- `MAX_LITELLM_WAIT_SECONDS=1800` — per-wait cap (30 min)
- `CLAUDE_RETRY_MAX=2` → 3 attempts total

So an in-flight backend outage of up to ~90 min total is absorbed
silently. Past that, the agent fails and the next workflow_run /
label-toggle re-triggers normally.

## What this does NOT cover

- Claude binary itself crashing (would surface as non-zero exit
  with LiteLLM still reachable — correctly does NOT retry; this is
  a real failure, not transient)
- LiteLLM up but returning malformed JSON / wrong protocol (no
  signal to distinguish from a claude bug)
- 4xx auth issues (fast-fail with diagnostic; not transient)
- Mid-stream output already consumed by tee / OUT file is not
  cleaned up before retry — a retried run will overwrite. For wiwi
  this means the previous attempt's terminal output is gone from
  `/tmp/wiwi-run.log` once the retry starts (only the last
  attempt's log persists).

## Test plan

Smoke-tested locally:
- [x] `litellm_appears_down` against live LiteLLM with dummy key → 4xx → returns 1 (NOT down). Correct: don't wait for a config issue.
- [x] `litellm_appears_down` against unreachable port → returns 0 (down). Correct: retry candidate.
- [x] `wait_for_litellm` against unreachable port + 20 s budget → 2 backoff log lines then rc=2.
- [x] All 4 modified scripts pass `bash -n`.

After merge:
- [ ] Re-toggle `agent:try` on a small test issue while LiteLLM is up — agent runs to completion normally (no behaviour change for the happy path).
- [ ] Re-toggle `agent:try`, then stop LiteLLM for 30 s mid-run — agent logs `::warning::wiwi claude exited X, LiteLLM down; waiting + retrying` and proceeds when LiteLLM comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)