### PR TITLE
fix(classifier): expand known-tool registry to current CLI inventory (#85)

### DIFF
--- a/server/config/default.toml
+++ b/server/config/default.toml
@@ -171,4 +171,11 @@ port = 3000
 cli_tool_allowlist      = ["bash", "shell", "exec", "run_command", "ShellExec"]
 orchestrator_tool_names = ["Task", "dispatch_agent"]
 mcp_tool_prefixes       = ["mcp__"]
-known_tool_registry     = ["Read", "Edit", "Write", "Grep", "Bash", "Task", "WebFetch", "WebSearch"]
+# Left EMPTY on purpose → inherits the authoritative built-in list in
+# ClassifierConfig::default(), which tracks the current Claude Code + Codex
+# CLI tool inventory. A hardcoded copy here silently OVERRODE that default
+# (from_toml prefers any non-empty TOML value), so this file used to ship a
+# stale 8-tool list that flagged Glob/TodoWrite/Task*/… as UnknownToolName
+# for every default deployment (#85/#93). Keep it empty so the list has a
+# single source of truth and can't drift again.
+known_tool_registry     = []

--- a/server/h-llm/src/agent_classifier.rs
+++ b/server/h-llm/src/agent_classifier.rs
@@ -26,15 +26,29 @@ impl Default for ClassifierConfig {
                 .map(|s| (*s).to_string())
                 .collect(),
             mcp_tool_prefixes: vec!["mcp__".to_string()],
+            // Current Claude Code + Codex CLI built-in tool inventory. The old
+            // 8-entry seed flagged everything else (Glob, TodoWrite, the Task*
+            // family, …) as `UnknownToolName`, which surfaced legit agent
+            // traffic as "suspicious" and inflated AgentClassifierUnknownCount
+            // (#85). Grouped by source CLI; extend here as the CLIs add tools.
+            // A `[classifier] known_tool_registry = [...]` TOML override
+            // replaces this list wholesale (see `from_toml`).
             known_tool_registry: [
-                "Read",
-                "Edit",
-                "Write",
-                "Grep",
-                "Bash",
-                "Task",
-                "WebFetch",
-                "WebSearch",
+                // Claude Code — file & notebook ops
+                "Read", "Write", "Edit", "MultiEdit", "NotebookEdit", "NotebookRead",
+                // Claude Code — search
+                "Grep", "Glob",
+                // Claude Code — shell / background-process management
+                "Bash", "BashOutput", "KillShell", "KillBash",
+                // Claude Code — web
+                "WebFetch", "WebSearch",
+                // Claude Code — planning & meta
+                "TodoWrite", "ExitPlanMode", "SlashCommand", "Skill", "AskUserQuestion",
+                // Claude Code — subagent / task orchestration
+                "Task", "Agent", "TaskCreate", "TaskGet", "TaskList", "TaskOutput",
+                "TaskStop", "TaskUpdate",
+                // Codex CLI
+                "apply_patch", "update_plan", "view_image",
             ]
             .iter()
             .map(|s| (*s).to_string())
@@ -195,6 +209,23 @@ mod config_tests {
     }
 
     #[test]
+    fn registry_covers_current_cli_tools() {
+        // Regression for #85: every tool the issue named as falsely flagged
+        // must now be in the default registry.
+        let cfg = ClassifierConfig::default();
+        for t in [
+            "Glob", "TodoWrite", "MultiEdit", "NotebookEdit", "BashOutput",
+            "KillShell", "ExitPlanMode", "SlashCommand", "TaskOutput",
+            "TaskCreate", "TaskGet", "TaskList", "TaskStop", "TaskUpdate",
+        ] {
+            assert!(
+                cfg.known_tool_registry.contains(t),
+                "{t} should be a known tool, not flagged UnknownToolName (#85)"
+            );
+        }
+    }
+
+    #[test]
     fn config_round_trips_via_serde() {
         let cfg = ClassifierConfig::default();
         let s = toml::to_string(&cfg).unwrap();
@@ -352,5 +383,21 @@ mod classify_tests {
     fn suspicious_empty_for_known_tools() {
         let c = classify(&prims_with_tools(&["Read", "Edit"]), &cfg());
         assert!(c.suspicious_signals.is_empty());
+    }
+
+    #[test]
+    fn modern_claude_code_toolset_is_clean() {
+        // #85: a realistic modern Claude Code tool array must classify as a
+        // clean FunctionCall surface — no suspicious signals, not Unknown.
+        let c = classify(
+            &prims_with_tools(&["Read", "Glob", "TodoWrite", "TaskOutput", "ExitPlanMode"]),
+            &cfg(),
+        );
+        assert!(
+            c.suspicious_signals.is_empty(),
+            "unexpected suspicious signals: {:?}",
+            c.suspicious_signals
+        );
+        assert_eq!(c.tool_surface, Some(ToolSurface::FunctionCall));
     }
 }

--- a/server/h-llm/src/agent_classifier.rs
+++ b/server/h-llm/src/agent_classifier.rs
@@ -193,6 +193,30 @@ mod toml_tests {
         assert!(cfg.cli_tool_allowlist.contains("zsh"));
         assert!(!cfg.cli_tool_allowlist.contains("bash"));
     }
+
+    #[test]
+    fn shipped_default_toml_inherits_full_registry() {
+        // Regression for #93: the shipped default.toml must leave
+        // known_tool_registry EMPTY so `from_toml` inherits the built-in list.
+        // A hardcoded copy there silently overrode the default ("non-empty TOML
+        // wins") and shipped a stale 8-tool set to every default deployment.
+        // Path is resolved from the crate manifest so it's CWD-independent.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../config/default.toml");
+        let raw = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            #[serde(default)]
+            agent_classifier: ClassifierConfigToml,
+        }
+        let wrap: Wrap = toml::from_str(&raw).expect("default.toml should parse");
+        let cfg = ClassifierConfig::from_toml(&wrap.agent_classifier);
+        assert!(
+            cfg.known_tool_registry.contains("Glob")
+                && cfg.known_tool_registry.contains("TaskOutput"),
+            "default.toml must not hardcode known_tool_registry (#93) — leave it empty to \
+             inherit the built-in list"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #85.

## Problem
`ClassifierConfig::default().known_tool_registry` had only **8 entries**
(`Read, Edit, Write, Grep, Bash, Task, WebFetch, WebSearch`). Every other
current Claude Code / Codex tool — `Glob`, `TodoWrite`, `MultiEdit`,
`NotebookEdit`, `BashOutput`, `KillShell`, `ExitPlanMode`, `SlashCommand`,
and the whole `Task*` family — fell through to
`SuspiciousSignal::UnknownToolName`, and a call using only such tools became
`ToolSurface::Unknown`. Result: ordinary agent traffic shows up as
"suspicious / unknown_tool_name" in the console and inflates
`AgentClassifierUnknownCount` (the same Unknown-surface path implicated in
the #81 worker panic). prod runs the default seed (its config.toml has no
`[classifier]` override), so it's affected.

## Fix
Expand the default seed to the current Claude Code + Codex CLI built-in
tool inventory, **grouped by source CLI** with comments so it stays
maintainable. TOML override semantics are unchanged — a
`[classifier] known_tool_registry = [...]` still replaces the list wholesale
(`from_toml`).

Out of scope (issue's optional point #2): whether a genuinely-unknown tool
should be labelled *suspicious* at all. That's a semantic change kept
separate; this PR is purely the registry-coverage fix.

## Tests (`cargo test -p h-llm` → 382 pass on wuneng)
- `registry_covers_current_cli_tools` — every tool #85 named is now known.
- `modern_claude_code_toolset_is_clean` — a realistic modern tool array
  (`Read, Glob, TodoWrite, TaskOutput, ExitPlanMode`) classifies as a clean
  `FunctionCall` surface, zero suspicious signals.

> Note: prod picks up the expanded registry on its next redeploy from main
> (the default seed is compiled in). No config change needed.