### PR TITLE
feat(staging): continuous auto-deploy to heron-stage VM (Quality Infra L6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,28 @@ jobs:
       - name: bun test
         working-directory: console
         run: bun test
+
+      # --- staging artifact ---------------------------------------------
+      # On a push to main (post-merge), build the deployable binary and
+      # publish it so deploy-staging.yml can roll it onto the heron-stage VM.
+      # MUST build the console bundle first AND pass `--features console`,
+      # else the embedded UI is empty (a bare cargo build serves a blank
+      # page — see docs/install.md "Building from source").
+      - name: build console bundle (staging artifact)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: console
+        run: bun run build
+
+      - name: build heron release binary with console (staging artifact)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: server
+        run: cargo build --release --bin heron --features console
+
+      - name: upload heron staging artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: heron-staging
+          path: server/target/release/heron
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,51 @@
+name: deploy-staging
+
+# Continuous staging deploy: after CI succeeds on `main`, push the freshly
+# built heron binary to the staging VM and gate on health.
+#
+# Security model: this runs ONLY on the dedicated `staging-deploy` self-hosted
+# runner and ONLY for successful `main`-branch CI runs. It never executes PR
+# (fork) code — `workflow_run` fires on the *base* repo with `main` already
+# merged, and the runner label is not shared with PR CI (which uses the
+# `heron` runner). So no untrusted code reaches the deploy host.
+#
+# Host-specific values (the VM name and its ssh user) come from repo
+# Variables, never the committed source: set them once with
+#   gh variable set HERON_STAGE_VM --body <domain>
+#   gh variable set HERON_STAGE_USER --body <login>
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+    branches: [main]
+
+# Never run two staging deploys at once; let an in-flight one finish.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # Only deploy when the triggering CI run actually passed.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: [self-hosted, staging-deploy]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download heron binary from the CI run
+        uses: actions/download-artifact@v4
+        with:
+          name: heron-staging
+          path: artifact
+          # Pull from the specific CI run that triggered us (cross-workflow).
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: deploy to the staging VM + health gate (rollback on failure)
+        env:
+          HERON_STAGE_VM: ${{ vars.HERON_STAGE_VM }}
+          HERON_STAGE_USER: ${{ vars.HERON_STAGE_USER }}
+        run: |
+          chmod +x artifact/heron
+          bash scripts/staging/deploy-staging.sh artifact/heron

--- a/scripts/staging/README.md
+++ b/scripts/staging/README.md
@@ -1,0 +1,78 @@
+# Staging auto-deploy
+
+Continuous deploy of `heron` to a long-lived **staging VM** after every
+successful `main` CI run. This is layer L6 of the quality chain: catch
+"builds and tests pass but the real binary doesn't come up healthy" before
+it reaches production.
+
+## Topology
+
+```
+push → main
+   │
+   ▼
+ci.yml  (runner: self-hosted, heron)
+   ├─ test / lint / bun test               (every push + PR)
+   └─ on main: bun run build               build the deployable artifact
+              + cargo build --release --features console
+              + upload-artifact heron-staging
+   │
+   ▼  workflow_run: ci completed, conclusion == success, branch == main
+deploy-staging.yml  (runner: self-hosted, staging-deploy)
+   ├─ download-artifact heron-staging  (from the triggering CI run)
+   └─ deploy-staging.sh artifact/heron
+          ├─ resolve heron-stage VM IP from libvirt DHCP leases
+          ├─ scp binary → VM, smoke-run --version
+          ├─ back up current binary, install, restart heron.service
+          ├─ health gate: status=ready AND pipeline running (≤90s)
+          └─ rollback to the backup if the gate fails
+```
+
+### Why a separate `staging-deploy` runner
+
+The staging VM lives in the deploy runner host's `default` libvirt network, so
+a runner on that host reaches it directly — no cross-host hop, no NAT
+port-forwarding. The runner is labelled `staging-deploy` (NOT `heron`), and
+`deploy-staging.yml` only triggers on **successful main-branch** CI via
+`workflow_run`. PR/fork code runs on the `heron` runner and never lands on
+the deploy host.
+
+## The staging VM (`heron-stage`)
+
+- Ubuntu cloud image, libvirt `default` NAT network, provisioned by
+  [`provision-vm.sh`](provision-vm.sh).
+- `heron` runs as a systemd unit ([`heron.service`](heron.service)) under a
+  dedicated `heron` user, with **`AmbientCapabilities=CAP_NET_RAW
+  CAP_NET_ADMIN`** — capture works with no `setcap`, so a rebuilt binary
+  can't silently degrade to API-only. (Recommended for production too.)
+- Binary at `/opt/heron/heron`, config [`config.toml`](config.toml) at
+  `/opt/heron/config.toml`, state under `/var/lib/heron`.
+
+### Re-provisioning
+
+```bash
+BASE_IMAGE=/path/to/ubuntu-noble-cloudimg-amd64.img \
+SSH_AUTHORIZED_KEYS_FILE=/path/to/authorized_keys \
+APT_PROXY=http://your-proxy:port \
+  scripts/staging/provision-vm.sh
+```
+
+`SSH_AUTHORIZED_KEYS_FILE` must include the **deploy runner host's** public
+key (the runner SSHes into the VM as `$HERON_STAGE_USER`). `APT_PROXY` is
+optional — omit it on a host with direct egress.
+
+## Manual deploy (debugging)
+
+From the deploy host, with the artifact in hand:
+
+```bash
+scripts/staging/deploy-staging.sh /path/to/heron
+# env knobs: HERON_STAGE_VM, HERON_STAGE_USER, HERON_STAGE_SSH_KEY,
+#            HERON_STAGE_PORT, HEALTH_TIMEOUT_SECS
+```
+
+## Not included yet
+
+A replay-server feed (recorded wire bytes → the VM's NIC) so staging
+exercises the full parse/extract path under load, plus a soak runner that
+diffs a known-good binary against the candidate. Tracked for a follow-on.

--- a/scripts/staging/config.toml
+++ b/scripts/staging/config.toml
@@ -1,0 +1,52 @@
+# Heron staging config. Mirrors the production schema; paths point at the
+# heron service's state dir. Capture runs on the VM NIC (the staging VM sees
+# little/no real LLM traffic — that's fine; a deploy is validated by the
+# pipeline coming up healthy, and a replay-server feed is a later addition).
+[[pipeline]]
+name = "local"
+dispatcher_count = 1
+flow_shard_count = 4
+
+[pipeline.turn]
+idle_timeout_secs = 600
+sweep_interval_secs = 10
+grace_ms = 1000
+shard_count = 1
+
+[pipeline.metrics]
+shard_count = 1
+
+[pipeline.pcap_dump]
+enabled = true
+dir = "/var/lib/heron/dumps"
+compression = "snappy"
+
+[pipeline.pcap_dump.retention]
+enabled = true
+check_interval_secs = 3600
+max_age_hours = 24
+max_size_mb = 10240
+
+[[pipeline.sources]]
+type = "pcap"
+interface = "any"
+bpf_filter = "tcp port 4000 or tcp port 4200 or tcp port 8000 or tcp port 9000 or tcp port 30000"
+snaplen = 262144
+
+[storage]
+backend = "duckdb"
+
+[storage.duckdb]
+path = "/var/lib/heron/data/heron.duckdb"
+
+[storage.sink]
+batch_size = 1000
+flush_interval_ms = 1000
+
+[internal_metrics]
+enabled = true
+interval_secs = 10
+
+[api]
+listen = "0.0.0.0"
+port = 4500

--- a/scripts/staging/deploy-staging.sh
+++ b/scripts/staging/deploy-staging.sh
@@ -32,6 +32,11 @@ SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
 PORT="${HERON_STAGE_PORT:-4500}"
 HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-90}"
 
+# StrictHostKeyChecking=no + a throwaway known_hosts: the target is an
+# ephemeral VM on a controlled internal libvirt network whose host key
+# changes on every reprovision (and whose DHCP IP can be reused by a
+# different VM), so pinning the key would just wedge the deploy. The trust
+# boundary is the libvirt network + the deploy key, not TOFU.
 SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8)
 remote() { ssh "${SSH_OPTS[@]}" "$SSH_USER@$IP" "$@"; }
 

--- a/scripts/staging/deploy-staging.sh
+++ b/scripts/staging/deploy-staging.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Deploy a freshly-built heron binary to the staging libvirt VM and gate
+# on health, rolling back on failure.
+#
+# Runs on the staging deploy runner (label `staging-deploy`). The staging VM
+# lives in the host's `default` libvirt network, so the runner reaches it
+# directly — no cross-host hop. All host-specific values (VM name, ssh user,
+# key, ports) are env-overridable so nothing internal is baked into the repo.
+#
+# Usage:
+#   scripts/staging/deploy-staging.sh <path-to-heron-binary>
+#
+# Env (all optional, with safe defaults):
+#   HERON_STAGE_VM       libvirt domain name             (default: heron-stage)
+#   HERON_STAGE_NET      libvirt network for the lease   (default: default)
+#   HERON_STAGE_USER     ssh user on the VM              (default: heron-admin)
+#   HERON_STAGE_SSH_KEY  ssh identity                    (default: ~/.ssh/id_ed25519)
+#   HERON_STAGE_PORT     heron API port inside the VM    (default: 4500)
+#   HEALTH_TIMEOUT_SECS  health-gate budget              (default: 90)
+#
+# Exit status: 0 = deployed + healthy; non-zero = failed (and rolled back if a
+# previous binary was present).
+set -euo pipefail
+
+BIN="${1:?usage: deploy-staging.sh <heron-binary>}"
+[ -f "$BIN" ] || { echo "::error::binary not found: $BIN" >&2; exit 1; }
+
+VM="${HERON_STAGE_VM:-heron-stage}"
+NET="${HERON_STAGE_NET:-default}"
+SSH_USER="${HERON_STAGE_USER:-heron-admin}"
+SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+PORT="${HERON_STAGE_PORT:-4500}"
+HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-90}"
+
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8)
+remote() { ssh "${SSH_OPTS[@]}" "$SSH_USER@$IP" "$@"; }
+
+echo "==> resolving $VM IP from libvirt '$NET' DHCP leases"
+IP="$(sudo virsh net-dhcp-leases "$NET" 2>/dev/null | awk -v n="$VM" '$0 ~ n {print $5}' | cut -d/ -f1 | head -1)"
+[ -n "$IP" ] || { echo "::error::no DHCP lease for domain '$VM' on net '$NET' — is the VM running?" >&2; exit 1; }
+echo "    $VM -> $IP"
+
+echo "==> uploading new binary + smoke-running it on the VM"
+scp "${SSH_OPTS[@]}" "$BIN" "$SSH_USER@$IP:/tmp/heron-new"
+remote 'chmod +x /tmp/heron-new && /tmp/heron-new --version' \
+  || { echo "::error::uploaded binary does not run on the VM (glibc/lib mismatch?)" >&2; exit 1; }
+
+echo "==> installing + restarting heron.service (current binary backed up)"
+remote 'set -e
+  sudo install -d -m 0755 /opt/heron
+  if [ -f /opt/heron/heron ]; then sudo cp -f /opt/heron/heron /opt/heron/heron.bak; fi
+  sudo install -m 0755 /tmp/heron-new /opt/heron/heron
+  sudo systemctl restart heron.service'
+
+echo "==> health gate (<= ${HEALTH_TIMEOUT_SECS}s): status=ready AND pipeline running"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SECS ))
+ok=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  # jq runs inside the VM (curl + jq are present there); the host only string-matches.
+  res="$(remote "curl -s -m 5 http://127.0.0.1:${PORT}/api/health | jq -r '(.data.status)+\"|\"+(.data.pipelines[0].running|tostring)'" 2>/dev/null || true)"
+  if [ "${res%%|*}" = "ready" ] && [ "${res##*|}" = "true" ]; then ok=1; break; fi
+  sleep 5
+done
+
+if [ "$ok" = 1 ]; then
+  echo "==> OK heron-stage healthy on ${IP}:${PORT} (status=ready, capturing)"
+  remote 'rm -f /tmp/heron-new; sudo rm -f /opt/heron/heron.bak' || true
+  exit 0
+fi
+
+echo "::error::health gate FAILED after ${HEALTH_TIMEOUT_SECS}s — rolling back"
+remote 'set -e
+  if [ -f /opt/heron/heron.bak ]; then
+    sudo install -m 0755 /opt/heron/heron.bak /opt/heron/heron
+    sudo systemctl restart heron.service
+    echo "rolled back to the previous /opt/heron/heron"
+  else
+    echo "no /opt/heron/heron.bak to roll back to (first deploy?)"
+  fi'
+exit 1

--- a/scripts/staging/heron.service
+++ b/scripts/staging/heron.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Heron capture server (staging)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=heron
+Group=heron
+ExecStart=/opt/heron/heron -v -c /opt/heron/config.toml
+WorkingDirectory=/opt/heron
+# Grant raw-capture privileges at runtime. The binary needs NO file caps,
+# so a `cargo` rebuild (which replaces the inode and drops file caps) can't
+# silently degrade capture to API-only — the unit re-grants them every start.
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+NoNewPrivileges=true
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/staging/provision-vm.sh
+++ b/scripts/staging/provision-vm.sh
@@ -92,6 +92,7 @@ package_update: true
 package_upgrade: false
 packages:
   - ca-certificates
+  - curl          # deploy-staging.sh health-gates via curl inside the VM
   - libpcap0.8
   - jq
 

--- a/scripts/staging/provision-vm.sh
+++ b/scripts/staging/provision-vm.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Provision the staging libvirt VM — the CI staging-deploy target.
+#
+# Idempotent-ish: refuses to clobber an existing domain (destroy it first to
+# re-provision). Produces a cloud-init Ubuntu VM with:
+#   - a `heron` system user + /opt/heron + /var/lib/heron
+#   - libpcap runtime + jq + ca-certificates
+#   - the heron.service unit (AmbientCapabilities, no setcap) and config.toml
+#     from this directory, written in place and `enable`d (NOT started — the
+#     binary lands on the first deploy, which starts it).
+#
+# Nothing internal is hardcoded: the base image, the keys to authorize, and
+# the apt proxy all come from the environment so this script is safe to commit.
+#
+# Required env:
+#   BASE_IMAGE                 path to an Ubuntu cloud qcow2 (e.g. noble)
+#   SSH_AUTHORIZED_KEYS_FILE   file of public keys (one per line) to authorize
+#                              for the VM's login user (deploy runner + ops)
+# Optional env:
+#   APT_PROXY                  http proxy for apt/egress (omitted if unset)
+#   VM_NAME (heron-stage)  VM_USER (heron-admin)  VM_RAM_MB (6144)  VM_VCPUS (4)
+#   VM_DISK_GB (40)  LIBVIRT_NET (default)  IMAGES_DIR (/var/lib/libvirt/images)
+#
+# Run on the libvirt host (needs sudo for virsh + the images dir).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${BASE_IMAGE:?set BASE_IMAGE to an Ubuntu cloud qcow2 path}"
+: "${SSH_AUTHORIZED_KEYS_FILE:?set SSH_AUTHORIZED_KEYS_FILE to a file of public keys}"
+[ -f "$BASE_IMAGE" ] || { echo "BASE_IMAGE not found: $BASE_IMAGE" >&2; exit 1; }
+[ -f "$SSH_AUTHORIZED_KEYS_FILE" ] || { echo "keys file not found: $SSH_AUTHORIZED_KEYS_FILE" >&2; exit 1; }
+
+VM_NAME="${VM_NAME:-heron-stage}"
+VM_USER="${VM_USER:-heron-admin}"
+VM_RAM_MB="${VM_RAM_MB:-6144}"
+VM_VCPUS="${VM_VCPUS:-4}"
+VM_DISK_GB="${VM_DISK_GB:-40}"
+LIBVIRT_NET="${LIBVIRT_NET:-default}"
+IMAGES_DIR="${IMAGES_DIR:-/var/lib/libvirt/images}"
+
+if sudo virsh dominfo "$VM_NAME" >/dev/null 2>&1; then
+  echo "domain '$VM_NAME' already exists — destroy+undefine it first to re-provision." >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# --- cloud-init: meta-data ---
+cat > "$WORK/meta-data" <<EOF
+instance-id: ${VM_NAME}-001
+local-hostname: ${VM_NAME}
+EOF
+
+# --- cloud-init: user-data ---
+# Indent embedded files by 6 spaces to sit under the write_files `content: |`.
+indent6() { sed 's/^/      /'; }
+KEYS_BLOCK="$(while IFS= read -r k; do [ -n "$k" ] && echo "      - $k"; done < "$SSH_AUTHORIZED_KEYS_FILE")"
+APT_BLOCK=""
+ENV_PROXY_BLOCK=""
+if [ -n "${APT_PROXY:-}" ]; then
+  APT_BLOCK=$'apt:\n  http_proxy: '"$APT_PROXY"$'\n  https_proxy: '"$APT_PROXY"
+  ENV_PROXY_BLOCK="  - path: /etc/environment
+    content: |
+      HTTP_PROXY=${APT_PROXY}
+      HTTPS_PROXY=${APT_PROXY}
+      http_proxy=${APT_PROXY}
+      https_proxy=${APT_PROXY}
+      no_proxy=localhost,127.0.0.1,.local
+      NO_PROXY=localhost,127.0.0.1,.local
+"
+fi
+
+{
+cat <<EOF
+#cloud-config
+hostname: ${VM_NAME}
+fqdn: ${VM_NAME}.local
+manage_etc_hosts: true
+
+users:
+  - name: ${VM_USER}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo, adm]
+    shell: /bin/bash
+    lock_passwd: true
+    ssh_authorized_keys:
+${KEYS_BLOCK}
+
+${APT_BLOCK}
+
+package_update: true
+package_upgrade: false
+packages:
+  - ca-certificates
+  - libpcap0.8
+  - jq
+
+write_files:
+${ENV_PROXY_BLOCK}  - path: /opt/heron/config.toml
+    permissions: '0644'
+    content: |
+$(indent6 < "$HERE/config.toml")
+  - path: /etc/systemd/system/heron.service
+    permissions: '0644'
+    content: |
+$(indent6 < "$HERE/heron.service")
+
+runcmd:
+  # SHELL strings (not exec-form lists) so '||' works — an exec-form
+  # [getent, group, heron, '||', ...] passes '||' as a literal arg and the
+  # heron user silently never gets created.
+  - "getent group heron || groupadd --system heron"
+  - "id -u heron >/dev/null 2>&1 || useradd --system --gid heron --home-dir /var/lib/heron --shell /usr/sbin/nologin heron"
+  - mkdir -p /opt/heron /var/lib/heron/data /var/lib/heron/dumps
+  - chown -R heron:heron /var/lib/heron
+  - systemctl daemon-reload
+  # enable (not start): the binary lands on the first deploy, which starts it.
+  - systemctl enable heron.service
+  - "echo ${VM_NAME} cloud-init complete > /var/lib/heron/.provisioned"
+EOF
+} > "$WORK/user-data"
+
+echo "==> building seed.iso"
+cloud-localds "$WORK/seed.iso" "$WORK/user-data" "$WORK/meta-data"
+
+echo "==> creating ${VM_DISK_GB}G disk from $BASE_IMAGE"
+sudo mkdir -p "$IMAGES_DIR/$VM_NAME"
+cp "$BASE_IMAGE" "$WORK/disk.qcow2"
+qemu-img resize "$WORK/disk.qcow2" "${VM_DISK_GB}G"
+sudo cp "$WORK/disk.qcow2" "$WORK/seed.iso" "$IMAGES_DIR/$VM_NAME/"
+sudo chown libvirt-qemu:kvm "$IMAGES_DIR/$VM_NAME/disk.qcow2" "$IMAGES_DIR/$VM_NAME/seed.iso"
+
+echo "==> virt-install $VM_NAME"
+sudo virt-install \
+  --name "$VM_NAME" \
+  --memory "$VM_RAM_MB" \
+  --vcpus "$VM_VCPUS" \
+  --disk "path=$IMAGES_DIR/$VM_NAME/disk.qcow2,format=qcow2,bus=virtio" \
+  --disk "path=$IMAGES_DIR/$VM_NAME/seed.iso,device=cdrom" \
+  --os-variant ubuntu24.04 \
+  --network "network=$LIBVIRT_NET,model=virtio" \
+  --graphics none --import --noautoconsole
+
+echo "==> $VM_NAME created. Find its IP with:"
+echo "    sudo virsh net-dhcp-leases $LIBVIRT_NET | grep $VM_NAME"
+echo "    (cloud-init finishes in a few minutes; /var/lib/heron/.provisioned marks done)"


### PR DESCRIPTION
Continuous deploy of heron to a long-lived **staging VM** after every successful `main` CI run — layer L6 of the quality chain.

## Pipeline
```
push→main → ci.yml (runner: heron)
              └ on main: bun run build + cargo build --release --features console + upload-artifact heron-staging
            → workflow_run(success, main) → deploy-staging.yml (runner: wukong-deploy)
              └ download artifact → deploy-staging.sh → resolve VM IP → scp+smoke → backup+install+restart → health-gate → rollback
```

## Security model
`deploy-staging.yml` triggers **only** on a successful **main**-branch CI run and runs **only** on the dedicated `wukong-deploy` runner (label not shared with PR CI). PR/fork code never reaches the deploy host.

## Why `--features console`
The console is rust-embedded behind the non-default `console` feature; a bare `cargo build` ships a blank UI. The artifact build does `bun run build` + `--features console`.

## Staging VM
`provision-vm.sh` (cloud-init; base image / keys / proxy all from env — nothing internal committed) + `heron.service` (AmbientCapabilities, **no setcap**) + `config.toml`. See `scripts/staging/README.md`.

## Validation
The deploy mechanics were run end-to-end against the live `heron-stage` VM before commit (resolve→scp→smoke→install→restart→health-gate all green). Local lint gates pass (check-leakage, check-secrets, YAML, bash -n).

Note: the runner `wukong-deploy` and the `heron-stage` VM are already provisioned and online.

## Not included yet
Replay-server feed + soak runner (a follow-on).