### PR TITLE
check-leakage: also flag machine-specific username paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
         # semantic half (plaintext passwords, internal hostnames, paths).
         run: bash scripts/lint/check-leakage.sh
 
+      - name: lint — leakage linter self-test
+        # Guards the leakage gate itself: a regression in check-leakage.sh
+        # (broken regex, mis-scoped allowlist) would otherwise silently
+        # weaken the gate without failing any build. Runs hermetically in
+        # a throwaway git repo, so it never touches the working tree.
+        run: bash scripts/lint/test-check-leakage.sh
+
       - name: cargo test
         working-directory: server
         env:

--- a/scripts/lint/check-leakage.sh
+++ b/scripts/lint/check-leakage.sh
@@ -13,10 +13,16 @@
 #      Real infra hosts trip this; documentation ranges (RFC5737),
 #      loopback, and the docker0 default do not.
 #   2. Private-key PEM blocks (`-----BEGIN ... PRIVATE KEY-----`).
+#   3. Machine-specific home-directory paths with real usernames:
+#      `/home/<name>/` or `/Users/<name>/` where `<name>` is a concrete
+#      user (not a placeholder like `<user>`, `$HOME`, `~`, etc.).
+#      Wire-data fixtures in tests/fixtures and docs/examples may
+#      legitimately contain captured paths from other machines and are
+#      excluded via the file-pattern allowlist.
 #
 # Out of scope (left to the human/agent reviewer's semantic pass —
 # regex can't separate these from legitimate prose):
-#   * Plaintext passwords, internal hostnames, machine-specific paths.
+#   * Plaintext passwords, internal hostnames.
 #   The PR-review agent prompt carries a leakage dimension for those.
 #
 # Scope: tracked text files only (git ls-files; binary files skipped via
@@ -37,7 +43,20 @@ ALLOWLIST="scripts/lint/leakage-allowlist.txt"
 # Safe IP prefixes (string match), comments/blank stripped.
 # (Plain `while read` rather than `mapfile` so this runs on bash 3.x too.)
 SAFE_PREFIXES=()
-while IFS= read -r _l; do SAFE_PREFIXES+=("$_l"); done < <(grep -vE '^\s*#|^\s*$' "$ALLOWLIST")
+while IFS= read -r _l; do
+  case "$_l" in
+    file:*) continue ;;  # file patterns handled separately
+    *) SAFE_PREFIXES+=("$_l") ;;
+  esac
+done < <(grep -vE '^\s*#|^\s*$' "$ALLOWLIST")
+
+# File patterns that may contain legitimate captured home-directory paths.
+HOME_PATH_ALLOWLIST=()
+while IFS= read -r _l; do
+  case "$_l" in
+    file:*) HOME_PATH_ALLOWLIST+=("${_l#file:}") ;;
+  esac
+done < <(grep -vE '^\s*#|^\s*$' "$ALLOWLIST")
 
 # Files to scan: tracked, minus the exclusions described above.
 FILES=()
@@ -54,6 +73,17 @@ is_allowed_ip() {
   for pfx in "${SAFE_PREFIXES[@]}"; do
     case "$ip" in
       "$pfx"*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Check if a file matches any pattern in the home-path allowlist.
+is_allowed_home_path_file() {
+  local file="$1" pattern
+  for pattern in "${HOME_PATH_ALLOWLIST[@]}"; do
+    case "$file" in
+      $pattern) return 0 ;;
     esac
   done
   return 1
@@ -86,6 +116,30 @@ for f in "${FILES[@]}"; do
   if grep -InE -- '-----BEGIN ([A-Z0-9]+ )*PRIVATE KEY-----' "$f" >/dev/null 2>&1; then
     report "$f contains a PRIVATE KEY block — private keys must never be committed. Remove it and rotate the key."
   fi
+
+  # --- Class 3: machine-specific home-directory paths ---
+  # Skip files that are allowed to contain captured paths (fixtures, examples).
+  if ! is_allowed_home_path_file "$f"; then
+    # Match /home/<name>/ or /Users/<name>/ where <name> is NOT a placeholder.
+    # Placeholders we allow: <user>, <name>, $HOME, ~, USERNAME, you.
+    # The regex captures the username part to report it.
+    HOME_PATH_RE='/(home|Users)/([^/<$~]|([^/<$~][^/<]*[^/<$~]))/'
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      lineno="${line%%:*}"
+      rest="${line#*:}"
+      # Extract each match and filter out known placeholders.
+      while IFS= read -r match; do
+        [ -z "$match" ] && continue
+        # Extract the username from the match.
+        username=$(echo "$match" | sed -E 's@^/(home|Users)/([^/]+)/.*$@\2@')
+        case "$username" in
+          '<user>'|'<name>'|'user'|'name'|'$HOME'|'USERNAME'|'you') continue ;;
+        esac
+        report "$f:$lineno contains machine-specific home-directory path '$match' — replace with a placeholder like <user> or /home/user."
+      done < <(grep -oE "$HOME_PATH_RE" <<<"$rest" 2>/dev/null || true)
+    done < <(grep -InE "$HOME_PATH_RE" "$f" 2>/dev/null || true)
+  fi
 done
 
 if [ "$bad" -gt 0 ]; then
@@ -93,4 +147,4 @@ if [ "$bad" -gt 0 ]; then
   exit 1
 fi
 
-echo "check-leakage: ✓ no private IPs or key material in ${#FILES[@]} tracked files"
+echo "check-leakage: ✓ no private IPs, key material, or machine-specific paths in ${#FILES[@]} tracked files"

--- a/scripts/lint/leakage-allowlist.txt
+++ b/scripts/lint/leakage-allowlist.txt
@@ -1,15 +1,21 @@
 # Leakage-linter allow-list.
 #
-# `check-leakage.sh` flags any private/internal IP in tracked files. The
-# only IPs that are SAFE to commit are documentation/test ranges and
-# well-known defaults — everything else is treated as a real-infra leak.
+# `check-leakage.sh` flags any private/internal IP or machine-specific
+# home-directory path in tracked files. The only values that are SAFE to
+# commit are documentation/test ranges and well-known defaults — everything
+# else is treated as a real-infra leak.
 #
-# This file lists the SAFE IP-address PREFIXES. Note: we deliberately
-# list only non-sensitive ranges here — never the internal addresses
-# the linter is meant to catch (per CLAUDE.md PR-hygiene rule, the lint
-# config must not itself enumerate the secrets it guards).
+# This file lists the SAFE IP-address PREFIXES and FILE PATTERNS to exclude
+# from machine-specific path checks. Note: we deliberately list only
+# non-sensitive ranges here — never the internal addresses the linter is
+# meant to catch (per CLAUDE.md PR-hygiene rule, the lint config must not
+# itself enumerate the secrets it guards).
 #
-# Format: one allowed IPv4 prefix per line (string prefix match).
+# Format:
+#   - IP allowlist: one allowed IPv4 prefix per line (string prefix match).
+#   - File pattern allowlist: lines starting with "file:" are glob patterns
+#     for files that may contain legitimate captured home-directory paths
+#     (e.g. recorded wire data fixtures).
 # Lines starting with # are comments.
 
 # Loopback.
@@ -34,3 +40,10 @@
 # Unspecified / broadcast sentinels.
 0.0.0.0
 255.255.255.255
+
+# File patterns that may contain legitimate captured home-directory paths.
+# These are recorded wire data from external machines (not our infra).
+file:server/h-llm/tests/fixtures/**
+file:server/h-protocol/tests/fixtures/**
+file:docs/examples/**
+file:scripts/lint/test-check-leakage.sh

--- a/scripts/lint/test-check-leakage.sh
+++ b/scripts/lint/test-check-leakage.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Test suite for check-leakage.sh
+#
+# This verifies the acceptance criteria for the home-directory path detection:
+#   1. A planted /home/<realuser>/ in a source file fails
+#   2. ~/... and /path/to/... style example paths pass
+#   3. Captured fixtures pass via allowlist
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LEAKAGE_CHECK="$SCRIPT_DIR/check-leakage.sh"
+
+pass=0
+fail=0
+
+test_pass() {
+  echo "✓ PASS: $1"
+  pass=$((pass + 1))
+}
+
+test_fail() {
+  echo "✗ FAIL: $1"
+  fail=$((fail + 1))
+}
+
+# Use a real source file for testing
+TEST_FILE="$REPO_ROOT/server/h-common/src/config.rs"
+ORIGINAL_CONTENT=$(cat "$TEST_FILE")
+
+cleanup() {
+  # Restore original content
+  echo "$ORIGINAL_CONTENT" > "$TEST_FILE"
+}
+trap cleanup EXIT
+
+# --- Test 1: Real home path in source file should fail ---
+echo "Test 1: Real home path in source file should fail"
+cat > "$TEST_FILE" <<'EOF'
+//! Test file for leakage detection
+/// Path: /home/somebody/secret.txt
+pub fn test() {}
+EOF
+
+# Run the check (should fail)
+OUTPUT=$(bash "$LEAKAGE_CHECK" 2>&1 || true)
+# Use a pattern that matches relative path output from the check
+echo "$OUTPUT" | grep -q "server/h-common/src/config.rs.*machine-specific home-directory path" && FOUND=1 || FOUND=0
+if [ "$FOUND" -eq 1 ]; then
+  test_pass "Real home path detected in test file"
+else
+  test_fail "Real home path not detected"
+  echo "  Output: $OUTPUT" | head -5
+fi
+
+# --- Test 2: Placeholder paths should pass ---
+echo "Test 2: Placeholder paths should pass"
+cat > "$TEST_FILE" <<'EOF'
+//! Test file for leakage detection
+/// Home: ~/Downloads
+/// Config: /home/user/.config
+/// Docs: /Users/name/Documents
+pub fn test() {}
+EOF
+
+# Run the check (should NOT flag the placeholder paths)
+if bash "$LEAKAGE_CHECK" 2>&1 | grep -q "$TEST_FILE.*machine-specific"; then
+  test_fail "Placeholder paths incorrectly flagged"
+else
+  test_pass "Placeholder paths not flagged"
+fi
+
+# --- Test 3: Fixtures should pass via allowlist ---
+echo "Test 3: Fixtures should pass via allowlist"
+# The fixtures already exist and contain real paths - verify they don't trigger
+FIXTURE_FILE="$REPO_ROOT/server/h-protocol/tests/fixtures/keepalive_2sse_client.bin"
+if [ -f "$FIXTURE_FILE" ]; then
+  if bash "$LEAKAGE_CHECK" 2>&1 | grep -q "$FIXTURE_FILE.*machine-specific"; then
+    test_fail "Fixture file incorrectly flagged (allowlist not working)"
+  else
+    test_pass "Fixture file allowed via allowlist"
+  fi
+else
+  echo "  (skipped - fixture file not found)"
+fi
+
+# --- Summary ---
+echo ""
+echo "========================================"
+echo "Tests passed: $pass"
+echo "Tests failed: $fail"
+echo "========================================"
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+
+echo "All tests passed!"

--- a/scripts/lint/test-check-leakage.sh
+++ b/scripts/lint/test-check-leakage.sh
@@ -1,87 +1,94 @@
 #!/usr/bin/env bash
-# Test suite for check-leakage.sh
+# Self-test for check-leakage.sh.
 #
-# This verifies the acceptance criteria for the home-directory path detection:
-#   1. A planted /home/<realuser>/ in a source file fails
-#   2. ~/... and /path/to/... style example paths pass
-#   3. Captured fixtures pass via allowlist
+# check-leakage.sh derives its repo root from its own location and scans
+# `git ls-files`, so to exercise it we build a THROWAWAY git repo under
+# $TMPDIR, drop a parallel scripts/lint/ (the script + its allowlist) plus
+# whatever sample sources each case needs, and invoke the *copied* script
+# there. The real working tree is never touched — a crash or SIGKILL can
+# at worst leak a temp dir, never corrupt a tracked source file.
+#
+# Acceptance criteria covered:
+#   1. A planted /home/<realuser>/ path in a source file is flagged.
+#   2. Placeholder paths (~/..., /home/user/..., /Users/name/...) pass.
+#   3. Captured fixtures are exempted via the file: allowlist patterns.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-LEAKAGE_CHECK="$SCRIPT_DIR/check-leakage.sh"
+CHECK_SRC="$SCRIPT_DIR/check-leakage.sh"
+ALLOW_SRC="$SCRIPT_DIR/leakage-allowlist.txt"
 
 pass=0
 fail=0
+test_pass() { echo "✓ PASS: $1"; pass=$((pass + 1)); }
+test_fail() { echo "✗ FAIL: $1"; fail=$((fail + 1)); }
 
-test_pass() {
-  echo "✓ PASS: $1"
-  pass=$((pass + 1))
-}
-
-test_fail() {
-  echo "✗ FAIL: $1"
-  fail=$((fail + 1))
-}
-
-# Use a real source file for testing
-TEST_FILE="$REPO_ROOT/server/h-common/src/config.rs"
-ORIGINAL_CONTENT=$(cat "$TEST_FILE")
-
-cleanup() {
-  # Restore original content
-  echo "$ORIGINAL_CONTENT" > "$TEST_FILE"
-}
+# --- Hermetic sandbox: a real git repo, but disposable. ---
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
 trap cleanup EXIT
 
-# --- Test 1: Real home path in source file should fail ---
-echo "Test 1: Real home path in source file should fail"
-cat > "$TEST_FILE" <<'EOF'
-//! Test file for leakage detection
+mkdir -p "$SANDBOX/scripts/lint"
+cp "$CHECK_SRC" "$SANDBOX/scripts/lint/check-leakage.sh"
+cp "$ALLOW_SRC" "$SANDBOX/scripts/lint/leakage-allowlist.txt"
+
+git -C "$SANDBOX" init -q
+git -C "$SANDBOX" config user.email test@example.com
+git -C "$SANDBOX" config user.name test-check-leakage
+
+CHECK="$SANDBOX/scripts/lint/check-leakage.sh"
+
+# Stage everything (so git ls-files sees it) then run the copied linter.
+run_check() {
+  git -C "$SANDBOX" add -A
+  bash "$CHECK" 2>&1 || true
+}
+
+# --- Test 1: real home path in a source file should be flagged ---
+echo "Test 1: real home path in a source file should fail"
+mkdir -p "$SANDBOX/server/h-common/src"
+cat > "$SANDBOX/server/h-common/src/config.rs" <<'EOF'
+//! sample source
 /// Path: /home/somebody/secret.txt
 pub fn test() {}
 EOF
-
-# Run the check (should fail)
-OUTPUT=$(bash "$LEAKAGE_CHECK" 2>&1 || true)
-# Use a pattern that matches relative path output from the check
-echo "$OUTPUT" | grep -q "server/h-common/src/config.rs.*machine-specific home-directory path" && FOUND=1 || FOUND=0
-if [ "$FOUND" -eq 1 ]; then
-  test_pass "Real home path detected in test file"
+if run_check | grep -q "server/h-common/src/config.rs.*machine-specific home-directory path"; then
+  test_pass "real home path detected"
 else
-  test_fail "Real home path not detected"
-  echo "  Output: $OUTPUT" | head -5
+  test_fail "real home path NOT detected"
 fi
 
-# --- Test 2: Placeholder paths should pass ---
-echo "Test 2: Placeholder paths should pass"
-cat > "$TEST_FILE" <<'EOF'
-//! Test file for leakage detection
+# --- Test 2: placeholder paths should pass ---
+echo "Test 2: placeholder paths should pass"
+cat > "$SANDBOX/server/h-common/src/config.rs" <<'EOF'
+//! sample source
 /// Home: ~/Downloads
 /// Config: /home/user/.config
 /// Docs: /Users/name/Documents
 pub fn test() {}
 EOF
-
-# Run the check (should NOT flag the placeholder paths)
-if bash "$LEAKAGE_CHECK" 2>&1 | grep -q "$TEST_FILE.*machine-specific"; then
-  test_fail "Placeholder paths incorrectly flagged"
+if run_check | grep -q "config.rs.*machine-specific"; then
+  test_fail "placeholder paths incorrectly flagged"
 else
-  test_pass "Placeholder paths not flagged"
+  test_pass "placeholder paths not flagged"
 fi
 
-# --- Test 3: Fixtures should pass via allowlist ---
-echo "Test 3: Fixtures should pass via allowlist"
-# The fixtures already exist and contain real paths - verify they don't trigger
-FIXTURE_FILE="$REPO_ROOT/server/h-protocol/tests/fixtures/keepalive_2sse_client.bin"
-if [ -f "$FIXTURE_FILE" ]; then
-  if bash "$LEAKAGE_CHECK" 2>&1 | grep -q "$FIXTURE_FILE.*machine-specific"; then
-    test_fail "Fixture file incorrectly flagged (allowlist not working)"
-  else
-    test_pass "Fixture file allowed via allowlist"
-  fi
+# --- Test 3: captured fixtures should pass via the file: allowlist ---
+# Reset the source to clean so only the fixture is under test, then plant a
+# real home path inside an allow-listed fixture directory and confirm the
+# allowlist (NOT the binary-file skip) is what exempts it.
+echo "Test 3: fixture paths should pass via allowlist"
+cat > "$SANDBOX/server/h-common/src/config.rs" <<'EOF'
+pub fn test() {}
+EOF
+mkdir -p "$SANDBOX/server/h-protocol/tests/fixtures"
+cat > "$SANDBOX/server/h-protocol/tests/fixtures/capture.txt" <<'EOF'
+recorded wire path: /home/realuser/data.pcap
+EOF
+if run_check | grep -q "fixtures/capture.txt.*machine-specific"; then
+  test_fail "fixture path incorrectly flagged (allowlist not working)"
 else
-  echo "  (skipped - fixture file not found)"
+  test_pass "fixture path exempt via allowlist"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

Extended `check-leakage.sh` to detect machine-specific home-directory paths (`/home/<username>/` and `/Users/<username>/`) in tracked source files. This closes a gap where leaked paths (e.g., `/home/somebody/secret`) were only caught during semantic PR review.

### Changes

- **Class 3 detection**: Added regex-based detection for home-directory paths with real usernames
- **Placeholder allowlist**: Filters out known placeholders (`<user>`, `user`, `name`, `<name>`, `$HOME`, `USERNAME`, `you`)
- **File-pattern allowlist**: Extended `leakage-allowlist.txt` to exempt legitimate captured fixtures:
  - `server/h-llm/tests/fixtures/**`
  - `server/h-protocol/tests/fixtures/**`
  - `docs/examples/**`
- **Test suite**: Added `test-check-leakage.sh` with 3 test cases verifying:
  1. Real home paths are detected
  2. Placeholder paths pass
  3. Fixture files are exempted via allowlist

### Verification

- All 3 tests pass
- Leakage check stays green on current `main`
- Build passes (`cargo build --release`)

Closes #75
---
🤖 Implemented by **wiwi** • issue author: @vaderyang
Eligible for auto-merge on vivi APPROVE.
