### PR TITLE
fix(storage): Phase-5 migration adds agent columns nullable (DuckDB compat)

### DIFF
--- a/server/h-storage-duckdb/src/schema.rs
+++ b/server/h-storage-duckdb/src/schema.rs
@@ -305,11 +305,24 @@ pub(crate) async fn init(backend: &DuckDbBackend) -> Result<()> {
         // does not abort the rest; failures are logged (not propagated) so
         // the app can start even against an older DuckDB that doesn't support
         // `ADD COLUMN IF NOT EXISTS`.
+        //
+        // NOTE: the agent columns are added WITHOUT `NOT NULL` here, even
+        // though the canonical CREATE TABLE declares them NOT NULL. DuckDB
+        // refuses `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT ...`
+        // (verified on 1.10501.0), so a NOT NULL form silently fails and
+        // leaves the column absent — which then breaks every subsequent
+        // INSERT on an upgraded DB. Adding them nullable-with-default
+        // succeeds, is a metadata-only operation (instant even on a
+        // multi-GB table), and is behaviorally equivalent: the writer
+        // always supplies a value, and these columns sit at the end of
+        // the table in both CREATE and ALTER so the appender's positional
+        // writes stay aligned. Fresh installs still get NOT NULL via
+        // CREATE TABLE.
         let agent_columns = [
-            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS is_agent_request BOOLEAN NOT NULL DEFAULT FALSE;",
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS is_agent_request BOOLEAN DEFAULT FALSE;",
             "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS tool_surface VARCHAR;",
             "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS agent_topology VARCHAR;",
-            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS tool_call_count UINTEGER NOT NULL DEFAULT 0;",
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS tool_call_count UINTEGER DEFAULT 0;",
             "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS tool_names_json VARCHAR;",
         ];
         for stmt in agent_columns {
@@ -328,9 +341,10 @@ pub(crate) async fn init(backend: &DuckDbBackend) -> Result<()> {
         // agent_turns. Same pattern as the llm_calls block above — each
         // statement runs independently so a failure on one column does not
         // abort the rest.
+        // Same NOT NULL-omission rationale as the llm_calls block above.
         let turn_agent_columns = [
             "ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS tool_surfaces_json VARCHAR;",
-            "ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS tool_call_total UINTEGER NOT NULL DEFAULT 0;",
+            "ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS tool_call_total UINTEGER DEFAULT 0;",
             "ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS agent_topology VARCHAR;",
             "ALTER TABLE agent_turns ADD COLUMN IF NOT EXISTS suspicious_skills_json VARCHAR;",
         ];

--- a/server/h-storage-duckdb/tests/migrations.rs
+++ b/server/h-storage-duckdb/tests/migrations.rs
@@ -173,24 +173,16 @@ async fn phase5_adds_nullable_agent_columns_to_llm_calls_on_legacy_db() {
     }
 }
 
-// FIXME(p1-followup): Phase-5 migration uses
-// `ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS is_agent_request \
-//  BOOLEAN NOT NULL DEFAULT FALSE` and the same for `tool_call_count`.
-// DuckDB (verified on 1.10501.0, the workspace pin) refuses
-// `ADD COLUMN ... NOT NULL` even with `DEFAULT`, surfacing an error
-// that `schema::init` swallows as `tracing::info!`. Net effect: a
-// pre-Phase-5 DB upgraded to 0.3.0 ends up missing the two NOT NULL
-// agent columns, while reads compiled against the canonical schema
-// expect them.
-//
-// This test is `#[ignore]`d so CI stays green; un-ignore it once the
-// migration is rewritten (likely a "rebuild llm_calls with the
-// canonical CREATE if pre-Phase-5 detected" path, mirroring
-// `needs_canonical_rebuild` for llm_metrics).
+// Regression test for the Phase-5 NOT NULL ADD COLUMN gap: DuckDB
+// (verified on 1.10501.0) refuses `ALTER TABLE ... ADD COLUMN ...
+// NOT NULL DEFAULT ...`, so the original migration silently left
+// `is_agent_request` / `tool_call_count` absent on upgraded DBs,
+// breaking every subsequent INSERT. `schema::init` now adds these
+// nullable-with-default (NOT NULL omitted on the ALTER path only), so
+// the columns land on a legacy DB. This test asserts they do — keep it
+// passing so the migration can't silently regress again.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "tracks the NOT NULL ADD COLUMN gap in schema::init — see FIXME above"]
-#[allow(non_snake_case)]
-async fn phase5_adds_not_null_agent_columns_to_llm_calls_on_legacy_db_FIXME() {
+async fn phase5_adds_agent_not_null_columns_to_llm_calls_on_legacy_db() {
     let tmp = TempDir::new().unwrap();
     let path = synth_db(&tmp, &[LEGACY_LLM_CALLS_PRE_PHASE5]);
 


### PR DESCRIPTION
## Why

Blocks any real `0.2.x → 0.4.0` in-place upgrade. DuckDB refuses `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT ...`, so the Phase-5 migration silently failed to add `is_agent_request` / `tool_call_count` (llm_calls) and `tool_call_total` (agent_turns) on a pre-Phase-5 DB — the error was swallowed as `tracing::info!`. The columns went missing, then every subsequent INSERT failed because the writer supplies them.

Found via the golden-DB migration test added in #64 (was `#[ignore]`d as a known gap); this fixes it and un-ignores the test.

## Fix

Add the columns **nullable-with-default** on the ALTER path (drop `NOT NULL`). DuckDB accepts it; metadata-only (instant on a 100GB table); the columns are at the table tail in both CREATE and ALTER so the appender stays positionally aligned; `ADD COLUMN DEFAULT` backfills existing rows with the default. Fresh installs keep NOT NULL via CREATE TABLE.

## Test plan
- [x] `cargo test -p h-storage-duckdb --test migrations` — 5 pass (incl. the un-ignored regression test)
- [x] `cargo test -p h-storage-duckdb --lib` — 95 pass (fresh-install schema unchanged)
- [ ] CI green

Needed before upgrading the existing 0.2.0 deployment (a ~100GB prod DuckDB) to avoid breaking writes post-migration.