### PR TITLE
fix(llm): register AgentClassifier{Unknown,Mixed}Count on llm worker — stops silent capture loss (#81)

### DIFF
--- a/server/h-llm/src/processor.rs
+++ b/server/h-llm/src/processor.rs
@@ -420,22 +420,30 @@ mod tests {
     }
 
     fn test_metrics() -> MetricsWorker {
+        // Build the test worker from the SAME list the production stage uses
+        // (crate::stage::LLM_WORKER_METRICS). This is what keeps the test and
+        // prod registrations from drifting: if LlmProcessor starts touching a
+        // metric absent from the production list, the existing processor tests
+        // here panic instead of passing against a hand-maintained superset
+        // (Netis/heron#81).
         let mut sys = MetricsSystem::new();
-        let w = sys.register_worker(
-            "test",
-            &[
-                Metric::WireDetected,
-                Metric::WireIgnored,
-                Metric::LlmGenericToolIdCanonicalized,
-                Metric::LlmGenericSessionIdSynthFailed,
-                Metric::LlmHeartbeatsReceived,
-                Metric::LlmTokensEstimated,
-                Metric::AgentClassifierUnknownCount,
-                Metric::AgentClassifierMixedCount,
-            ],
-        );
+        let w = sys.register_worker("test", crate::stage::LLM_WORKER_METRICS);
         let _svc = sys.start();
         w
+    }
+
+    #[test]
+    fn llm_worker_metrics_cover_agent_classifier_counters() {
+        // Regression for Netis/heron#81: the production worker registration
+        // must include every metric LlmProcessor can increment. These two were
+        // missing, so the first Unknown/Mixed classification panicked the
+        // worker and silently stopped capture. `.counter()` panics if the
+        // metric is unregistered, so this test fails loudly on a re-drift.
+        let mut sys = MetricsSystem::new();
+        let w = sys.register_worker("test", crate::stage::LLM_WORKER_METRICS);
+        let _svc = sys.start();
+        w.counter(Metric::AgentClassifierUnknownCount).inc();
+        w.counter(Metric::AgentClassifierMixedCount).inc();
     }
 
     fn flow() -> FlowKey {

--- a/server/h-llm/src/stage.rs
+++ b/server/h-llm/src/stage.rs
@@ -18,6 +18,30 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use h_common::internal_metrics::{Metric, MetricsSystem};
+
+/// Metrics registered for every `llm.{i}` worker. SINGLE SOURCE OF TRUTH:
+/// the `register_worker` call below AND `LlmProcessor`'s unit tests build
+/// their worker from this exact list, so a metric that `LlmProcessor`
+/// increments can never be absent from the registration. A missing metric
+/// makes `MetricsWorker::counter()` panic, which kills the llm stage and
+/// tears down the whole capture pipeline (Netis/heron#81).
+pub const LLM_WORKER_METRICS: &[Metric] = &[
+    Metric::WireDetected,
+    Metric::WireIgnored,
+    Metric::LlmCallsWithAgent,
+    Metric::LlmCallsWithoutAgent,
+    Metric::LlmGenericToolIdCanonicalized,
+    Metric::LlmGenericSessionIdSynthFailed,
+    Metric::LlmHeartbeatsReceived,
+    Metric::LlmTokensEstimated,
+    Metric::MetricsHeartbeatsDropped,
+    Metric::TurnHeartbeatsDropped,
+    // Incremented by LlmProcessor when tool_surface is Unknown / Mixed
+    // (processor.rs). Previously omitted here → the worker panicked on the
+    // first such classification (data-dependent, ~hourly in prod).
+    Metric::AgentClassifierUnknownCount,
+    Metric::AgentClassifierMixedCount,
+];
 use h_protocol::joiner::HttpJoinerEvent;
 
 use crate::agent_classifier::ClassifierConfig;
@@ -66,21 +90,7 @@ pub fn spawn_llm_stage(
         let metrics_txs = metrics_shard_txs.clone();
         let calls_tx = calls_tx.clone();
         let classifier_cfg = classifier_cfg.clone();
-        let worker_metrics = metrics_sys.register_worker(
-            &format!("llm.{i}"),
-            &[
-                Metric::WireDetected,
-                Metric::WireIgnored,
-                Metric::LlmCallsWithAgent,
-                Metric::LlmCallsWithoutAgent,
-                Metric::LlmGenericToolIdCanonicalized,
-                Metric::LlmGenericSessionIdSynthFailed,
-                Metric::LlmHeartbeatsReceived,
-                Metric::LlmTokensEstimated,
-                Metric::MetricsHeartbeatsDropped,
-                Metric::TurnHeartbeatsDropped,
-            ],
-        );
+        let worker_metrics = metrics_sys.register_worker(&format!("llm.{i}"), LLM_WORKER_METRICS);
         handles.push(tokio::spawn(async move {
             let shard = i;
             let mut processor = LlmProcessor::new(wire_apis, reg, worker_metrics.clone())


### PR DESCRIPTION
Fixes #81 — the recurring prod capture outage.

## Root cause
`stage.rs` registered the llm worker's metrics by hand and omitted `AgentClassifierUnknownCount` / `AgentClassifierMixedCount`, which `LlmProcessor` increments on `tool_surface == Unknown/Mixed`. `MetricsWorker::counter()` panics on an unregistered metric → llm worker panics → stage exits → pipeline tears down. Data-dependent, so it fired ~hourly. The processor's `test_metrics()` helper registered the full set, masking the drift.

## Fix
- `stage::LLM_WORKER_METRICS` is now the single source of truth; `register_worker` and the processor tests both use it, so they can't drift.
- New regression test `llm_worker_metrics_cover_agent_classifier_counters`.

## Verification
- CI (cargo test --workspace) must be green.
- Will be rebuilt + redeployed to prod immediately after merge.

🤖 Fast-tracked fix (prod actively affected); not via the wiwi loop.

Closes #81