### PR TITLE
Rebrand → Heron Phase 4 (lite): operator scripts + Rust doc-comment sweep

### DIFF
--- a/scripts/demo-server-setup.sh
+++ b/scripts/demo-server-setup.sh
@@ -14,9 +14,9 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 TS_USER="ts"
-PUBKEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFtjiC3olMik26ZQRitCiOtUwrUtOcjBDJZfC6aHx1yV tokenscope-demo"
+PUBKEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFtjiC3olMik26ZQRitCiOtUwrUtOcjBDJZfC6aHx1yV heron-demo"
 
-echo -e "${GREEN}=== TokenScope Demo Server Setup ===${NC}"
+echo -e "${GREEN}=== Heron Demo Server Setup ===${NC}"
 
 # 1. Create ts user
 if id $TS_USER &>/dev/null; then
@@ -40,11 +40,11 @@ echo -e "${GREEN}SSH key installed${NC}"
 echo "Granting capture permissions..."
 # Allow ts to use tcpdump/libpcap without root
 if command -v setcap &>/dev/null; then
-    # If tokenscope binary exists, grant cap_net_raw
-    if [[ -f /root/tokenscope/bin/tokenscope ]]; then
-        cp /root/tokenscope/bin/tokenscope /home/$TS_USER/tokenscope-cap 2>/dev/null || true
-        setcap cap_net_raw,cap_net_admin=eip /home/$TS_USER/tokenscope-cap 2>/dev/null || true
-        chown $TS_USER:$TS_USER /home/$TS_USER/tokenscope-cap 2>/dev/null || true
+    # If heron binary exists, grant cap_net_raw
+    if [[ -f /root/heron/bin/heron ]]; then
+        cp /root/heron/bin/heron /home/$TS_USER/heron-cap 2>/dev/null || true
+        setcap cap_net_raw,cap_net_admin=eip /home/$TS_USER/heron-cap 2>/dev/null || true
+        chown $TS_USER:$TS_USER /home/$TS_USER/heron-cap 2>/dev/null || true
     fi
     echo -e "${GREEN}cap_net_raw granted${NC}"
 else
@@ -74,11 +74,11 @@ echo ""
 echo -e "${GREEN}=== Setup Complete ===${NC}"
 echo ""
 echo "Test from local machine (via jump host):"
-echo "  ssh -J william@172.16.103.73 -i ~/.ssh/id_ed25519_tokenscope ts@10.40.7.104"
+echo "  ssh -J william@172.16.103.73 -i ~/.ssh/id_ed25519_heron ts@10.40.7.104"
 echo ""
 echo "Next steps (run locally):"
 echo "  1. just demo ping         # verify SSH"
 echo "  2. just demo setup        # install just, bun, rust, claude, codex"
-echo "  3. just demo clone        # clone TokenScope repo"
+echo "  3. just demo clone        # clone Heron repo"
 echo "  4. just demo build        # build binary"
 echo "  5. just demo start        # start the service"

--- a/scripts/lib/demo-common.sh
+++ b/scripts/lib/demo-common.sh
@@ -24,12 +24,12 @@ fi
 
 DEMO_HOST="${DEMO_HOST:-10.40.7.104}"
 DEMO_USER="${DEMO_USER:-ts}"
-DEMO_SSH_KEY="${DEMO_SSH_KEY:-$HOME/.ssh/id_ed25519_tokenscope}"
+DEMO_SSH_KEY="${DEMO_SSH_KEY:-$HOME/.ssh/id_ed25519_heron}"
 DEMO_URL="${DEMO_URL:-http://10.40.7.104:3000/}"
 DEMO_JUMP_HOST="${DEMO_JUMP_HOST:-}"
 DEMO_JUMP_USER="${DEMO_JUMP_USER:-william}"
 DEMO_JUMP_KEY="${DEMO_JUMP_KEY:-$HOME/.ssh/id_ed25519_macbook_m5}"
-DEMO_REMOTE_DIR="/home/${DEMO_USER}/TokenScope"
+DEMO_REMOTE_DIR="/home/${DEMO_USER}/Heron"
 
 # ---------------------------------------------------------------------------
 # SSH helpers

--- a/scripts/lint/check-rebrand.sh
+++ b/scripts/lint/check-rebrand.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Rebrand verification test — ensures no old branding remains in scope.
+# Exit 0 if clean, exit 1 if any legacy references found.
+set -euo pipefail
+
+# Operator scripts (Phase 4 scope)
+SCRIPT_FILES=(
+    scripts/demo-server-setup.sh
+    scripts/lib/demo-common.sh
+    scripts/reindex_turns.py
+    scripts/traffic-gen.py
+    scripts/lint/check-secrets.sh
+)
+
+# Rust doc comments (Phase 4 scope)
+RUST_FILES=(
+    server/ts-llm/src/wire_apis/mod.rs
+    server/ts-llm/src/agents/generic.rs
+    server/ts-turn/src/proxy_pair.rs
+    server/ts-pcap-extract/src/filter.rs
+)
+
+# Adjust paths if Phase 2 (ts-* → h-*) has landed
+for f in "${RUST_FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        # Try h-* variant
+        h_f="${f/ts-/h-}"
+        if [[ -f "$h_f" ]]; then
+            RUST_FILES[${RUST_FILES[$i]}]="$h_f"
+        fi
+    fi
+done
+
+errors=0
+
+echo "Checking operator scripts for legacy branding..."
+for f in "${SCRIPT_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        if grep -qiE 'tokenscope|TokenScope' "$f" 2>/dev/null; then
+            echo "::error::$f contains legacy branding (tokenscope/TokenScope)"
+            grep -niE 'tokenscope|TokenScope' "$f" || true
+            ((errors++))
+        fi
+    else
+        echo "::warning::$f not found (may have been moved or deleted)"
+    fi
+done
+
+echo "Checking Rust doc comments for legacy branding..."
+for f in "${RUST_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        if grep -qiE 'tokenscope|TokenScope' "$f" 2>/dev/null; then
+            echo "::error::$f contains legacy branding (tokenscope/TokenScope)"
+            grep -niE 'tokenscope|TokenScope' "$f" || true
+            ((errors++))
+        fi
+    else
+        echo "::warning::$f not found (may have been moved or deleted)"
+    fi
+done
+
+if [[ $errors -eq 0 ]]; then
+    echo "check-rebrand: ✓ no legacy branding found in scope"
+    exit 0
+else
+    echo "check-rebrand: $errors file(s) contain legacy branding"
+    exit 1
+fi

--- a/scripts/lint/check-secrets.sh
+++ b/scripts/lint/check-secrets.sh
@@ -29,7 +29,7 @@
 # Usage
 # -----
 #   scripts/lint/check-secrets.sh                     # against $GITHUB_REPOSITORY or origin
-#   scripts/lint/check-secrets.sh Netis/TokenScope    # explicit
+#   scripts/lint/check-secrets.sh Netis/Heron    # explicit
 set -euo pipefail
 
 REPO="${1:-${GITHUB_REPOSITORY:-}}"

--- a/scripts/reindex_turns.py
+++ b/scripts/reindex_turns.py
@@ -23,9 +23,9 @@ FROM llm_calls` shows every row in this database is openai-chat. Add Anthropic
 
 Usage:
 
-    # Stop tokenscope first (it holds an exclusive db lock):
-    pkill -f 'target/release/tokenscope' && sleep 2
-    python3 reindex_turns.py /home/vader/.local/share/tokenscope/data/tokenscope.duckdb
+    # Stop heron first (it holds an exclusive db lock):
+    pkill -f 'target/release/heron' && sleep 2
+    python3 reindex_turns.py /home/vader/.local/share/heron/data/heron.duckdb
 """
 
 import json

--- a/scripts/traffic-gen.py
+++ b/scripts/traffic-gen.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-traffic-gen.py — LLM API traffic generator for TokenScope demos.
+traffic-gen.py — LLM API traffic generator for Heron demos.
 
 Continuously sends requests via Claude Code CLI and Codex CLI through a local
-proxy so that TokenScope can capture plaintext HTTP traffic.
+proxy so that Heron can capture plaintext HTTP traffic.
 
 Usage:
     python3 scripts/traffic-gen.py
@@ -234,7 +234,7 @@ def execute_scenario(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="LLM API traffic generator for TokenScope demos"
+        description="LLM API traffic generator for Heron demos"
     )
     parser.add_argument(
         "--interval",
@@ -301,7 +301,7 @@ def main():
         log.error("No valid providers available. Install claude and/or codex CLI.")
         sys.exit(1)
 
-    log.info("=== TokenScope Traffic Generator ===")
+    log.info("=== Heron Traffic Generator ===")
     log.info("Providers: %s", ", ".join(valid_providers))
     log.info("Interval: %.0fs (±20%% jitter)", args.interval)
     log.info("Scenario ratio: %.0f%%", args.scenario_ratio * 100)

--- a/server/ts-llm/src/agents/generic.rs
+++ b/server/ts-llm/src/agents/generic.rs
@@ -1,5 +1,5 @@
 //! Generic agent profile — synthesizes a session id from request / response
-//! payload tool-call anchors, so TokenScope can still produce `AgentTurn`s for
+//! payload tool-call anchors, so Heron can still produce `AgentTurn`s for
 //! header-less tool-using LLM traffic across supported wire APIs.
 //!
 //! `agent_kind == "generic"` is wire-api-agnostic; downstream consumers read

--- a/server/ts-llm/src/wire_apis/mod.rs
+++ b/server/ts-llm/src/wire_apis/mod.rs
@@ -4,7 +4,7 @@
 //! schema the request/response bodies follow and which endpoint handles them.
 //! It is **not** the vendor: Azure OpenAI, vLLM, Ollama and api.openai.com all
 //! speak the same `openai-chat` wire API despite being different vendors.
-//! (When TokenScope later needs to distinguish vendors, that will be a
+//! (When Heron later needs to distinguish vendors, that will be a
 //! separate field sourced from hostname / key prefix / route prefix.)
 //!
 //! Values use the compound `<vendor>-<api>` form so operators and storage

--- a/server/ts-pcap-extract/src/filter.rs
+++ b/server/ts-pcap-extract/src/filter.rs
@@ -1,6 +1,6 @@
 //! Per-record predicate: time window AND 5-tuple in either direction.
 //! Records that don't decode to TCP via `ts_protocol::de::decode` are
-//! dropped. (TokenScope is TCP-only today; ARP / ICMP / UDP / QUIC /
+//! dropped. (Heron is TCP-only today; ARP / ICMP / UDP / QUIC /
 //! malformed all fall through to "skip".)
 
 use ts_protocol::de::decode;

--- a/server/ts-turn/src/proxy_pair.rs
+++ b/server/ts-turn/src/proxy_pair.rs
@@ -2,10 +2,10 @@
 //! represent the same logical LLM call observed at different network
 //! vantage points.
 //!
-//! Three (or more) scenarios produce duplicate turns in TokenScope:
+//! Three (or more) scenarios produce duplicate turns in Heron:
 //!
 //! 1. **Real proxy hops** — e.g. an external client → haproxy_glm5 container
-//!    → sglang container. Both legs cross interfaces TokenScope captures
+//!    → sglang container. Both legs cross interfaces Heron captures
 //!    so each becomes its own `AgentTurn`. The proxy_in leg strictly
 //!    contains the proxy_out leg in event time.
 //!


### PR DESCRIPTION
# Rebrand → Heron Phase 4 (lite): operator scripts + Rust doc-comment sweep

## Summary

This PR completes the Heron rebranding by updating the remaining operator scripts
and Rust doc comments that still referenced `tokenscope`/`TokenScope`.

## Changes

### Operator scripts (9 files)

- `scripts/demo-server-setup.sh` — SSH key name, setup header, binary paths, repo clone reference
- `scripts/lib/demo-common.sh` — SSH key default path, remote directory name
- `scripts/reindex_turns.py` — Usage doc: binary name, DB path
- `scripts/traffic-gen.py` — Module doc, argparser description, log header
- `scripts/lint/check-secrets.sh` — Example command URL

### Rust doc comments (4 files)

- `server/ts-llm/src/wire_apis/mod.rs` — Wire-API vendor future-field comment
- `server/ts-llm/src/agents/generic.rs` — Profile purpose doc
- `server/ts-turn/src/proxy_pair.rs` — Duplicate turn scenario explanation (2 occurrences)
- `server/ts-pcap-extract/src/filter.rs` — TCP-only filter rationale

### New test script

- `scripts/lint/check-rebrand.sh` — Automated verification that no legacy branding
  remains in the Phase 4 scope

## Acceptance criteria

✅ `grep -rn 'tokenscope\|TokenScope' scripts/demo-server-setup.sh scripts/lib/demo-common.sh scripts/reindex_turns.py scripts/traffic-gen.py scripts/lint/check-secrets.sh` returns empty

✅ `grep -rn 'tokenscope\|TokenScope' server/ts-llm/src/wire_apis/mod.rs server/ts-llm/src/agents/generic.rs server/ts-turn/src/proxy_pair.rs server/ts-pcap-extract/src/filter.rs` returns empty

✅ `cargo check --workspace` clean

✅ `bash scripts/lint/check-secrets.sh` passes (self-test)

## Test plan

- Ran `cargo check --workspace` — passes
- Ran `cargo build --workspace --release` — passes
- Ran `scripts/lint/check-secrets.sh` — passes
- Ran `scripts/lint/check-rebrand.sh` — passes (new verification script)

Closes #61
---
🤖 Implemented by **wiwi** • issue author: @vaderyang
Eligible for auto-merge on vivi APPROVE.
