### PR TITLE
docs: launch assets — README badges, technical blog, launch posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Heron
 
+[![CI](https://github.com/Netis/heron/actions/workflows/ci.yml/badge.svg)](https://github.com/Netis/heron/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Netis/heron?sort=semver)](https://github.com/Netis/heron/releases/latest)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Platforms](https://img.shields.io/badge/platforms-linux%20%C2%B7%20macOS-informational)](docs/install.md)
+
 **Agent observability from the network wire.** A passive analyzer that watches LLM traffic on the wire and reconstructs what your agents are actually *doing* — tool calls, multi-step plans, where time is spent, where loops happen, who calls whom — without an SDK, sidecar, or proxy in the request path.
+
+> **Try it in 30 seconds, no live capture, no privileges:** grab a `.pcap` with LLM
+> traffic and replay it —
+> `heron --pcap-file capture.pcap --no-retention` — then open
+> <http://localhost:3000>. See [Quickstart](#quickstart).
 
 ![Agent turn detail — a 247-call agent run, every tool call ordered on the Timeline, drilling into one call's request/response on the right](docs/images/agent-turn-detail.png)
 

--- a/docs/blog/2026-06-01-agent-turns-from-the-wire.md
+++ b/docs/blog/2026-06-01-agent-turns-from-the-wire.md
@@ -1,0 +1,128 @@
+# Reconstructing agent turns from raw packets
+
+*How Heron rebuilds what an AI agent is actually doing — tool calls, plan
+loops, multi-leg proxy hops — from plaintext HTTP on the wire, with no SDK,
+no proxy in the request path, and no cooperation from the workload.*
+
+---
+
+## The problem with watching agents
+
+An agent run is not one LLM call. It's a loop: the planner calls the model,
+the model asks for a tool, the tool result goes back, the planner calls
+again — dozens or hundreds of times — until it submits an answer. When that
+loop misbehaves in production (a tool call stalls, the planner oscillates
+between two states, a downstream proxy silently swaps the model), the
+evidence is spread across many HTTP calls that nobody stitched back together.
+
+The usual ways to see this each cost you something:
+
+- **SDK instrumentation** (Langfuse/LangSmith-style) needs every client to
+  emit, and it sits in your code path.
+- **A reverse proxy** (LiteLLM and friends) sees full bodies but is *in the
+  request path* — if it falls over, so do your calls — and it only sees
+  per-call data, not the turn.
+- **OpenTelemetry from the server** needs the server to emit, and usually
+  only gets partial bodies.
+
+Heron takes a different bet: **read the bytes already on the wire.**
+
+## Where Heron sits
+
+Heron runs where the traffic is *already decrypted* — on the inference host,
+behind the TLS terminator, or fed from a SPAN/TAP via
+[cloud-probe](https://github.com/Netis/cloud-probe). It never sits in the
+request path, so the observer can crash without breaking a single call, and
+the workloads being observed need zero changes.
+
+```
+NIC / .pcap / cloud-probe (ZMQ)
+        │
+        ▼
+   capture → flow dispatcher (hash by 5-tuple)
+        │
+        ▼
+   N parallel workers: HTTP/SSE parse → wire-API decode → semantic extraction
+        │
+        ▼
+   turn tracker  +  metrics aggregator  +  storage sink
+        │
+        ▼
+       DuckDB ── REST API ── React console
+```
+
+## The hard parts
+
+Turning packets into "this agent ran a 247-call plan, looped twice on the
+edit tool, and one leg went through litellm to a vLLM backend" takes a few
+non-obvious steps.
+
+### 1. Reassemble HTTP/SSE from TCP, zero-copy
+
+Packets arrive fragmented and interleaved across connections. A flow
+dispatcher hashes by 5-tuple so every packet of one connection lands on the
+same worker — parsing state stays local and lock-free. Each worker
+reassembles the TCP stream and parses HTTP with a zero-copy parser, including
+streaming `text/event-stream` (SSE) responses, which is where most of the
+interesting token-timing signal lives.
+
+### 2. Decode the wire API, not just "an HTTP call"
+
+OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and Gemini
+all look like HTTP POSTs but carry different shapes. Heron detects the
+wire API and extracts a normalized `LlmCall`: model, tokens, finish reason,
+TTFT, tool calls, and the raw body for drill-down. This is also where the
+streaming-vs-non-streaming TTFT distinction matters — a non-streaming
+response has no meaningful time-to-first-token, so Heron doesn't fabricate
+one.
+
+### 3. Stitch calls into a turn
+
+This is the part nobody else does from the wire. Heron matches a per-agent
+profile (Claude Code, Codex CLI, a generic tool-call-anchored fallback) to
+group the call sequence into a single addressable **agent turn**, rolling up
+tool surfaces, tool-call counts, and topology. A text-only one-shot call
+stays on the calls page; a real tool-using loop becomes one turn you can open
+and read end to end.
+
+### 4. Fold multi-leg proxy hops
+
+In a real fleet, one logical call shows up several times on the wire:
+a client → a litellm proxy → a vLLM/SGLang backend, sometimes captured twice
+more by `any`-interface double-capture on `br0` and `docker0`. Heron's
+passive pair-sweeper folds these legs into one row by content + timing
+fingerprint — deliberately *not* by topology, because docker bridges SNAT
+the source IP and the proxy's listen-IP differs from its outbound-IP, so the
+obvious "A.server_ip == B.client_ip" signal is unreliable. Content and timing
+are what survive.
+
+The result is a service graph that shows the call path you actually have —
+clients → litellm → vLLM/SGLang — with each hop measured independently, and a
+classifier that names what each endpoint serves (vLLM, SGLang, Ollama,
+llama.cpp, LiteLLM) from the bytes, not from config someone told it.
+
+## What you get
+
+- **Agent turns**, not just calls — open a 247-call run and read the whole
+  plan on a timeline.
+- **TTFT · E2E latency · TPOT · token throughput · cache-hit ratio**, framed
+  first at the agent layer, then per call.
+- **Service topology** with proxy / inferred / client edges and
+  auto-classified backends.
+- **Full request/response bodies** captured for every call — the evidence is
+  on the page, not behind a re-run.
+- One **statically-linked binary** with the web console embedded; runs on any
+  Linux (musl) or macOS, no libpcap/glibc install dance.
+
+## Try it without a live interface
+
+You don't need to point it at production to see what it does. Replay a pcap:
+
+```bash
+heron --pcap-file capture.pcap --no-retention
+# open http://localhost:3000
+```
+
+Heron keeps the console up after the file drains so you can browse the
+reconstructed turns. Apache-2.0, single binary, no telemetry:
+**https://github.com/Netis/heron**

--- a/docs/promo/launch-posts.md
+++ b/docs/promo/launch-posts.md
@@ -1,0 +1,121 @@
+# Launch posts — Heron
+
+Ready-to-paste copy for the v0.4.0 launch. Tune the personal/“why I built
+this” lines to your own voice before posting. **Do not** paste any internal
+host/IP/credential anywhere — keep it to the public repo + public demo only.
+
+Timing: post Show HN Tue–Thu ~8–10am US Pacific; cross-post to Reddit/X the
+same morning and stay around to answer comments for the first 3–4 hours.
+
+---
+
+## Show HN
+
+**Title:**
+> Show HN: Heron – Reconstruct AI agent behavior from network packets (no SDK)
+
+**Body:**
+```
+Heron is a passive observability tool for LLM/agent traffic. Instead of an
+SDK or a proxy in the request path, it reads the plaintext HTTP already on
+the wire (on the inference host, behind your TLS terminator, or from a
+SPAN/TAP) and reconstructs what your agents are actually doing — tool calls,
+multi-step plans, where time goes, where loops happen, who calls whom.
+
+The part I couldn't find elsewhere: it stitches the call sequence into a
+single addressable "agent turn" (Claude Code, Codex CLI, and a generic
+tool-call profile), and folds multi-leg proxy hops (client → litellm →
+vLLM/SGLang) into one row by content+timing fingerprint, then draws the
+service graph and auto-classifies each backend from the bytes.
+
+Why passive: the observer can crash without breaking the calls it watches,
+and the workloads need zero changes. Trade-off is honest — you only see
+TLS-terminated traffic, so you install it where the bytes are already
+decrypted.
+
+Decoders: OpenAI Chat/Responses, Anthropic Messages, Gemini — which covers
+OpenAI/Azure/Anthropic/Bedrock/Vertex/Gemini and any OpenAI-compatible local
+server (vLLM, SGLang, Ollama, llama.cpp).
+
+Single statically-linked binary with the web console embedded; Linux (musl)
++ macOS. Apache-2.0, no telemetry.
+
+You can try it with zero privileges by replaying a pcap:
+  heron --pcap-file capture.pcap --no-retention
+then open http://localhost:3000.
+
+Repo: https://github.com/Netis/heron
+How it works (turn reconstruction from packets): [link to the blog post]
+
+Happy to answer questions about the TCP/SSE reassembly, the turn-stitching
+profiles, or the proxy-hop folding.
+```
+
+---
+
+## r/LocalLLaMA
+
+**Title:**
+> I built a passive monitor that reconstructs agent turns from your vLLM/SGLang traffic — no SDK, no proxy in the path
+
+**Body:**
+```
+If you self-host inference (vLLM, SGLang, Ollama, llama.cpp) behind something
+like litellm, you've probably had a hard time seeing what your agents are
+actually doing across the call graph — and SDK/proxy approaches either need
+code changes or sit in the request path.
+
+Heron reads the plaintext HTTP on the wire (post-TLS, on the host or via a
+tap) and rebuilds it: per-call detail with full bodies, agent *turns*
+(the whole tool-call loop as one unit), TTFT/TPOT/throughput, and a service
+graph that folds client → litellm → vLLM/SGLang hops into one row and
+auto-classifies each backend from the bytes (it'll tell vLLM from SGLang from
+Ollama without you configuring it).
+
+Zero-privilege try: replay a pcap, open localhost:3000.
+
+Single static binary + embedded console, Apache-2.0, no telemetry:
+https://github.com/Netis/heron
+
+Curious what backends/wire-APIs people here would want covered next.
+```
+
+---
+
+## X / Twitter thread
+
+```
+1/ Heron: see what your AI agents actually do — reconstructed from network
+packets. No SDK. No proxy in the request path. The observer can crash and
+your calls keep working. 🪶 https://github.com/Netis/heron
+
+2/ Most agent observability needs an SDK (code changes) or a reverse proxy
+(in your request path, per-call only). Heron reads the plaintext HTTP already
+on the wire — on the inference host or from a tap — and needs zero
+cooperation from the workload.
+
+3/ The hard part it solves: stitching the call sequence into one *agent turn*
+(planner → tool → planner → tool…), so you open one row and read a 247-call
+run end to end instead of joining HTTP logs in your warehouse.
+
+4/ It also folds multi-leg proxy hops — client → litellm → vLLM/SGLang — into
+a single row by content+timing (not topology; docker SNAT lies), and
+auto-classifies each backend from the bytes.
+
+5/ One static binary, embedded console, Linux+macOS, Apache-2.0, no
+telemetry. Try it with zero privileges by replaying a pcap:
+heron --pcap-file capture.pcap --no-retention → localhost:3000
+```
+
+---
+
+## Where else to seed (low effort, high signal)
+
+- Comment in the **LiteLLM / vLLM / SGLang** Discords/issues where people ask
+  "how do I see what's flowing through my proxy" — link the service-graph
+  feature specifically.
+- PR into **awesome-llmops** and **awesome-observability** lists.
+- r/devops, r/selfhosted, r/mlops with the angle that fits each (ops/topology
+  for devops, single-binary self-host for selfhosted, spend/metrics for mlops).
+- Lobsters (`ai`, `devops` tags) with the technical blog post, not the repo
+  link, as the submission.


### PR DESCRIPTION
## Summary

Promo/launch assets for the v0.4.0 push.

- **README**: CI / release / license / platform badges; plus a "try it in 30 seconds via pcap replay, no privileges" callout above the fold (the lowest-friction onboarding path).
- **docs/blog/2026-06-01-agent-turns-from-the-wire.md**: technical deep-dive — TCP/SSE reassembly → wire-API decode → turn stitching → proxy-hop folding. The hard-content lead for HN/Reddit/Lobsters.
- **docs/promo/launch-posts.md**: ready-to-paste Show HN / r/LocalLLaMA / X copy + a seeding checklist (LiteLLM/vLLM/SGLang communities, awesome-* lists).

Also expanded GitHub topics (rust, litellm, ollama, llmops) for discoverability.

## Notes
- All public-facing copy is scrub-clean — no internal hosts/IPs/credentials (verified by `check-leakage.sh`, 507 files).
- The promo posts are operational drafts; tune the personal voice before posting.

## Test plan
- [x] `check-leakage.sh` clean
- [x] no internal identifiers in README/blog/promo
- [ ] CI green (docs-only)