### PR TITLE
chore(deps): bump DuckDB 1.5.1 → 1.5.3 (fixes checkpoint/ART bug behind the prod outage)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -625,10 +625,11 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -722,6 +723,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,12 +825,13 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1748,9 +1772,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10503.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
 dependencies = [
  "cc",
  "flate2",
@@ -1790,6 +1814,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.4",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2527,6 +2557,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno 0.3.14",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2534,7 +2577,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno 0.3.14",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2740,7 +2783,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -2900,7 +2943,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3973,7 +4016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -69,6 +69,10 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 rust-embed = "8"
 mime_guess = "2"
+# Keep >= DuckDB 1.5.3 (crate 1.10503): 1.5.2/1.5.3 fix the checkpoint+ART
+# bugs behind the prod outage — #22591 (ARTOperator::Delete on nested leaf),
+# #22094 (RemoveFromIndexes / "remove all rows merging checkpoint deltas"),
+# #22503 (BlockAllocator invalid memory access → the SIGSEGV). Cargo.lock pins it.
 duckdb = { version = "1", features = ["bundled", "json"] }
 chrono = "0.4"
 tdigest = "0.2"


### PR DESCRIPTION
**The real root fix for the prod DuckDB outage.** prod heron SIGSEGV-crashed (5.7h down) when its DuckDB grew to 102GB and a pair-sweeper `CHECKPOINT` hit `Failed to remove all rows while merging checkpoint deltas — broken index`, invalidating the DB until a native segfault. We were on DuckDB **1.5.1** (crate 1.10501); **1.5.2/1.5.3** land direct fixes:

- [#22591](https://github.com/duckdb/duckdb/pull/22591) ARTOperator::Delete returns false if rowid not found in a nested ART leaf — the "remove all rows from index" failure
- [#22094](https://github.com/duckdb/duckdb/pull/22094) fix commit iteration offset bug + relax RemoveFromIndexes assertion — the merging-checkpoint-deltas path
- [#22503](https://github.com/duckdb/duckdb/pull/22503) Fix BlockAllocator invalid memory access — a checkpoint-time SIGSEGV
- [#22253](https://github.com/duckdb/duckdb/pull/22253) correct row-group reuse when checkpointing

Patch-level bump (same 1.5 minor) → low API/format risk. **Verified on the build host**: `cargo test -p h-storage-duckdb` (95 pass), `--features fault-injection` (97 pass, incl. the reopen-recovery tests), `--test migrations` (5 golden-DB schema tests pass) — all green against 1.5.3.

Cargo.lock-only dep change (+ duckdb's transitive tree). The prod retention tightening (calls/turns 7d, http_exchanges 2d) stays as defence-in-depth; this removes the underlying bug.

Source: [DuckDB v1.5.3 release notes](https://github.com/duckdb/duckdb/releases/tag/v1.5.3).