### PR TITLE
ci(staging): add workflow_dispatch manual deploy to deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,10 @@ on:
     workflows: [ci]
     types: [completed]
     branches: [main]
+  # Manual lever: deploy the latest successful main build on demand — e.g.
+  # when a CI run was cancelled by a rapid follow-up merge so the auto chain
+  # never fired. Pulls the most recent successful main CI's artifact.
+  workflow_dispatch: {}
 
 # Never run two staging deploys at once; let an in-flight one finish.
 concurrency:
@@ -26,20 +30,35 @@ concurrency:
 
 jobs:
   deploy:
-    # Only deploy when the triggering CI run actually passed.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Auto path: only when the triggering CI run passed. Manual path: always.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, staging-deploy]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
+      - name: resolve the CI run to pull the artifact from
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Most recent successful main CI run (the one that built an artifact).
+            rid=$(gh run list --repo "${{ github.repository }}" --workflow ci.yml \
+                  --branch main --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          else
+            rid=${{ github.event.workflow_run.id }}
+          fi
+          [ -n "$rid" ] || { echo "::error::no CI run with a heron-staging artifact found"; exit 1; }
+          echo "run_id=$rid" >> "$GITHUB_OUTPUT"
+          echo "pulling artifact from CI run $rid"
 
       - name: download heron binary from the CI run
         uses: actions/download-artifact@v4
         with:
           name: heron-staging
           path: artifact
-          # Pull from the specific CI run that triggered us (cross-workflow).
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.pick.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: deploy to the staging VM + health gate (rollback on failure)


### PR DESCRIPTION
Adds a **manual deploy lever** to `deploy-staging.yml`. The auto chain (`workflow_run` on CI success) silently never fires when a main CI run is cancelled by a rapid follow-up merge (`cancel-in-progress` concurrency), and re-running a cancelled CI run self-cancels under that same concurrency — so there was no way to recover without a fresh push.

`workflow_dispatch` now deploys the **latest successful main CI artifact**: a `resolve the CI run` step uses `github.event.workflow_run.id` for the auto path and the newest successful main `ci.yml` run for the manual path. Same deploy-staging.sh + health-gate + rollback after that.

Merging this also produces the first post-#84 main CI artifact and exercises the auto chain end-to-end.