### PR TITLE
ci: bump test-job timeout 25→60m for the on-main artifact build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,11 @@ concurrency:
 jobs:
   test:
     runs-on: [self-hosted, heron]
-    timeout-minutes: 25
+    # 25 was fine for test+lint, but the on-main artifact build adds a full
+    # release compile (cargo build --release --features console) + the console
+    # bundle, which pushed main-push runs past 25m and got them auto-cancelled
+    # (so the staging deploy never fired). 60 covers a cold release build.
+    timeout-minutes: 60
     env:
       # actions/checkout@v4 ships Node 20; GitHub is deprecating
       # Node 20 on runners. Opt JS actions into Node 24 so each run


### PR DESCRIPTION
**Root cause of the staging deploy never firing.** The on-main artifact steps added in #84 (`bun run build` + `cargo build --release --features console`) push main-push CI past the **25m timeout**, so every post-#84 main-push run was auto-cancelled (conclusion=cancelled, annotation "exceeded the maximum execution time of 25m0s"). A cancelled CI never triggers `deploy-staging` (gated on conclusion==success), so the deploy chain silently never ran.

PR runs were unaffected — they skip the artifact build (`if: push && main`), staying under 25m.

Bump to 60m to cover a cold release build. (A cleaner follow-up would split the artifact build into its own job with its own budget; this unblocks first.)