### PR TITLE
ci: deterministic recovery + schema-migration tests (P1 quality infra)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,29 @@ jobs:
           CARGO_TERM_COLOR: always
         run: cargo test --workspace --quiet
 
+      - name: cargo test (fault-injection feature)
+        # Builds ts-storage-duckdb with the `fault-injection` feature and
+        # runs its concurrent_tests module, which contains the
+        # deterministic recovery tests that drive the PR#48-class
+        # "FATAL → reopen → every surface works" path. The feature is
+        # off by default in `cargo test --workspace` above so production
+        # builds and the headline test run see no extra code; this step
+        # exists to keep the recovery-path tests green.
+        working-directory: server
+        env:
+          CARGO_TERM_COLOR: always
+        run: cargo test -p ts-storage-duckdb --features fault-injection --quiet
+
+      - name: cargo test (schema-migration golden DBs)
+        # Locks in the auto-migration code in ts-storage-duckdb/src/schema.rs
+        # against silent regression. Tests synthesize the on-disk shape
+        # of older releases via DDL, run current init(), and assert the
+        # expected drift (columns added/dropped, legacy values rewritten).
+        working-directory: server
+        env:
+          CARGO_TERM_COLOR: always
+        run: cargo test -p ts-storage-duckdb --test migrations --quiet
+
       - name: cargo clippy (informational; not enforcing yet)
         working-directory: server
         # Clippy enforcement deferred — main has accumulated lint debt

--- a/scripts/testdata/regenerate-golden-dbs.sh
+++ b/scripts/testdata/regenerate-golden-dbs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regenerate per-release golden DuckDB fixtures under testdata/golden-dbs/.
+#
+# Default behavior (no tag arg): print a friendly note and exit 0. The
+# migration test suite at server/ts-storage-duckdb/tests/migrations.rs
+# uses **code-defined synthetic fixtures** rather than binary blobs as
+# of v0.3.0, so regenerating fixtures is opt-in.
+#
+# Usage:
+#   scripts/testdata/regenerate-golden-dbs.sh                   # status only
+#   scripts/testdata/regenerate-golden-dbs.sh <tag>             # build + seed
+#   scripts/testdata/regenerate-golden-dbs.sh <tag1> <tag2>...  # batch
+#
+# Effect: for each <tag>, builds the binary at that ref in a temporary
+# worktree, runs it against a canonical seed dataset, and writes
+#   testdata/golden-dbs/<tag>.duckdb
+#
+# NOTE: the seed-driver invocation below assumes a `--seed-golden-db
+# <path>` CLI flag on the binary, which does NOT exist as of v0.3.0.
+# Implement it (and remove this NOTE) before the first time you try to
+# regenerate a fixture. The pattern is in the migration test file —
+# the canonical row counts there define the contract.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="$REPO_ROOT/testdata/golden-dbs"
+
+if [ $# -eq 0 ]; then
+    cat <<'NOTE'
+No tag specified.
+
+Migration tests currently use code-defined synthetic fixtures, not
+binary .duckdb files (see testdata/golden-dbs/README.md). Run this
+script with one or more release tags only when a future migration
+needs an opaque on-disk state that DDL alone cannot reproduce.
+
+Example:
+    scripts/testdata/regenerate-golden-dbs.sh v0.2.0
+NOTE
+    exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+
+for TAG in "$@"; do
+    echo "==> Regenerating fixture for $TAG"
+    WORKTREE="$(mktemp -d -t "ts-golden-${TAG}-XXXXXX")"
+    trap 'rm -rf "$WORKTREE"' EXIT
+
+    git -C "$REPO_ROOT" worktree add --detach "$WORKTREE" "$TAG"
+
+    (
+        cd "$WORKTREE/server"
+        cargo build --release -p tokenscope
+        # Bin name was `tokenscope` before 0.3.0 (PR#59 rebrand to `heron`);
+        # the worktree's binary name is the one shipped by that tag.
+        BIN="$(ls "$WORKTREE/server/target/release/" | grep -E '^(tokenscope|heron)$' | head -1)"
+        if [ -z "$BIN" ]; then
+            echo "Cannot locate built binary for $TAG" >&2
+            exit 1
+        fi
+        "$WORKTREE/server/target/release/$BIN" \
+            --seed-golden-db "$OUT_DIR/$TAG.duckdb"
+    )
+
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE"
+    trap - EXIT
+    echo "==> Wrote $OUT_DIR/$TAG.duckdb"
+done

--- a/server/ts-storage-duckdb/Cargo.toml
+++ b/server/ts-storage-duckdb/Cargo.toml
@@ -21,3 +21,9 @@ bytes.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+# Enables `fault_injection` module + injection hooks on backend paths.
+# Off by default: production builds and `cargo test --workspace` see
+# no extra code. Tests that exercise recovery paths opt in explicitly.
+fault-injection = []

--- a/server/ts-storage-duckdb/src/calls.rs
+++ b/server/ts-storage-duckdb/src/calls.rs
@@ -247,6 +247,16 @@ impl DuckDbBackend {
         if calls.is_empty() {
             return Ok(());
         }
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
+        }
         let conn = self.write_calls_conn.clone();
         tokio::task::spawn_blocking(move || {
             // Serialize/format outside the writer Mutex so the lock is held

--- a/server/ts-storage-duckdb/src/concurrent_tests.rs
+++ b/server/ts-storage-duckdb/src/concurrent_tests.rs
@@ -313,3 +313,169 @@ async fn reopen_all_connections_keeps_reads_and_writes_alive() {
         "post-reopen writes must persist and be queryable"
     );
 }
+
+// Deterministic counterpart to the test above. Where that one can only
+// say "if we call reopen, downstream surfaces keep working", this one
+// drives the actual sequence the production sweeper sees:
+//
+//   1. A write fails with a FATAL invalidation,
+//   2. `reopen_all_connections` rebuilds the writer + reader set,
+//   3. Subsequent writes and reads on every code path succeed.
+//
+// PR#48 was missed because the prod failure could not be reproduced from
+// a unit test (real DuckDB FATAL needs real load pressure). The
+// fault-injection path closes that gap: armed faults look identical to
+// the real FATAL from the recovery code's perspective.
+#[cfg(feature = "fault-injection")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reopen_recovers_from_injected_duckdb_invalidate() {
+    use crate::fault_injection::{FaultGuard, FaultPoint};
+
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("reopen-injected.duckdb");
+    let backend =
+        Arc::new(DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).unwrap());
+    backend.init().await.unwrap();
+
+    // Baseline write, before any fault — exercises the writer set.
+    backend.write_turns(vec![mk_turn(0)]).await.unwrap();
+
+    // ARM: every write path now synthesizes a FATAL invalidation error
+    // identical in shape to what DuckDB returns when its in-process
+    // instance dies.
+    {
+        let _guard = FaultGuard::arm(backend.fault_set(), FaultPoint::DuckDbInvalidate);
+        assert!(backend.fault_set().should_fire(FaultPoint::DuckDbInvalidate));
+
+        let err = backend
+            .write_turns(vec![mk_turn(1)])
+            .await
+            .expect_err("write_turns must surface the injected FATAL");
+        assert!(
+            format!("{err}").contains("FATAL"),
+            "injected error message must mention FATAL: got {err}"
+        );
+
+        let err = backend
+            .write_calls(vec![mk_call(0)])
+            .await
+            .expect_err("write_calls must surface the injected FATAL");
+        assert!(format!("{err}").contains("FATAL"));
+
+        let err = backend
+            .write_metrics(vec![mk_metric(0)])
+            .await
+            .expect_err("write_metrics must surface the injected FATAL");
+        assert!(format!("{err}").contains("FATAL"));
+
+        // Recover. reopen_all_connections itself is NOT gated by the
+        // fault — it must succeed even while the fault is armed,
+        // because in production the sweeper invokes reopen *because*
+        // writes are FATAL'ing.
+        backend.reopen_all_connections().await.unwrap();
+        // _guard drops here, disarming DuckDbInvalidate.
+    }
+
+    assert!(
+        !backend.fault_set().should_fire(FaultPoint::DuckDbInvalidate),
+        "FaultGuard::drop must disarm"
+    );
+
+    // Post-recovery: every writer mutex must accept fresh work, and
+    // every reader path (turn list, distinct-agent-kinds — backed by
+    // the pool that `reopen_all_connections` is supposed to have fully
+    // replaced) must serve the new row plus the pre-fault baseline.
+    backend.write_turns(vec![mk_turn(2)]).await.unwrap();
+    backend.write_calls(vec![mk_call(0)]).await.unwrap();
+    backend.write_metrics(vec![mk_metric(0)]).await.unwrap();
+
+    let turns_q = TurnsQuery {
+        time_range: TimeRange {
+            start_us: 1_700_000_000_000_000 - 1_000_000,
+            end_us: 1_700_000_000_000_000 + 60_000_000_000,
+        },
+        filter: DimensionFilter::default(),
+        client_ips: vec![],
+        server_ports: vec![],
+        statuses: vec![],
+        agent_kinds: vec![],
+        sort_by: "start_time".into(),
+        sort_order: "desc".into(),
+        page: 1,
+        page_size: 50,
+        include_proxy_hops: false,
+    };
+    let page = backend.query_turns(&turns_q).await.unwrap();
+    assert_eq!(
+        page.total, 2,
+        "post-recovery list query must see baseline turn-0 + new turn-2"
+    );
+
+    // Drain the pool more than its size so any stale-handle reuse on
+    // any reader slot would surface.
+    for _ in 0..4 {
+        let kinds = backend
+            .query_distinct_agent_kinds(&DistinctAgentKindsQuery {
+                time_range: turns_q.time_range.clone(),
+                filter: DimensionFilter::default(),
+                include_proxy_hops: false,
+            })
+            .await
+            .unwrap();
+        assert!(
+            kinds.iter().any(|k| k == "test"),
+            "post-recovery distinct-kinds must see the seeded agent_kind"
+        );
+    }
+}
+
+// Independently verify the ReadPoolPoisoned injection point —
+// `pair_sweeper` and a few API surfaces depend on pool acquires never
+// silently returning a stale connection. The fault makes the next
+// `acquire()` return a poisoned-pool error so tests can exercise the
+// downstream handling path.
+#[cfg(feature = "fault-injection")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn read_pool_poisoned_fault_propagates_to_reads() {
+    use crate::fault_injection::{FaultGuard, FaultPoint};
+
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("pool-poison.duckdb");
+    let backend =
+        Arc::new(DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).unwrap());
+    backend.init().await.unwrap();
+    backend.write_turns(vec![mk_turn(0)]).await.unwrap();
+
+    let turns_q = TurnsQuery {
+        time_range: TimeRange {
+            start_us: 1_700_000_000_000_000 - 1_000_000,
+            end_us: 1_700_000_000_000_000 + 60_000_000_000,
+        },
+        filter: DimensionFilter::default(),
+        client_ips: vec![],
+        server_ports: vec![],
+        statuses: vec![],
+        agent_kinds: vec![],
+        sort_by: "start_time".into(),
+        sort_order: "desc".into(),
+        page: 1,
+        page_size: 50,
+        include_proxy_hops: false,
+    };
+
+    {
+        let _guard = FaultGuard::arm(backend.fault_set(), FaultPoint::ReadPoolPoisoned);
+        let err = backend
+            .query_turns(&turns_q)
+            .await
+            .expect_err("query must surface poisoned-pool error");
+        assert!(
+            format!("{err}").contains("read pool poisoned"),
+            "injected error must mention pool poisoning: got {err}"
+        );
+    }
+
+    // After guard drops, queries work again.
+    let page = backend.query_turns(&turns_q).await.unwrap();
+    assert_eq!(page.total, 1);
+}

--- a/server/ts-storage-duckdb/src/exchanges.rs
+++ b/server/ts-storage-duckdb/src/exchanges.rs
@@ -74,6 +74,16 @@ impl DuckDbBackend {
         if exchanges.is_empty() {
             return Ok(());
         }
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
+        }
         let conn = self.write_exchanges_conn.clone();
         tokio::task::spawn_blocking(move || {
             let prepared: Vec<PreparedExchange> =

--- a/server/ts-storage-duckdb/src/fault_injection.rs
+++ b/server/ts-storage-duckdb/src/fault_injection.rs
@@ -1,0 +1,122 @@
+//! Deterministic fault injection for backend-recovery tests.
+//!
+//! Entirely feature-gated: when the `fault-injection` cargo feature is off,
+//! this module does not compile and call sites guarded by
+//! `#[cfg(feature = "fault-injection")]` evaporate. Production binaries
+//! pay zero overhead.
+//!
+//! Why this exists: the canonical PR#48-class incident (DuckDB FATAL,
+//! read pool stayed poisoned, prod 500-looped three times) is exactly
+//! the kind of thing a unit test should pin down — but the FATAL itself
+//! cannot be triggered deterministically from a synthetic load. Fault
+//! injection lets the recovery path be exercised on demand and verified
+//! end-to-end (write returns FATAL → reopen → every downstream surface
+//! works) without waiting for prod traffic to manifest the bug again.
+//!
+//! Scope is per-backend: each `DuckDbBackend` owns its own armed-fault
+//! set so parallel tests running with the `fault-injection` feature do
+//! not leak state across one another.
+//!
+//! Usage in tests:
+//!
+//! ```ignore
+//! let _guard = FaultGuard::arm(&backend, FaultPoint::DuckDbInvalidate);
+//! let err = backend.write_turns(vec![mk_turn(0)]).await.unwrap_err();
+//! // _guard's Drop disarms automatically — no leakage into sibling tests.
+//! ```
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use ts_common::error::AppError;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum FaultPoint {
+    /// Make the next write path return a synthesized FATAL invalidation
+    /// error, mimicking DuckDB's in-process instance becoming unusable.
+    DuckDbInvalidate,
+    /// Make the next read-pool acquire surface a poisoned-pool error.
+    ReadPoolPoisoned,
+    /// Make the next write path return a synthesized disk-full error.
+    DiskFull,
+}
+
+/// Per-backend armed-fault set. Cloning an instance shares the same
+/// inner storage — that's what lets the backend and its read pool see
+/// the same armed-fault state without a global.
+#[derive(Clone, Default)]
+pub struct FaultSet {
+    inner: Arc<Mutex<HashSet<FaultPoint>>>,
+}
+
+impl FaultSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn arm(&self, point: FaultPoint) {
+        if let Ok(mut g) = self.inner.lock() {
+            g.insert(point);
+        }
+    }
+
+    pub fn disarm(&self, point: FaultPoint) {
+        if let Ok(mut g) = self.inner.lock() {
+            g.remove(&point);
+        }
+    }
+
+    pub fn disarm_all(&self) {
+        if let Ok(mut g) = self.inner.lock() {
+            g.clear();
+        }
+    }
+
+    pub fn should_fire(&self, point: FaultPoint) -> bool {
+        self.inner
+            .lock()
+            .map(|g| g.contains(&point))
+            .unwrap_or(false)
+    }
+}
+
+/// RAII guard. Arms on construction, disarms on drop. Use in tests so
+/// that a panic-after-arm or an early return never leaks the armed state.
+pub struct FaultGuard {
+    set: FaultSet,
+    point: FaultPoint,
+}
+
+impl FaultGuard {
+    pub fn arm(set: &FaultSet, point: FaultPoint) -> Self {
+        set.arm(point);
+        Self {
+            set: set.clone(),
+            point,
+        }
+    }
+}
+
+impl Drop for FaultGuard {
+    fn drop(&mut self) {
+        self.set.disarm(self.point);
+    }
+}
+
+/// Synthesize the `AppError` that a real DuckDB FATAL invalidation
+/// surfaces to callers. Used by instrumented write paths so injected
+/// faults are indistinguishable from production failures from the
+/// recovery code's perspective.
+pub fn fatal_invalidate_error() -> AppError {
+    AppError::Storage("duckdb FATAL: instance invalidated (fault-injection)".to_string())
+}
+
+/// Synthesize the `AppError` for a disk-full write failure.
+pub fn disk_full_error() -> AppError {
+    AppError::Storage("write failed: ENOSPC (fault-injection)".to_string())
+}
+
+/// Synthesize the `AppError` for a poisoned read pool.
+pub fn read_pool_poisoned_error() -> AppError {
+    AppError::Storage("read pool poisoned (fault-injection)".to_string())
+}

--- a/server/ts-storage-duckdb/src/lib.rs
+++ b/server/ts-storage-duckdb/src/lib.rs
@@ -4,6 +4,8 @@ mod calls;
 mod concurrent_tests;
 mod distincts;
 mod exchanges;
+#[cfg(feature = "fault-injection")]
+pub mod fault_injection;
 mod metrics;
 mod pool;
 mod retention;
@@ -56,6 +58,12 @@ pub struct DuckDbBackend {
     /// Captured at construction; used by `reopen_all_connections` to
     /// rebuild the reader pool at the same size.
     pub(crate) read_pool_size: usize,
+    /// Per-backend armed-fault set. Only present when the
+    /// `fault-injection` feature is enabled; shared by reference with
+    /// `read_pool` so writer-path and reader-path injections both see
+    /// the same set.
+    #[cfg(feature = "fault-injection")]
+    pub(crate) fault_set: fault_injection::FaultSet,
 }
 
 impl DuckDbBackend {
@@ -101,15 +109,30 @@ impl DuckDbBackend {
             pool_size
         );
 
+        #[cfg(feature = "fault-injection")]
+        let fault_set = fault_injection::FaultSet::new();
+
         Ok(Self {
             write_calls_conn: Arc::new(StdMutex::new(calls_writer)),
             write_turns_conn: Arc::new(StdMutex::new(turns_writer)),
             write_metrics_conn: Arc::new(StdMutex::new(metrics_writer)),
             write_exchanges_conn: Arc::new(StdMutex::new(exchanges_writer)),
-            read_pool: ReadPool::new(readers),
+            read_pool: ReadPool::new(
+                readers,
+                #[cfg(feature = "fault-injection")]
+                fault_set.clone(),
+            ),
             db_path: path.to_string(),
             read_pool_size: pool_size,
+            #[cfg(feature = "fault-injection")]
+            fault_set,
         })
+    }
+
+    /// Test-only accessor for the per-backend fault-injection set.
+    #[cfg(feature = "fault-injection")]
+    pub fn fault_set(&self) -> &fault_injection::FaultSet {
+        &self.fault_set
     }
 
     #[cfg(test)]

--- a/server/ts-storage-duckdb/src/metrics.rs
+++ b/server/ts-storage-duckdb/src/metrics.rs
@@ -219,6 +219,16 @@ impl DuckDbBackend {
         if metrics.is_empty() {
             return Ok(());
         }
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
+        }
         let conn = self.write_metrics_conn.clone();
         tokio::task::spawn_blocking(move || {
             let prepared: Vec<PreparedMetric> = metrics.into_iter().map(prepare_metric).collect();
@@ -296,6 +306,16 @@ impl DuckDbBackend {
     pub(crate) async fn write_finish_metrics(&self, metrics: Vec<LlmFinishMetric>) -> Result<()> {
         if metrics.is_empty() {
             return Ok(());
+        }
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
         }
         // Shares the metrics writer Mutex with `write_metrics` so the two
         // long/wide rollups for one bucket flush serialize against each other

--- a/server/ts-storage-duckdb/src/pool.rs
+++ b/server/ts-storage-duckdb/src/pool.rs
@@ -27,10 +27,15 @@ struct ReadPoolInner {
 pub(crate) struct ReadPool {
     inner: Arc<StdMutex<Arc<ReadPoolInner>>>,
     semaphore: Arc<Semaphore>,
+    #[cfg(feature = "fault-injection")]
+    fault_set: crate::fault_injection::FaultSet,
 }
 
 impl ReadPool {
-    pub(crate) fn new(conns: Vec<Connection>) -> Self {
+    pub(crate) fn new(
+        conns: Vec<Connection>,
+        #[cfg(feature = "fault-injection")] fault_set: crate::fault_injection::FaultSet,
+    ) -> Self {
         let size = conns.len();
         let inner = Arc::new(ReadPoolInner {
             conns: StdMutex::new(conns),
@@ -38,10 +43,19 @@ impl ReadPool {
         Self {
             inner: Arc::new(StdMutex::new(inner)),
             semaphore: Arc::new(Semaphore::new(size)),
+            #[cfg(feature = "fault-injection")]
+            fault_set,
         }
     }
 
     pub(crate) async fn acquire(&self) -> Result<PooledConn> {
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::ReadPoolPoisoned) {
+                return Err(crate::fault_injection::read_pool_poisoned_error());
+            }
+        }
         let permit = self
             .semaphore
             .clone()

--- a/server/ts-storage-duckdb/src/turns.rs
+++ b/server/ts-storage-duckdb/src/turns.rs
@@ -125,6 +125,16 @@ impl DuckDbBackend {
         if turns.is_empty() {
             return Ok(());
         }
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
+        }
         let conn = self.write_turns_conn.clone();
         tokio::task::spawn_blocking(move || {
             let prepared: Vec<PreparedTurn> = turns.into_iter().map(prepare_turn).collect();
@@ -714,6 +724,16 @@ impl DuckDbBackend {
         turn_id: &str,
         patch: serde_json::Value,
     ) -> Result<()> {
+        #[cfg(feature = "fault-injection")]
+        {
+            use crate::fault_injection::FaultPoint;
+            if self.fault_set.should_fire(FaultPoint::DuckDbInvalidate) {
+                return Err(crate::fault_injection::fatal_invalidate_error());
+            }
+            if self.fault_set.should_fire(FaultPoint::DiskFull) {
+                return Err(crate::fault_injection::disk_full_error());
+            }
+        }
         let conn = self.write_turns_conn.clone();
         let turn_id = turn_id.to_string();
         tokio::task::spawn_blocking(move || {

--- a/server/ts-storage-duckdb/tests/migrations.rs
+++ b/server/ts-storage-duckdb/tests/migrations.rs
@@ -1,0 +1,363 @@
+//! Schema-migration integration tests.
+//!
+//! Each test synthesizes the on-disk shape of an older `tokenscope`
+//! release directly via DDL — no historical binary build required — then
+//! runs the current `DuckDbBackend::init()` against it and asserts that:
+//!
+//!   1. init succeeds (schema reconciles cleanly)
+//!   2. the expected migrations actually fired (columns added/dropped,
+//!      legacy values rewritten)
+//!   3. canonical read paths still work
+//!
+//! This locks in the existing migration code in `schema.rs` against the
+//! "PR#48 class" — silent regressions where a future refactor breaks the
+//! upgrade path without breaking any fresh-install test.
+//!
+//! Binary `.duckdb` fixtures (per release tag) are out of scope: they
+//! require building each tagged binary, take meaningful disk, and add
+//! drift risk between fixture and reality. The synthesized approach
+//! covers the same migration code paths deterministically. See
+//! `testdata/golden-dbs/README.md` for the binary-fixture flow if/when
+//! per-tag fixtures become necessary.
+
+use std::sync::Arc;
+
+use duckdb::Connection;
+use tempfile::TempDir;
+
+use ts_storage::query::{DimensionFilter, TimeRange, TurnsQuery};
+use ts_storage::StorageBackend;
+use ts_storage_duckdb::DuckDbBackend;
+
+/// Schema shape immediately before Phase 5 added the agent-classification
+/// columns to `llm_calls`. Used to drive the
+/// `phase5_adds_agent_columns_to_llm_calls` test.
+const LEGACY_LLM_CALLS_PRE_PHASE5: &str = "
+CREATE TABLE llm_calls (
+    id                VARCHAR NOT NULL PRIMARY KEY,
+    source_id         VARCHAR NOT NULL DEFAULT '',
+    client_ip         VARCHAR NOT NULL,
+    client_port       USMALLINT NOT NULL,
+    server_ip         VARCHAR NOT NULL,
+    server_port       USMALLINT NOT NULL,
+    request_time      TIMESTAMP NOT NULL,
+    response_time     TIMESTAMP,
+    complete_time     TIMESTAMP,
+    wire_api          VARCHAR NOT NULL,
+    model             VARCHAR NOT NULL,
+    api_type          VARCHAR NOT NULL,
+    is_stream         BOOLEAN NOT NULL,
+    request_path      VARCHAR NOT NULL,
+    status_code       USMALLINT,
+    finish_reason     VARCHAR,
+    input_tokens      UINTEGER,
+    output_tokens     UINTEGER,
+    total_tokens      UINTEGER,
+    cache_read_input_tokens   UINTEGER,
+    cache_creation_input_tokens UINTEGER,
+    ttft_ms           DOUBLE,
+    e2e_latency_ms    DOUBLE,
+    request_body      VARCHAR,
+    response_body     VARCHAR,
+    response_id       VARCHAR,
+    request_headers   VARCHAR,
+    response_headers  VARCHAR
+);
+";
+
+/// `llm_metrics` shape that includes the Phase-4-dropped finish_*_count
+/// columns. The init() migration must drop them.
+const LEGACY_LLM_METRICS_WITH_FINISH_COUNTS: &str = "
+CREATE TABLE llm_metrics (
+    timestamp           TIMESTAMP NOT NULL,
+    source_id           VARCHAR NOT NULL,
+    granularity         VARCHAR NOT NULL,
+    wire_api            VARCHAR NOT NULL,
+    model               VARCHAR NOT NULL,
+    server_ip           VARCHAR NOT NULL,
+    finish_complete_count    UBIGINT NOT NULL DEFAULT 0,
+    finish_length_count      UBIGINT NOT NULL DEFAULT 0,
+    finish_tool_use_count    UBIGINT NOT NULL DEFAULT 0,
+    finish_error_count       UBIGINT NOT NULL DEFAULT 0,
+    finish_cancelled_count   UBIGINT NOT NULL DEFAULT 0
+);
+";
+
+/// `agent_turns` shape with Phase-3 legacy status values still in rows.
+const LEGACY_AGENT_TURNS_WITH_OLD_STATUS: &str = "
+CREATE TABLE agent_turns (
+    source_id          VARCHAR NOT NULL DEFAULT '',
+    turn_id            VARCHAR NOT NULL PRIMARY KEY,
+    session_id         VARCHAR NOT NULL,
+    wire_api           VARCHAR NOT NULL,
+    agent_kind         VARCHAR NOT NULL,
+    client_ip          VARCHAR NOT NULL,
+    server_ip          VARCHAR NOT NULL,
+    start_time         TIMESTAMP NOT NULL,
+    end_time           TIMESTAMP NOT NULL,
+    duration_ms        UBIGINT NOT NULL,
+    call_count         UBIGINT NOT NULL,
+    models_used        VARCHAR,
+    subagents_used     VARCHAR,
+    total_input_tokens UBIGINT NOT NULL,
+    total_output_tokens UBIGINT NOT NULL,
+    total_cache_read_input_tokens   UBIGINT NOT NULL,
+    total_cache_creation_input_tokens UBIGINT NOT NULL,
+    total_cost_usd     DOUBLE,
+    status             VARCHAR NOT NULL,
+    final_finish_reason VARCHAR,
+    user_input_preview VARCHAR,
+    user_call_id       VARCHAR,
+    final_answer_preview VARCHAR,
+    final_call_id      VARCHAR,
+    call_ids           VARCHAR,
+    metadata           VARCHAR
+);
+";
+
+fn synth_db(dir: &TempDir, ddl: &[&str]) -> std::path::PathBuf {
+    let path = dir.path().join("legacy.duckdb");
+    let conn = Connection::open(&path).expect("open synth db");
+    for sql in ddl {
+        conn.execute_batch(sql)
+            .unwrap_or_else(|e| panic!("synth DDL failed: {e}\nsql: {sql}"));
+    }
+    drop(conn);
+    path
+}
+
+fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT column_name FROM duckdb_columns() \
+             WHERE table_name = '{table}' \
+             ORDER BY column_index"
+        ))
+        .expect("prepare duckdb_columns");
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(0))
+        .expect("query duckdb_columns");
+    rows.filter_map(|r| r.ok()).collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn phase5_adds_nullable_agent_columns_to_llm_calls_on_legacy_db() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_LLM_CALLS_PRE_PHASE5]);
+
+    // Pre-condition: agent fields are absent.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_calls");
+        assert!(
+            !cols.iter().any(|c| c == "tool_surface"),
+            "synth pre-condition: agent fields must be absent in legacy DB, got cols: {cols:?}"
+        );
+    }
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    let conn = Connection::open(&path).unwrap();
+    let cols = column_names(&conn, "llm_calls");
+    // The three nullable Phase-5 columns can always be added via
+    // `ALTER ADD COLUMN IF NOT EXISTS`. See FIXME below for the NOT NULL
+    // columns DuckDB refuses to add to a populated/aged table.
+    for expected in ["tool_surface", "agent_topology", "tool_names_json"] {
+        assert!(
+            cols.iter().any(|c| c == expected),
+            "post-migration llm_calls must contain {expected}, got: {cols:?}"
+        );
+    }
+}
+
+// FIXME(p1-followup): Phase-5 migration uses
+// `ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS is_agent_request \
+//  BOOLEAN NOT NULL DEFAULT FALSE` and the same for `tool_call_count`.
+// DuckDB (verified on 1.10501.0, the workspace pin) refuses
+// `ADD COLUMN ... NOT NULL` even with `DEFAULT`, surfacing an error
+// that `schema::init` swallows as `tracing::info!`. Net effect: a
+// pre-Phase-5 DB upgraded to 0.3.0 ends up missing the two NOT NULL
+// agent columns, while reads compiled against the canonical schema
+// expect them.
+//
+// This test is `#[ignore]`d so CI stays green; un-ignore it once the
+// migration is rewritten (likely a "rebuild llm_calls with the
+// canonical CREATE if pre-Phase-5 detected" path, mirroring
+// `needs_canonical_rebuild` for llm_metrics).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "tracks the NOT NULL ADD COLUMN gap in schema::init — see FIXME above"]
+#[allow(non_snake_case)]
+async fn phase5_adds_not_null_agent_columns_to_llm_calls_on_legacy_db_FIXME() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_LLM_CALLS_PRE_PHASE5]);
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    let conn = Connection::open(&path).unwrap();
+    let cols = column_names(&conn, "llm_calls");
+    for expected in ["is_agent_request", "tool_call_count"] {
+        assert!(
+            cols.iter().any(|c| c == expected),
+            "post-migration llm_calls must contain {expected}, got: {cols:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn phase4_drops_finish_count_columns_from_llm_metrics() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_LLM_METRICS_WITH_FINISH_COUNTS]);
+
+    // Pre-condition.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_metrics");
+        assert!(
+            cols.iter().any(|c| c == "finish_complete_count"),
+            "synth pre-condition: finish_*_count columns must be present"
+        );
+    }
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    let conn = Connection::open(&path).unwrap();
+    let cols = column_names(&conn, "llm_metrics");
+    for dropped in [
+        "finish_complete_count",
+        "finish_length_count",
+        "finish_tool_use_count",
+        "finish_error_count",
+        "finish_cancelled_count",
+    ] {
+        assert!(
+            !cols.iter().any(|c| c == dropped),
+            "post-migration llm_metrics must NOT contain {dropped}, got: {cols:?}"
+        );
+    }
+    // The Phase-4 migration is strictly DROP COLUMN — it does not
+    // backfill the canonical data columns that v0.3.0 expects (call_count,
+    // ttft_*, etc.). A real legacy DB would have those from the start.
+    // We deliberately do NOT smoke-test summary queries here because
+    // the synth DDL above intentionally exercises just the drop path.
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn phase3_rewrites_legacy_agent_turn_status_values() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_AGENT_TURNS_WITH_OLD_STATUS]);
+
+    // Seed legacy status values directly via raw SQL so the test does
+    // not depend on any current Rust struct shape.
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "INSERT INTO agent_turns \
+             (turn_id, session_id, wire_api, agent_kind, client_ip, server_ip, \
+              start_time, end_time, duration_ms, call_count, \
+              total_input_tokens, total_output_tokens, \
+              total_cache_read_input_tokens, total_cache_creation_input_tokens, \
+              status) VALUES \
+             ('t-len',    's', 'openai-chat', 'test', '1.1.1.1', '2.2.2.2', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 'length'),\
+             ('t-fail',   's', 'openai-chat', 'test', '1.1.1.1', '2.2.2.2', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 'failed'),\
+             ('t-cancel', 's', 'openai-chat', 'test', '1.1.1.1', '2.2.2.2', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 'cancelled'),\
+             ('t-ok',     's', 'openai-chat', 'test', '1.1.1.1', '2.2.2.2', NOW(), NOW(), 0, 0, 0, 0, 0, 0, 'complete');"
+        ).expect("seed legacy status rows");
+    }
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    // Inspect the raw status column post-migration.
+    let conn = Connection::open(&path).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT turn_id, status FROM agent_turns ORDER BY turn_id")
+        .unwrap();
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let map: std::collections::HashMap<_, _> = rows.into_iter().collect();
+    assert_eq!(
+        map.get("t-len").map(String::as_str),
+        Some("complete"),
+        "phase3: 'length' must rewrite to 'complete' (max_tokens is a wire terminal)"
+    );
+    assert_eq!(
+        map.get("t-fail").map(String::as_str),
+        Some("incomplete"),
+        "phase3: 'failed' must rewrite to 'incomplete'"
+    );
+    assert_eq!(
+        map.get("t-cancel").map(String::as_str),
+        Some("incomplete"),
+        "phase3: 'cancelled' must rewrite to 'incomplete'"
+    );
+    assert_eq!(
+        map.get("t-ok").map(String::as_str),
+        Some("complete"),
+        "phase3: pre-existing canonical values must stay untouched"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn init_is_idempotent_against_canonical_schema() {
+    // The "no-op" case: a freshly-init'd DB must accept a second init()
+    // without error or drift. Catches accidental migration code that
+    // mutates state on every boot (slow startup, lock contention).
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("fresh.duckdb");
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.unwrap();
+
+    let cols_before = {
+        let conn = Connection::open(&path).unwrap();
+        column_names(&conn, "llm_calls")
+    };
+
+    backend.init().await.expect("re-init must succeed");
+
+    let cols_after = {
+        let conn = Connection::open(&path).unwrap();
+        column_names(&conn, "llm_calls")
+    };
+    assert_eq!(
+        cols_before, cols_after,
+        "second init() must not drift the llm_calls column set"
+    );
+
+    // And the read path must still work.
+    let _ = backend
+        .query_turns(&TurnsQuery {
+            time_range: TimeRange {
+                start_us: 0,
+                end_us: i64::MAX,
+            },
+            filter: DimensionFilter::default(),
+            client_ips: vec![],
+            server_ports: vec![],
+            statuses: vec![],
+            agent_kinds: vec![],
+            sort_by: "start_time".into(),
+            sort_order: "desc".into(),
+            page: 1,
+            page_size: 10,
+            include_proxy_hops: false,
+        })
+        .await
+        .expect("query_turns must work after double-init");
+}

--- a/testdata/golden-dbs/README.md
+++ b/testdata/golden-dbs/README.md
@@ -1,0 +1,55 @@
+# Golden DuckDB fixtures
+
+Per-release `.duckdb` files used to lock in schema-migration behavior:
+load a frozen historical DB → run current `DuckDbBackend::init()` →
+assert auto-migration succeeds and downstream queries return expected
+rows. Catches the "PR#48 class" of bugs where a future refactor breaks
+the upgrade path without breaking any fresh-install test.
+
+## Current status
+
+This directory is intentionally **empty as of v0.3.0**. The migration
+test suite at `server/ts-storage-duckdb/tests/migrations.rs` uses
+**code-defined synthetic fixtures** (legacy DDL embedded as Rust
+constants) rather than binary `.duckdb` files. That approach:
+
+- Ships zero binary blobs in the repo
+- Stays deterministic across DuckDB version bumps (we control the SQL)
+- Removes drift risk between fixture and reality
+- Runs hermetically in CI with no fixture-rebuild step
+
+Add a binary fixture here **only when the synthetic approach proves
+insufficient** — for example, when a future migration depends on
+opaque on-disk encoding that can't be recreated by re-issuing DDL
+(WAL state, internal page layout, etc.).
+
+## How to add a binary fixture (when needed)
+
+1. Decide the release tag to capture (e.g., `v0.2.0`).
+2. From a clean checkout of that tag, build and run the binary with
+   the `regenerate-golden-dbs.sh` script:
+
+   ```sh
+   ./scripts/testdata/regenerate-golden-dbs.sh v0.2.0
+   ```
+
+   The script checks out the tag in a worktree, builds, runs against
+   a canonical seed dataset, and writes
+   `testdata/golden-dbs/v0.2.0.duckdb` here.
+
+3. Add a corresponding test in
+   `server/ts-storage-duckdb/tests/migrations.rs` that loads
+   `testdata/golden-dbs/v0.2.0.duckdb`, runs current `init()`, and
+   asserts post-migration invariants.
+
+## Naming
+
+`v<release-tag>.duckdb`, one file per release tag captured. Per-minor
+or per-major is fine too, decided at point of need — but the test
+file paths must match exactly.
+
+## Size budget
+
+Fixtures should stay under ~100 KB each (canonical seed dataset:
+10 calls, 5 turns, 50 metrics rows). If the file is larger, the seed
+script is generating more data than necessary.


### PR DESCRIPTION
## Summary

P1 of the quality-infrastructure roadmap. Closes the PR#48-class gap where
DuckDB FATAL → reopen recovery only had a "trust me, this runs"
assertion, and locks in `schema::init`'s auto-migration paths against
silent regression.

- **In-crate `fault_injection` module** behind the `fault-injection`
  cargo feature, scoped per-backend (no global state, parallel tests
  don't cross-pollinate). Three armed-fault points hook into the
  write paths and the read pool: `DuckDbInvalidate`, `DiskFull`,
  `ReadPoolPoisoned`.
- **Deterministic recovery tests** in `concurrent_tests.rs` drive the
  canonical FATAL → reopen → every-surface-works sequence and the
  pool-poison propagation path — neither was triggerable from real
  load.
- **Schema-migration integration suite** in
  `server/ts-storage-duckdb/tests/migrations.rs` synthesizes legacy
  on-disk shapes via embedded DDL and asserts `init()` performs the
  expected drift (Phase-4 drop, Phase-5 add, Phase-3 status rewrite).
  Uses code-defined fixtures only — `testdata/golden-dbs/` ships a
  README; binary fixtures are deferred until a future migration needs
  opaque on-disk state.
- **Real bug found**: DuckDB refuses
  `ALTER ADD COLUMN ... NOT NULL DEFAULT`, so `is_agent_request` /
  `tool_call_count` never get added to upgraded DBs. The migration
  code swallows the error as `tracing::info!`. Captured in an
  `#[ignore]`d FIXME test so the fix can land independently.
- **CI**: existing `cargo test --workspace` stays, plus two new test
  steps — fault-injection feature pass + migrations integration pass.

## Source spec

Path: `~/.claude/plans/precious-juggling-fiddle.md` — section "P1 (1–2 weeks, RECOMMENDED NEXT)".

## Test plan

- [x] `cargo test --workspace` — 700+ tests pass on default features
- [x] `cargo test -p ts-storage-duckdb --features fault-injection` —
      97 lib tests pass (95 existing + 2 new deterministic recovery)
- [x] `cargo test -p ts-storage-duckdb --test migrations` —
      4 pass + 1 ignored (FIXME tracking the ALTER NOT NULL bug)
- [x] Default-feature build is byte-identical behavior to pre-PR:
      every injection point is `#[cfg(feature = "fault-injection")]`,
      no runtime overhead in prod
- [ ] CI green on the PR

## Out of scope

- P2/P3/P4 (staging VM / shadow canary / observer agent) — separate
  follow-up
- The DuckDB ALTER NOT NULL fix itself — `#[ignore]`d test stays as
  the regression guard for a dedicated PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)