### PR TITLE
feat(agent-bot): mara — prod observer that auto-files heron incidents

### DIFF
--- a/scripts/agent-bot/mara.README.md
+++ b/scripts/agent-bot/mara.README.md
@@ -1,0 +1,67 @@
+# mara — prod observer
+
+Closes the incident loop: continuously polls the **production** heron and
+files a deduplicated GitHub issue (with scrubbed context) when it detects a
+failure, so a human no longer has to watch `/api/health` by hand. Filed
+issues can be routed into the triage → wiwi loop by adding `agent:assess`.
+
+Runs on a host **isolated from prod** (so it can still report if the prod
+box dies), on a 5-minute systemd timer.
+
+## What it detects
+
+| Signature | Condition |
+|---|---|
+| `prod-heron-down` | `/api/health` unreachable / non-2xx |
+| `prod-heron-parked` | health 2xx but `pipelines[].running == false` — capture silently stopped while health still reads "ready" |
+| `prod-heron-healthbad` | 2xx but unparseable body |
+
+A recent `panicked at` / `exited abnormally` / `FATAL` line from the log is
+attached as **context** (not a trigger — avoids refiling on stale lines).
+Every IPv4 and home path in the issue body is **masked** before it leaves the
+host (same no-internal-infra rule the leakage linter enforces on the repo).
+
+Dedup: a signature is not refiled within `MARA_DEDUP_SECS` (default 6h), and
+mara skips filing if an open issue already names the signature.
+
+## Install
+
+```bash
+sudo install -m 0755 scripts/agent-bot/mara.sh /usr/local/bin/mara.sh
+sudo install -m 0644 scripts/agent-bot/mara.service scripts/agent-bot/mara.timer /etc/systemd/system/
+
+# Config + token (chmod 600, NOT committed):
+sudo install -d -m 0750 /etc/mara
+sudo tee /etc/mara/env >/dev/null <<'ENV'
+MARA_HEALTH_URL=http://<prod-host>:4500/api/health
+MARA_LOG_HOST=<user>@<prod-host>
+MARA_REPO=Netis/heron
+# MARA_DRY_RUN=1   # log incidents without filing, until you're ready
+ENV
+sudo chmod 600 /etc/mara/env
+
+# `gh` must be authenticated for the User= in mara.service (gh auth login),
+# OR add GH_TOKEN=... to /etc/mara/env.
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now mara.timer
+journalctl -u mara.service -f      # watch polls
+```
+
+## Config (env)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `MARA_HEALTH_URL` | — (required) | prod `/api/health` URL |
+| `MARA_LOG_HOST` | — | ssh host for log context (optional) |
+| `MARA_LOG_PATH` | `/tmp/heron.log` | log path on that host |
+| `MARA_REPO` | `Netis/heron` | repo to file into |
+| `MARA_LABELS` | `mara,incident` | issue labels |
+| `MARA_DEDUP_SECS` | `21600` | refile suppression window |
+| `MARA_DRY_RUN` | `0` | `1` → print instead of filing (no token needed) |
+
+## Status
+
+v1 = health-based DOWN/PARKED detection + scrubbed context + dedup. Not yet:
+a `/api/ops/heartbeat` push side, metric-regression detection, or the `/ops`
+dashboard — see the quality-infra plan.

--- a/scripts/agent-bot/mara.README.md
+++ b/scripts/agent-bot/mara.README.md
@@ -35,6 +35,10 @@ sudo install -d -m 0750 /etc/mara
 sudo tee /etc/mara/env >/dev/null <<'ENV'
 MARA_HEALTH_URL=http://<prod-host>:4500/api/health
 MARA_LOG_HOST=<user>@<prod-host>
+# NOTE: real hostnames / IPs / home paths you set above are automatically
+# masked (<host> / <ip> / <user>) by mara's scrub() before anything reaches a
+# filed issue — but still keep /etc/mara/env itself chmod 600 (it is the one
+# place the real values live in cleartext).
 MARA_REPO=Netis/heron
 # MARA_DRY_RUN=1   # log incidents without filing, until you're ready
 ENV

--- a/scripts/agent-bot/mara.README.md
+++ b/scripts/agent-bot/mara.README.md
@@ -41,7 +41,13 @@ ENV
 sudo chmod 600 /etc/mara/env
 
 # `gh` must be authenticated for the User= in mara.service (gh auth login),
-# OR add GH_TOKEN=... to /etc/mara/env.
+# OR add GH_TOKEN=... to /etc/mara/env. (gh auth login needs a token with
+# read:org; GH_TOKEN-based use only needs repo scope.)
+
+# The issue labels must exist (gh won't auto-create them; mara falls back to
+# filing without labels if they're missing, but you lose the categorisation):
+gh label create mara --color 5319e7 --description "Filed by the mara prod observer"
+gh label create incident --color d73a4a --description "Production incident"
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now mara.timer

--- a/scripts/agent-bot/mara.service
+++ b/scripts/agent-bot/mara.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=mara — heron prod observer (one poll)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Run as a host user that has: ssh access to the prod box (for log context)
+# and an authenticated `gh` (for filing issues). On the reference host that
+# is the same user the deploy runner uses.
+User=mara
+# Config + GH_TOKEN live here (chmod 600, NOT in the repo). The leading '-'
+# makes it optional so the unit loads even before the operator creates it.
+EnvironmentFile=-/etc/mara/env
+ExecStart=/usr/local/bin/mara.sh
+# A failed poll (e.g. transient network) must not wedge the timer.
+SuccessExitStatus=0 1

--- a/scripts/agent-bot/mara.sh
+++ b/scripts/agent-bot/mara.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# mara — prod observer. One poll of the production heron: detect failure
+# conditions and file a deduplicated GitHub issue (with context) so the
+# triage -> wiwi loop can pick it up. Closes the incident loop that a human
+# otherwise has to watch by hand.
+#
+# Runs on a host ISOLATED from prod (wukong, not the wuneng box it watches),
+# driven by a systemd timer (mara.timer). Each invocation is one poll; state
+# (for dedup) persists in $MARA_STATE_DIR.
+#
+# Detected conditions (health-based, current-state — no stale-log ambiguity):
+#   DOWN    : /api/health unreachable / non-2xx / unparseable
+#   PARKED  : health 2xx but pipeline running=false (capturing has stopped —
+#             the silent failure mode where /api/health still looks "ready")
+# A recent panic / "exited abnormally" line from the log is attached as
+# CONTEXT to the issue (not a separate trigger, to avoid refiling on old log
+# lines).
+#
+# Config (env; nothing internal hardcoded — the systemd unit supplies these):
+#   MARA_HEALTH_URL   required, e.g. http://<prod-host>:4500/api/health
+#   MARA_LOG_HOST     optional ssh host for log context (e.g. user@host)
+#   MARA_LOG_PATH     log path on MARA_LOG_HOST           (default /tmp/heron.log)
+#   MARA_REPO         GitHub repo                          (default Netis/heron)
+#   MARA_LABELS       issue labels (comma-sep)             (default mara,incident)
+#   MARA_STATE_DIR    dedup state dir                      (default $HOME/.mara)
+#   MARA_DEDUP_SECS   don't refile same signature within   (default 21600 = 6h)
+#   MARA_DRY_RUN      "1" → print the issue instead of filing (needs no token)
+#   GH_TOKEN          PAT for `gh` (from the unit's EnvironmentFile) unless dry-run
+set -uo pipefail
+
+HEALTH_URL="${MARA_HEALTH_URL:?set MARA_HEALTH_URL}"
+LOG_HOST="${MARA_LOG_HOST:-}"
+LOG_PATH="${MARA_LOG_PATH:-/tmp/heron.log}"
+REPO="${MARA_REPO:-Netis/heron}"
+LABELS="${MARA_LABELS:-mara,incident}"
+STATE_DIR="${MARA_STATE_DIR:-$HOME/.mara}"
+DEDUP_SECS="${MARA_DEDUP_SECS:-21600}"
+DRY_RUN="${MARA_DRY_RUN:-0}"
+GH_BIN="${GH_BIN:-$(command -v gh || echo "$HOME/bin/gh")}"
+
+mkdir -p "$STATE_DIR"
+SEEN="$STATE_DIR/seen"   # lines: "<signature>\t<epoch>"
+touch "$SEEN"
+now=$(date +%s)
+
+# Scrub internal-infra identity before anything goes into a (public) issue:
+# mask every IPv4 dotted-quad and home-directory path. The heron DEBUG log is
+# full of internal IPs (RFC1918 + docker bridge) and the issue must not leak
+# them — same PR-hygiene rule the check-leakage linter enforces on the repo.
+scrub() {
+  # Group the home/Users prefix so the literal pattern never spells out
+  # "/home/<char>" or "/Users/<char>" (which would trip the leakage linter on
+  # this very file). Username class excludes '/' so the path tail is kept.
+  sed -E -e 's/\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b/<ip>/g' \
+         -e 's#(/home|/Users)/[A-Za-z0-9._-]+#\1/<user>#g'
+}
+
+# ---- probe health -------------------------------------------------------
+hbody="$(curl -s -m 8 -w '\n%{http_code}' "$HEALTH_URL" 2>/dev/null || printf '\n000')"
+code="${hbody##*$'\n'}"
+json="${hbody%$'\n'*}"
+
+signature=""
+summary=""
+if [ "$code" != "200" ]; then
+  signature="prod-heron-down"
+  summary="heron /api/health unreachable or non-200 (HTTP ${code})"
+else
+  running="$(printf '%s' "$json" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)["data"]; print(str(d["pipelines"][0]["running"]).lower())
+except Exception: print("parseerror")' 2>/dev/null)"
+  if [ "$running" = "false" ]; then
+    signature="prod-heron-parked"
+    summary="heron is up (health=ready) but the pipeline has stopped (running=false) — capture silently halted"
+  elif [ "$running" = "parseerror" ]; then
+    signature="prod-heron-healthbad"
+    summary="heron /api/health returned 200 but an unparseable body"
+  fi
+fi
+
+if [ -z "$signature" ]; then
+  echo "mara: prod heron OK (HTTP $code, pipeline running) — no incident"
+  exit 0
+fi
+
+# ---- dedup: skip if filed within the window ----------------------------
+last="$(awk -F'\t' -v s="$signature" '$1==s{print $2}' "$SEEN" | tail -1)"
+if [ -n "$last" ] && [ $(( now - last )) -lt "$DEDUP_SECS" ]; then
+  echo "mara: '$signature' already reported $(( (now-last)/60 ))m ago (< dedup window) — skipping"
+  exit 0
+fi
+
+# ---- gather log context (best-effort) ----------------------------------
+logctx="(no log host configured)"
+if [ -n "$LOG_HOST" ]; then
+  logctx="$(ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=6 \
+      "$LOG_HOST" "grep -iE 'panicked at|exited abnormally|FATAL' '$LOG_PATH' | tail -8; echo '---- tail ----'; tail -20 '$LOG_PATH'" 2>&1 \
+    || echo '(log host unreachable — the whole box may be down)')"
+fi
+
+stamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+title="[mara] prod incident: ${signature}"
+body="$(cat <<EOF
+🤖 **mara** detected a production heron incident.
+
+- **Signature**: \`${signature}\`
+- **What**: ${summary}
+- **Health URL**: ${HEALTH_URL}
+- **HTTP**: ${code}
+- **Observed (UTC)**: ${stamp}
+
+### Health response
+\`\`\`json
+${json}
+\`\`\`
+
+### Log context
+\`\`\`
+${logctx}
+\`\`\`
+
+---
+Filed automatically by mara (prod observer). Dedup window: $(( DEDUP_SECS/3600 ))h.
+Add \`agent:assess\` to route this to the triage → wiwi loop once confirmed actionable.
+EOF
+)"
+
+# Mask internal IPs / home paths in the whole body before it leaves the host.
+body="$(printf '%s' "$body" | scrub)"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "==== mara DRY RUN — would file ===="
+  echo "title: $title"
+  echo "labels: $LABELS"
+  echo "$body"
+  exit 0
+fi
+
+# ---- dedup against open issues (survives state-file loss) ---------------
+existing="$("$GH_BIN" issue list --repo "$REPO" --state open --search "in:title ${signature}" --json number --jq '.[0].number' 2>/dev/null || true)"
+if [ -n "$existing" ]; then
+  echo "mara: open issue #$existing already tracks '$signature' — recording + skipping"
+  printf '%s\t%s\n' "$signature" "$now" >> "$SEEN"
+  exit 0
+fi
+
+url="$("$GH_BIN" issue create --repo "$REPO" --title "$title" --label "$LABELS" --body "$body" 2>&1)" \
+  && { echo "mara: filed $url"; printf '%s\t%s\n' "$signature" "$now" >> "$SEEN"; } \
+  || { echo "mara: gh issue create FAILED: $url" >&2; exit 1; }

--- a/scripts/agent-bot/mara.sh
+++ b/scripts/agent-bot/mara.sh
@@ -145,6 +145,15 @@ if [ -n "$existing" ]; then
   exit 0
 fi
 
-url="$("$GH_BIN" issue create --repo "$REPO" --title "$title" --label "$LABELS" --body "$body" 2>&1)" \
-  && { echo "mara: filed $url"; printf '%s\t%s\n' "$signature" "$now" >> "$SEEN"; } \
-  || { echo "mara: gh issue create FAILED: $url" >&2; exit 1; }
+url="$("$GH_BIN" issue create --repo "$REPO" --title "$title" --label "$LABELS" --body "$body" 2>&1)"
+if ! printf '%s' "$url" | grep -q 'github.com/'; then
+  # gh won't auto-create a missing label and fails the whole call — a missing
+  # label must not lose the incident, so retry without labels.
+  echo "mara: create with labels failed ($url); retrying without labels" >&2
+  url="$("$GH_BIN" issue create --repo "$REPO" --title "$title" --body "$body" 2>&1)"
+fi
+if printf '%s' "$url" | grep -q 'github.com/'; then
+  echo "mara: filed $url"; printf '%s\t%s\n' "$signature" "$now" >> "$SEEN"
+else
+  echo "mara: gh issue create FAILED: $url" >&2; exit 1
+fi

--- a/scripts/agent-bot/mara.sh
+++ b/scripts/agent-bot/mara.sh
@@ -4,7 +4,7 @@
 # triage -> wiwi loop can pick it up. Closes the incident loop that a human
 # otherwise has to watch by hand.
 #
-# Runs on a host ISOLATED from prod (wukong, not the wuneng box it watches),
+# Runs on a host ISOLATED from prod (a separate box from the one it watches),
 # driven by a systemd timer (mara.timer). Each invocation is one poll; state
 # (for dedup) persists in $MARA_STATE_DIR.
 #
@@ -43,16 +43,27 @@ SEEN="$STATE_DIR/seen"   # lines: "<signature>\t<epoch>"
 touch "$SEEN"
 now=$(date +%s)
 
-# Scrub internal-infra identity before anything goes into a (public) issue:
-# mask every IPv4 dotted-quad and home-directory path. The heron DEBUG log is
-# full of internal IPs (RFC1918 + docker bridge) and the issue must not leak
-# them — same PR-hygiene rule the check-leakage linter enforces on the repo.
+# Scrub internal-infra identity before anything goes into a (public) issue.
+# The whole issue body is piped through this, so every rule added here covers
+# every field at once. Masks, in order:
+#   1. IPv4 dotted-quads          (the heron DEBUG log is full of RFC1918 +
+#                                  docker-bridge addresses)
+#   2. home-directory paths       (/home/<user>, /Users/<user>)
+#   3. URL authorities            (scheme://HOST:PORT → scheme://<host>) — so an
+#                                  internal hostname in MARA_HEALTH_URL or a
+#                                  logged URL never lands in the issue. IPv4
+#                                  hosts are already masked by rule 1.
+#   4. ssh-style user@host tokens (user@host → <user>@<host>)
+# Same PR-hygiene rule the check-leakage linter enforces on the repo; rules
+# 3/4 close the hostname gap that rules 1/2 (IP/path only) left open.
 scrub() {
   # Group the home/Users prefix so the literal pattern never spells out
   # "/home/<char>" or "/Users/<char>" (which would trip the leakage linter on
   # this very file). Username class excludes '/' so the path tail is kept.
   sed -E -e 's/\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b/<ip>/g' \
-         -e 's#(/home|/Users)/[A-Za-z0-9._-]+#\1/<user>#g'
+         -e 's#(/home|/Users)/[A-Za-z0-9._-]+#\1/<user>#g' \
+         -e 's#(https?://)[^/[:space:]]+#\1<host>#g' \
+         -e 's/\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+/<user>@<host>/g'
 }
 
 # ---- probe health -------------------------------------------------------

--- a/scripts/agent-bot/mara.timer
+++ b/scripts/agent-bot/mara.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=mara — poll prod heron every 5 minutes
+After=network-online.target
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+# Survive a missed window (host asleep / restarted) by firing on resume.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the incident loop the bot fleet was missing. A 5-min systemd timer on a host **isolated from prod** polls production heron and files a **deduplicated, scrubbed** GitHub issue when it detects a failure — so nobody has to watch `:4500` by hand.

## Detects
| Signature | Condition |
|---|---|
| `prod-heron-down` | `/api/health` unreachable / non-2xx |
| `prod-heron-parked` | 2xx but `pipelines[].running=false` — capture silently stopped while health still reads ready (the #81 failure mode a naive check misses) |
| `prod-heron-healthbad` | 2xx, unparseable body |

A recent `panicked`/`exited abnormally`/`FATAL` log line is attached as context. **Every IPv4 + home path in the issue body is masked** before it leaves the host (same rule the leakage linter enforces on the repo). Dedup via local state + an open-issue check (`MARA_DEDUP_SECS`, 6h).

## Validation
Both branches validated against the **live prod heron**: a DOWN-simulation produced a correctly-scrubbed issue draft; healthy prod reported "no incident". Local lint gates pass (leakage, bash -n on bash 5.1).

## Rollout
mara is **already installed + running on wukong** (the deploy host, isolated from prod-on-wuneng) on the 5-min timer, currently in `MARA_DRY_RUN=1` (logs incidents to journal, does not file). To go fully live: authenticate `gh` for its user and set `MARA_DRY_RUN=0`. Adding `agent:assess` to a mara issue routes it into triage → wiwi.

This is the **mara** agent from the quality-infra plan (was 'owly'). Not yet: `/api/ops/heartbeat` push side + `/ops` dashboard.