### PR TITLE
ci(pr-review): bump vivi agent + job timeout to 7200s/120min

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -45,7 +45,10 @@ jobs:
         github.event.workflow_run.pull_requests[0] != null
       )
     runs-on: [self-hosted, tokenscope]
-    timeout-minutes: 30
+    # 120 min covers large-PR reviews (e.g. rebrand-scale 200-file
+    # mechanical diffs). The earlier 30-min ceiling killed the agent
+    # mid-read on PR #66 even though the diff was reviewable.
+    timeout-minutes: 120
     env:
       # Agent endpoint + key live in repo secrets so this workflow
       # is portable across deployments without exposing internal

--- a/docs/pr-review-agent.md
+++ b/docs/pr-review-agent.md
@@ -35,7 +35,7 @@ GitHub                                  wuneng VM heron-ci
 * `scripts/pr-review/run_review.sh`
   Substitutes `PR_NUMBER` / `HEAD_SHA` / `BASE_REF` into the prompt
   template, pre-flights LiteLLM, runs `claude -p` with the read-only
-  tool allowlist + 1800 s outer timeout, writes the model's stdout to
+  tool allowlist + 7200 s outer timeout, writes the model's stdout to
   `/tmp/pr-review-${N}-out.md`.
 * `scripts/pr-review/prompt.md`
   Instructional prompt. Encodes repo facts the agent has to know
@@ -151,7 +151,7 @@ footguns.
 | Failure | What happens | Mitigation |
 |---|---|---|
 | LiteLLM down | Pre-flight curl fails, `run_review.sh` exits 2 | `post_review.py` posts a brief "agent failed" comment with link to workflow log; PR is not blocked |
-| Agent loops | `timeout 1800` kills the agent | Same: failure comment, no block |
+| Agent loops | `timeout 7200` kills the agent | Same: failure comment, no block |
 | GLM-5 returns garbage / no `### Summary` | `run_review.sh` appends a warning to the output | `post_review.py` still posts it as COMMENT — the agent's broken output is visible, which is signal |
 | Bot can't `--approve` its own PR | `gh pr review` rc != 0 | `post_review.py` falls back to `gh pr comment` |
 | Schema mirror miss inside the agent | Agent under-reports | Add the missed signature to `prompt.md` § "Things this repo has been bitten by" — encode the lesson |

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -49,9 +49,10 @@ ALLOWED_TOOLS="$(grep -v '^#' "$WORKDIR/allowed_tools.txt" \
   | grep -v '^[[:space:]]*$' \
   | paste -sd, -)"
 
-# Headless agent run. The 1800 s outer cap is a hard fence — if the
+# Headless agent run. The 7200 s outer cap is a hard fence — if the
 # model loops we'd rather post a "review timed out" than wedge the
-# workflow.
+# workflow. 7200 s lets large-diff reviews (200+ files, rebrand-class
+# refactors) complete instead of timing out mid-read.
 #
 # Feed the prompt over stdin instead of as a trailing positional arg —
 # `--allowed-tools` is variadic (<tools...>), so a positional prompt
@@ -69,7 +70,7 @@ attempt=0
 claude_rc=0
 while true; do
     set +e
-    timeout 1800 claude \
+    timeout 7200 claude \
       --print \
       --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
       --max-turns 60 \


### PR DESCRIPTION
## Summary

vivi (the PR review agent) hit the 30-min GHA \`timeout-minutes\` ceiling on **PR #66** (Heron Phase 2 crate rename, 202 files / +796/-796). The agent was cancelled mid-read before producing any review output, leaving #66 blocked with no review.

Even though the diff was mechanical, GLM-5's per-token wall time on a 200-file diff doesn't fit in 30 minutes.

## Changes

Three coupled knobs all move from 1800s/30min → 7200s/120min:
- \`.github/workflows/pr-review.yml\` \`timeout-minutes\` (job-level)
- \`scripts/pr-review/run_review.sh\` \`timeout NNNN claude\` (agent-level)
- \`docs/pr-review-agent.md\` doc references

2h ceiling gives headroom for rebrand-class refactors. Small PRs are unaffected — the agent exits as soon as it's done; the timeout is a fence, not a target.

## Test plan

- [x] \`grep 1800\` returns no stale refs in pr-review yaml / shell / docs
- [ ] Next vivi run (on this PR or a follow-up) completes well under 120 min — confirms the new ceiling isn't degenerate