### PR TITLE
ci: move runner label tokenscope → heron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, tokenscope]
+    runs-on: [self-hosted, heron]
     timeout-minutes: 25
     env:
       # actions/checkout@v4 ships Node 20; GitHub is deprecating

--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   implement:
     if: ${{ github.event.label.name == 'agent:try' }}
-    runs-on: [self-hosted, tokenscope]
+    runs-on: [self-hosted, heron]
     # 120-minute fence. A clean, well-scoped wiwi run (per the triage
     # gates: <300 LOC, <10 files) typically completes in 10-25 min; the
     # 120-min cap absorbs slower LiteLLM ↔ GLM-5 round-trips on busy

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   triage:
     if: ${{ github.event.label.name == 'agent:assess' }}
-    runs-on: [self-hosted, tokenscope]
+    runs-on: [self-hosted, heron]
     timeout-minutes: 10
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}

--- a/.github/workflows/pr-review-probe.yml
+++ b/.github/workflows/pr-review-probe.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   probe:
-    runs-on: [self-hosted, tokenscope]
+    runs-on: [self-hosted, heron]
     timeout-minutes: 5
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -44,7 +44,7 @@ jobs:
         github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.pull_requests[0] != null
       )
-    runs-on: [self-hosted, tokenscope]
+    runs-on: [self-hosted, heron]
     # 120 min covers large-PR reviews (e.g. rebrand-scale 200-file
     # mechanical diffs). The earlier 30-min ceiling killed the agent
     # mid-read on PR #66 even though the diff was reviewable.


### PR DESCRIPTION
## Summary

Switches all 5 workflows' `runs-on` from `[self-hosted, heron]` (was `[self-hosted, tokenscope]`). The self-hosted runner already had a `heron` label added (via the runners API), so it matches the new label immediately — the old `tokenscope` label stays on the runner until this merges, so no job is unschedulable during the switch. The stale labels are removed after merge.

Renaming the runner *itself* (its name still embeds an internal hostname) needs a runner-side `config.sh remove` + re-register and is handled separately as an infra step.

## Files
- `.github/workflows/{ci,pr-review,pr-review-probe,issue-implement,issue-triage}.yml`

## Test plan
- [ ] This PR's own CI runs on the runner via the `heron` label (proves the label match works before we drop the old one)