### PR TITLE
docs: warn that a bare cargo build ships a blank console (--features console)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ just test all        # cargo test (all crates)
 
 Run `just help` for the full menu. Design docs under [docs/design/](docs/design/) describe the per-module contract — read the relevant one before changing anything load-bearing.
 
+> **Build via `just build all`, not a bare `cargo build`.** The web console is embedded behind the non-default `console` cargo feature; a raw `cargo build --release` yields a working API with a **blank console**. If you invoke cargo directly, run `bun run build` in `console/` first and pass `--features console` — see [docs/install.md → Building from source](docs/install.md#building-from-source).
+
 ## License
 
 [Apache 2.0](LICENSE).

--- a/docs/install.md
+++ b/docs/install.md
@@ -65,6 +65,32 @@ directory — `cd` into it, or pass `-c <path>` from elsewhere.
 
 For other targets, swap `TARGET` to the value from the table above.
 
+## Building from source
+
+```bash
+just build all       # frontend bundle + binary with embedded console
+```
+
+`just build all` is the supported path: it runs `bun run build` in
+`console/` and then `cargo build --release --features console`, so the web
+console gets embedded in the binary.
+
+> **Gotcha — a bare `cargo build` ships a blank console.** The web UI is
+> embedded via `rust-embed` behind the **non-default `console` cargo
+> feature**. If you build the binary directly with
+> `cargo build --release` (or `--bin heron`) and forget `--features
+> console`, the binary compiles and `/api/health` returns 200, but the
+> console at `:4500` serves a **blank page** — the assets were never
+> embedded. Build the frontend first, then build with the feature:
+>
+> ```bash
+> (cd console && bun run build)            # produces console/dist/
+> cargo build --release --bin heron --features console
+> ```
+>
+> Prefer `just build all`, which does both for you. The same applies when
+> you rebuild to deploy an upgrade — re-run with `--features console`.
+
 ## Verify the download
 
 Each release ships a `SHA256SUMS` file. Verify before running:

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,7 +80,7 @@ console gets embedded in the binary.
 > feature**. If you build the binary directly with
 > `cargo build --release` (or `--bin heron`) and forget `--features
 > console`, the binary compiles and `/api/health` returns 200, but the
-> console at `:4500` serves a **blank page** — the assets were never
+> console (default port `3000`) serves a **blank page** — the assets were never
 > embedded. Build the frontend first, then build with the feature:
 >
 > ```bash


### PR DESCRIPTION
## Why

The web console is embedded via `rust-embed` behind the **non-default `console` cargo feature**. Building the binary with a bare `cargo build --release` compiles fine and `/api/health` returns 200 — but the console at `:4500` serves a **blank page** because the assets were never embedded. The symptom (blank UI, healthy API) points nowhere near the cause; this bit a real from-source deploy.

## What

- **docs/install.md** — new "Building from source" section documenting `just build all` (the supported path: `bun run build` + `cargo build --features console`) and the manual-cargo gotcha, including the upgrade-rebuild case.
- **README.md** — a short callout in Contributing pointing at the same.

Docs only.