### PR TITLE
feat(staging): tara soak runner — replay-invariant gate after deploy (L7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,11 @@ jobs:
         working-directory: console
         run: bun test
 
+      - name: tara soak invariant-checker tests
+        # Guards the staging-soak judgement logic (scripts/staging/tara_invariants.py).
+        # Dependency-free (stdlib only) so it needs no pip install on the runner.
+        run: python3 scripts/staging/tests/test_tara_invariants.py
+
       # --- staging artifact ---------------------------------------------
       # On a push to main (post-merge), build the deployable binary and
       # publish it so deploy-staging.yml can roll it onto the heron-stage VM.

--- a/.github/workflows/staging-soak.yml
+++ b/.github/workflows/staging-soak.yml
@@ -1,0 +1,39 @@
+name: staging-soak
+
+# Quality-infra L7: after a staging deploy succeeds, replay a known pcap
+# corpus through the freshly-deployed heron binary (tara) and assert
+# parse/pairing/turn/persistence invariants. Catches the regression class
+# that compiles + passes unit tests but mangles real wire traffic
+# (the PR#47 validator-bypass / PR#48 storage-poisoning families).
+#
+# Chains after deploy-staging: ci(main) -> deploy-staging -> staging-soak.
+# Runs ONLY on the dedicated `staging-deploy` self-hosted runner and ONLY for
+# a successful deploy-staging run, so no untrusted/PR code reaches the host.
+#
+# Host-specific values come from repo Variables, never committed source:
+#   gh variable set HERON_STAGE_VM   --body <domain>
+#   gh variable set HERON_STAGE_USER --body <login>
+on:
+  workflow_run:
+    workflows: [deploy-staging]
+    types: [completed]
+  # Manual lever: soak whatever is currently deployed on the VM, on demand.
+  workflow_dispatch: {}
+
+concurrency:
+  group: staging-soak
+  cancel-in-progress: false
+
+jobs:
+  soak:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: [self-hosted, staging-deploy]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: tara soak the deployed staging binary
+        env:
+          HERON_STAGE_VM: ${{ vars.HERON_STAGE_VM }}
+          HERON_STAGE_USER: ${{ vars.HERON_STAGE_USER }}
+        run: bash scripts/staging/soak-staging.sh

--- a/scripts/staging/README.md
+++ b/scripts/staging/README.md
@@ -26,6 +26,14 @@ deploy-staging.yml  (runner: self-hosted, staging-deploy)
           ├─ back up current binary, install, restart heron.service
           ├─ health gate: status=ready AND pipeline running (≤90s)
           └─ rollback to the backup if the gate fails
+   │
+   ▼  workflow_run: deploy-staging completed, conclusion == success
+staging-soak.yml  (runner: self-hosted, staging-deploy)
+   └─ soak-staging.sh
+          ├─ resolve heron-stage VM IP, scp tara + corpus into the VM
+          └─ tara.sh: replay a known pcap through the deployed binary
+                      (pcap-file source) and assert parse/pairing/turn/
+                      persistence invariants — fail the job on regression
 ```
 
 ### Why a separate `staging-deploy` runner
@@ -71,8 +79,51 @@ scripts/staging/deploy-staging.sh /path/to/heron
 #            HERON_STAGE_PORT, HEALTH_TIMEOUT_SECS
 ```
 
-## Not included yet
+## Soak runner (`tara`) — L7
 
-A replay-server feed (recorded wire bytes → the VM's NIC) so staging
-exercises the full parse/extract path under load, plus a soak runner that
-diffs a known-good binary against the candidate. Tracked for a follow-on.
+After a deploy is healthy, **tara** replays a known pcap corpus through the
+deployed binary and asserts that it still parses real wire traffic correctly.
+This catches the regression class that compiles and passes unit tests but
+mangles live traffic — the PR#47 (validator bypassed by a direct caller) and
+PR#48 (storage poisoning under load) families.
+
+How it works — no NIC, no `tcpreplay`:
+
+- [`tara.sh`](tara.sh) starts a throwaway heron instance on a private port
+  with an isolated DuckDB, pointed at the corpus via heron's built-in
+  **`pcap-file`** capture source (`type = "pcap-file"`). It never touches the
+  deployed `heron.service` or its DB. Because `pcap-file` reads a file (not a
+  device), the soak needs **no capture capabilities**.
+- After ingest (pcap EOF) it snapshots `/api/internal-metrics` and runs
+  [`tara_invariants.py`](tara_invariants.py), which asserts: corpus fully
+  ingested, no FATAL/panic, zero malformed/read errors, every routed packet
+  parsed, HTTP exchanges all paired, LLM calls detected + ingested, turns
+  built, no late drops.
+- **Known-good self-test**: pass `--baseline <last-good heron>` and tara runs
+  *both* binaries through the identical corpus. If the baseline fails an
+  invariant, tara reports `harness_broken` (exit 3) and does **not** blame the
+  candidate — so a bad corpus or flaky environment never red-flags a good
+  build. A candidate that fails where the baseline passed is a real regression
+  (exit 1).
+
+The invariant logic is unit-tested (stdlib-only, runs in CI):
+`python3 scripts/staging/tests/test_tara_invariants.py`.
+
+### Manual soak (debugging)
+
+```bash
+# Against the deployed VM binary, from the deploy host:
+scripts/staging/soak-staging.sh                 # uses the committed fixture
+scripts/staging/soak-staging.sh /path/corpus.pcap
+#   env: HERON_STAGE_VM/USER/SSH_KEY, HERON_STAGE_BIN, HERON_STAGE_BASELINE
+
+# Or directly, given a binary + corpus on the same host:
+scripts/staging/tara.sh --binary ./heron \
+  --corpus server/h-protocol/tests/fixtures/keepalive_2sse_pipelined.pcap \
+  --baseline ./heron-last-good --json-out soak.json
+```
+
+The corpus is the committed `keepalive_2sse_pipelined.pcap` fixture — small,
+deterministic, ships with the repo. A richer/larger corpus (real scrubbed
+dumps, or LLM-synthesized fixtures) is a later enrichment; the dual-binary
+self-test makes swapping the corpus safe.

--- a/scripts/staging/README.md
+++ b/scripts/staging/README.md
@@ -106,6 +106,29 @@ How it works — no NIC, no `tcpreplay`:
   build. A candidate that fails where the baseline passed is a real regression
   (exit 1).
 
+### Known-good promotion (the self-test is standing, not one-off)
+
+`soak-staging.sh` makes the dual-binary self-test continuous via a **rolling
+known-good**: the baseline is `/opt/heron/heron.last-good` on the VM — the
+last binary that *passed* a soak. Each deploy is soaked against it, and on a
+pass the freshly-deployed binary is **promoted** to become the next
+known-good. So every new build is compared against the previous good build and
+the pointer advances on its own — no stale, hand-pinned baseline.
+
+```
+deploy N   → soak vs last-good(N-1) → pass → promote: last-good := N
+deploy N+1 → soak vs last-good(N)   → …
+```
+
+- First ever run (no known-good): candidate-only **bootstrap**, then promote.
+- Candidate regresses (exit 1): job fails, **known-good unchanged**.
+- Baseline itself fails (`harness_broken`, exit 3): corpus/env problem, or the
+  known-good needs re-baselining → warn, don't fail, **don't advance**.
+
+Override knobs: `HERON_STAGE_BASELINE` pins an explicit baseline (debug),
+`HERON_STAGE_NO_PROMOTE=1` soaks without advancing,
+`HERON_STAGE_LASTGOOD` relocates the pointer.
+
 The invariant logic is unit-tested (stdlib-only, runs in CI):
 `python3 scripts/staging/tests/test_tara_invariants.py`.
 

--- a/scripts/staging/deploy-staging.sh
+++ b/scripts/staging/deploy-staging.sh
@@ -11,9 +11,10 @@
 #   scripts/staging/deploy-staging.sh <path-to-heron-binary>
 #
 # Env (all optional, with safe defaults):
-#   HERON_STAGE_VM       libvirt domain name             (default: heron-stage)
+#   HERON_STAGE_VM       REQUIRED  libvirt domain name (CI: repo Variable
+#                                  vars.HERON_STAGE_VM — never hardcoded)
+#   HERON_STAGE_USER     REQUIRED  ssh login on the VM (CI: vars.HERON_STAGE_USER)
 #   HERON_STAGE_NET      libvirt network for the lease   (default: default)
-#   HERON_STAGE_USER     ssh user on the VM              (default: heron-admin)
 #   HERON_STAGE_SSH_KEY  ssh identity                    (default: ~/.ssh/id_ed25519)
 #   HERON_STAGE_PORT     heron API port inside the VM    (default: 4500)
 #   HEALTH_TIMEOUT_SECS  health-gate budget              (default: 90)
@@ -25,9 +26,11 @@ set -euo pipefail
 BIN="${1:?usage: deploy-staging.sh <heron-binary>}"
 [ -f "$BIN" ] || { echo "::error::binary not found: $BIN" >&2; exit 1; }
 
-VM="${HERON_STAGE_VM:-heron-stage}"
+# VM name + ssh login describe internal topology → never hardcode them in
+# source; CI supplies them from repo Variables (see deploy-staging.yml).
+VM="${HERON_STAGE_VM:?set HERON_STAGE_VM (libvirt domain; CI passes vars.HERON_STAGE_VM)}"
+SSH_USER="${HERON_STAGE_USER:?set HERON_STAGE_USER (VM ssh login; CI passes vars.HERON_STAGE_USER)}"
 NET="${HERON_STAGE_NET:-default}"
-SSH_USER="${HERON_STAGE_USER:-heron-admin}"
 SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
 PORT="${HERON_STAGE_PORT:-4500}"
 HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-90}"

--- a/scripts/staging/provision-vm.sh
+++ b/scripts/staging/provision-vm.sh
@@ -18,7 +18,10 @@
 #                              for the VM's login user (deploy runner + ops)
 # Optional env:
 #   APT_PROXY                  http proxy for apt/egress (omitted if unset)
-#   VM_NAME (heron-stage)  VM_USER (heron-admin)  VM_RAM_MB (6144)  VM_VCPUS (4)
+#   VM_NAME / VM_USER          REQUIRED — the VM domain + login (keep in sync
+#                              with repo Variables HERON_STAGE_VM/USER; never
+#                              hardcoded in source, per the PR-hygiene rule)
+#   VM_RAM_MB (6144)  VM_VCPUS (4)
 #   VM_DISK_GB (40)  LIBVIRT_NET (default)  IMAGES_DIR (/var/lib/libvirt/images)
 #
 # Run on the libvirt host (needs sudo for virsh + the images dir).
@@ -30,8 +33,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -f "$BASE_IMAGE" ] || { echo "BASE_IMAGE not found: $BASE_IMAGE" >&2; exit 1; }
 [ -f "$SSH_AUTHORIZED_KEYS_FILE" ] || { echo "keys file not found: $SSH_AUTHORIZED_KEYS_FILE" >&2; exit 1; }
 
-VM_NAME="${VM_NAME:-heron-stage}"
-VM_USER="${VM_USER:-heron-admin}"
+# VM domain + login describe internal topology → never hardcode in source;
+# keep these in sync with repo Variables HERON_STAGE_VM / HERON_STAGE_USER.
+VM_NAME="${VM_NAME:?set VM_NAME (the libvirt domain; matches HERON_STAGE_VM)}"
+VM_USER="${VM_USER:?set VM_USER (the VM login; matches HERON_STAGE_USER)}"
 VM_RAM_MB="${VM_RAM_MB:-6144}"
 VM_VCPUS="${VM_VCPUS:-4}"
 VM_DISK_GB="${VM_DISK_GB:-40}"

--- a/scripts/staging/soak-staging.sh
+++ b/scripts/staging/soak-staging.sh
@@ -18,9 +18,13 @@
 #   - baseline itself fails (harness_broken, exit 3): env/corpus problem or the
 #     known-good needs re-baselining → warn, don't fail, don't advance.
 #
-# Env (all optional; same family as deploy-staging.sh):
-#   HERON_STAGE_VM/NET/USER/SSH_KEY  VM resolution + ssh (defaults heron-stage
-#                                    / default / heron-admin / ~/.ssh/id_ed25519)
+# Env (same family as deploy-staging.sh):
+#   HERON_STAGE_VM    REQUIRED  libvirt domain name (CI: repo Variable
+#                               vars.HERON_STAGE_VM — never hardcoded, per the
+#                               PR-hygiene/no-infra-in-source rule)
+#   HERON_STAGE_USER  REQUIRED  ssh login on the VM (CI: vars.HERON_STAGE_USER)
+#   HERON_STAGE_NET/SSH_KEY     libvirt net + ssh key (generic defaults:
+#                               default / ~/.ssh/id_ed25519)
 #   HERON_STAGE_BIN        binary on the VM to soak    (default /opt/heron/heron)
 #   HERON_STAGE_LASTGOOD   rolling known-good path on the VM
 #                                          (default /opt/heron/heron.last-good)
@@ -37,9 +41,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CORPUS="${1:-$HERE/../../server/h-protocol/tests/fixtures/keepalive_2sse_pipelined.pcap}"
 [ -f "$CORPUS" ] || { echo "::error::corpus not found: $CORPUS" >&2; exit 2; }
 
-VM="${HERON_STAGE_VM:-heron-stage}"
+# VM name + ssh login describe internal topology → never hardcode them in
+# source; CI supplies them from repo Variables (see deploy-staging.yml).
+VM="${HERON_STAGE_VM:?set HERON_STAGE_VM (libvirt domain; CI passes vars.HERON_STAGE_VM)}"
+SSH_USER="${HERON_STAGE_USER:?set HERON_STAGE_USER (VM ssh login; CI passes vars.HERON_STAGE_USER)}"
 NET="${HERON_STAGE_NET:-default}"
-SSH_USER="${HERON_STAGE_USER:-heron-admin}"
 SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
 STAGE_BIN="${HERON_STAGE_BIN:-/opt/heron/heron}"
 LAST_GOOD="${HERON_STAGE_LASTGOOD:-/opt/heron/heron.last-good}"

--- a/scripts/staging/soak-staging.sh
+++ b/scripts/staging/soak-staging.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Run the tara soak against the heron binary currently deployed on the staging
+# VM. Resolves the VM via libvirt DHCP leases, ships tara + the corpus, runs
+# the soak inside the VM, prints the verdict, and maps tara's exit to a job
+# result. Mirrors deploy-staging.sh's VM-resolution + ssh model exactly.
+#
+# Usage:
+#   scripts/staging/soak-staging.sh [corpus.pcap]
+#
+# Env (all optional; same family as deploy-staging.sh):
+#   HERON_STAGE_VM/NET/USER/SSH_KEY  VM resolution + ssh (defaults heron-stage
+#                                    / default / heron-admin / ~/.ssh/id_ed25519)
+#   HERON_STAGE_BIN        binary on the VM to soak   (default /opt/heron/heron)
+#   HERON_STAGE_BASELINE   known-good binary on the VM for the dual-binary
+#                          self-test (optional; unset → candidate-only soak)
+#
+# Exit: 0 pass · 1 candidate regressed · 2 setup error. A tara `harness_broken`
+# (baseline itself failed → corpus/env problem, never the candidate) is logged
+# as a warning and does NOT fail the job.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORPUS="${1:-$HERE/../../server/h-protocol/tests/fixtures/keepalive_2sse_pipelined.pcap}"
+[ -f "$CORPUS" ] || { echo "::error::corpus not found: $CORPUS" >&2; exit 2; }
+
+VM="${HERON_STAGE_VM:-heron-stage}"
+NET="${HERON_STAGE_NET:-default}"
+SSH_USER="${HERON_STAGE_USER:-heron-admin}"
+SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+STAGE_BIN="${HERON_STAGE_BIN:-/opt/heron/heron}"
+BASELINE="${HERON_STAGE_BASELINE:-}"
+
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8)
+remote() { ssh "${SSH_OPTS[@]}" "$SSH_USER@$IP" "$@"; }
+
+echo "==> resolving $VM IP from libvirt '$NET' DHCP leases"
+IP="$(sudo virsh net-dhcp-leases "$NET" 2>/dev/null | awk -v n="$VM" '$0 ~ n {print $5}' | cut -d/ -f1 | head -1)"
+[ -n "$IP" ] || { echo "::error::no DHCP lease for domain '$VM' on net '$NET' — is the VM running?" >&2; exit 2; }
+echo "    $VM -> $IP  (soak binary: $STAGE_BIN)"
+
+RD="/tmp/tara.$$"
+remote "mkdir -p $RD"
+# shellcheck disable=SC2064
+trap "ssh ${SSH_OPTS[*]} $SSH_USER@$IP 'rm -rf $RD' >/dev/null 2>&1 || true" EXIT
+scp "${SSH_OPTS[@]}" "$HERE/tara.sh" "$HERE/tara_invariants.py" "$CORPUS" "$SSH_USER@$IP:$RD/"
+CORPUS_VM="$RD/$(basename "$CORPUS")"
+
+base_arg=""
+[ -z "$BASELINE" ] || base_arg="--baseline $BASELINE"
+
+echo "==> running tara soak inside the VM"
+set +e
+remote "cd $RD && bash tara.sh --binary '$STAGE_BIN' --corpus '$CORPUS_VM' $base_arg --json-out $RD/out.json"
+rc=$?
+set -e
+
+echo "==> verdict:"
+remote "cat $RD/out.json 2>/dev/null" || echo "(no verdict file — tara aborted before writing)"
+
+case "$rc" in
+  0) echo "==> SOAK PASS — staging binary healthy under replay"; exit 0;;
+  3) echo "::warning::tara reported harness_broken (the baseline failed → corpus/env issue, NOT the candidate) — not failing the job"; exit 0;;
+  *) echo "::error::SOAK FAILED — the deployed staging binary regressed (tara rc=$rc)"; exit 1;;
+esac

--- a/scripts/staging/soak-staging.sh
+++ b/scripts/staging/soak-staging.sh
@@ -7,12 +7,26 @@
 # Usage:
 #   scripts/staging/soak-staging.sh [corpus.pcap]
 #
+# Known-good promotion (makes the dual-binary self-test a STANDING gate):
+# the baseline is a rolling "last binary that passed soak", stored on the VM
+# at $HERON_STAGE_LASTGOOD. Each run soaks the freshly-deployed binary against
+# it; on a pass the deployed binary is promoted to become the next known-good.
+# So every new build is compared against the previous good build, and the
+# known-good pointer advances on its own — no stale, hand-pinned baseline.
+#   - first ever run (no known-good): candidate-only bootstrap, then promote.
+#   - candidate regresses (exit 1): job fails, known-good UNCHANGED.
+#   - baseline itself fails (harness_broken, exit 3): env/corpus problem or the
+#     known-good needs re-baselining → warn, don't fail, don't advance.
+#
 # Env (all optional; same family as deploy-staging.sh):
 #   HERON_STAGE_VM/NET/USER/SSH_KEY  VM resolution + ssh (defaults heron-stage
 #                                    / default / heron-admin / ~/.ssh/id_ed25519)
-#   HERON_STAGE_BIN        binary on the VM to soak   (default /opt/heron/heron)
-#   HERON_STAGE_BASELINE   known-good binary on the VM for the dual-binary
-#                          self-test (optional; unset → candidate-only soak)
+#   HERON_STAGE_BIN        binary on the VM to soak    (default /opt/heron/heron)
+#   HERON_STAGE_LASTGOOD   rolling known-good path on the VM
+#                                          (default /opt/heron/heron.last-good)
+#   HERON_STAGE_BASELINE   pin an explicit baseline, overriding the rolling
+#                          known-good (manual/debug; unset → use known-good)
+#   HERON_STAGE_NO_PROMOTE set to 1 to soak without advancing the known-good
 #
 # Exit: 0 pass · 1 candidate regressed · 2 setup error. A tara `harness_broken`
 # (baseline itself failed → corpus/env problem, never the candidate) is logged
@@ -28,7 +42,9 @@ NET="${HERON_STAGE_NET:-default}"
 SSH_USER="${HERON_STAGE_USER:-heron-admin}"
 SSH_KEY="${HERON_STAGE_SSH_KEY:-$HOME/.ssh/id_ed25519}"
 STAGE_BIN="${HERON_STAGE_BIN:-/opt/heron/heron}"
+LAST_GOOD="${HERON_STAGE_LASTGOOD:-/opt/heron/heron.last-good}"
 BASELINE="${HERON_STAGE_BASELINE:-}"
+PROMOTE=1; [ "${HERON_STAGE_NO_PROMOTE:-0}" = 1 ] && PROMOTE=0
 
 SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8)
 remote() { ssh "${SSH_OPTS[@]}" "$SSH_USER@$IP" "$@"; }
@@ -45,8 +61,18 @@ trap "ssh ${SSH_OPTS[*]} $SSH_USER@$IP 'rm -rf $RD' >/dev/null 2>&1 || true" EXI
 scp "${SSH_OPTS[@]}" "$HERE/tara.sh" "$HERE/tara_invariants.py" "$CORPUS" "$SSH_USER@$IP:$RD/"
 CORPUS_VM="$RD/$(basename "$CORPUS")"
 
-base_arg=""
-[ -z "$BASELINE" ] || base_arg="--baseline $BASELINE"
+# Resolve the baseline: an explicit pin wins, else the rolling known-good if
+# one exists on the VM, else none (bootstrap — the very first soak).
+if [ -z "$BASELINE" ] && remote "test -x '$LAST_GOOD'" 2>/dev/null; then
+  BASELINE="$LAST_GOOD"
+fi
+if [ -n "$BASELINE" ]; then
+  echo "    self-test baseline: $BASELINE"
+  base_arg="--baseline '$BASELINE'"
+else
+  echo "    no known-good baseline yet → candidate-only bootstrap soak"
+  base_arg=""
+fi
 
 echo "==> running tara soak inside the VM"
 set +e
@@ -58,7 +84,20 @@ echo "==> verdict:"
 remote "cat $RD/out.json 2>/dev/null" || echo "(no verdict file — tara aborted before writing)"
 
 case "$rc" in
-  0) echo "==> SOAK PASS — staging binary healthy under replay"; exit 0;;
-  3) echo "::warning::tara reported harness_broken (the baseline failed → corpus/env issue, NOT the candidate) — not failing the job"; exit 0;;
-  *) echo "::error::SOAK FAILED — the deployed staging binary regressed (tara rc=$rc)"; exit 1;;
+  0)
+    echo "==> SOAK PASS — staging binary healthy under replay"
+    if [ "$PROMOTE" = 1 ]; then
+      if remote "sudo install -m 0755 '$STAGE_BIN' '$LAST_GOOD'"; then
+        echo "==> known-good advanced → $LAST_GOOD (next soak compares against this build)"
+      else
+        echo "::warning::soak passed but could not advance known-good ($LAST_GOOD)"
+      fi
+    fi
+    exit 0;;
+  3)
+    echo "::warning::tara harness_broken — the baseline (known-good) itself failed the soak, so this is a corpus/env problem or the known-good needs re-baselining, NOT a candidate regression. Not failing the job; known-good UNCHANGED."
+    exit 0;;
+  *)
+    echo "::error::SOAK FAILED — the deployed staging binary regressed (tara rc=$rc); known-good UNCHANGED"
+    exit 1;;
 esac

--- a/scripts/staging/tara.sh
+++ b/scripts/staging/tara.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tara — staging soak runner (quality-infra L7).
+#
+# Replays a known pcap corpus through a heron binary using heron's built-in
+# `pcap-file` capture source (no NIC, no tcpreplay — deterministic, fast),
+# then asserts parse / pairing / turn / persistence invariants from
+# /api/internal-metrics (see tara_invariants.py).
+#
+# Known-good self-test: pass --baseline <last-released heron> and tara runs
+# BOTH binaries through the identical corpus. If the baseline fails an
+# invariant the HARNESS (corpus/env) is broken — tara reports `harness_broken`
+# and does NOT blame the candidate. Only a candidate that fails where the
+# baseline passed is a real regression.
+#
+# Each heron instance runs in a throwaway workdir on a private port with an
+# isolated DuckDB, so tara never touches the deployed heron.service / its DB.
+# pcap-file reads a file (not a NIC), so NO capture capabilities are needed.
+#
+# Usage:
+#   tara.sh --binary <heron> --corpus <pcap> [--baseline <heron>]
+#           [--json-out <file>] [--port <base>] [--workdir <dir>]
+#           [--min-reqs N] [--min-turns N] [--keep]
+#
+# Exit: 0 pass · 1 candidate regressed · 2 usage/setup · 3 harness_broken
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$HERE/tara_invariants.py"
+
+BINARY="" CORPUS="" BASELINE="" JSON_OUT="" PORT_BASE=4599 WORKROOT="" KEEP=0
+MIN_REQS=1 MIN_TURNS=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --binary)    BINARY="$2"; shift 2;;
+    --corpus)    CORPUS="$2"; shift 2;;
+    --baseline)  BASELINE="$2"; shift 2;;
+    --json-out)  JSON_OUT="$2"; shift 2;;
+    --port)      PORT_BASE="$2"; shift 2;;
+    --workdir)   WORKROOT="$2"; shift 2;;
+    --min-reqs)  MIN_REQS="$2"; shift 2;;
+    --min-turns) MIN_TURNS="$2"; shift 2;;
+    --keep)      KEEP=1; shift;;
+    *) echo "tara: unknown arg '$1'" >&2; exit 2;;
+  esac
+done
+
+[ -x "$BINARY" ] || { echo "tara: --binary '$BINARY' missing/not executable" >&2; exit 2; }
+[ -f "$CORPUS" ] || { echo "tara: --corpus '$CORPUS' not found" >&2; exit 2; }
+[ -f "$CHECKER" ] || { echo "tara: checker '$CHECKER' not found" >&2; exit 2; }
+[ -z "$BASELINE" ] || [ -x "$BASELINE" ] || { echo "tara: --baseline '$BASELINE' not executable" >&2; exit 2; }
+
+WORKROOT="${WORKROOT:-$(mktemp -d /tmp/tara.XXXXXX)}"
+mkdir -p "$WORKROOT"
+cleanup() { [ "$KEEP" = 1 ] || rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+CORPUS_ABS="$(cd "$(dirname "$CORPUS")" && pwd)/$(basename "$CORPUS")"
+
+# Run one heron instance over the corpus; write the verdict JSON to stdout.
+# Args: <binary> <label> <port>
+soak_one() {
+  local bin="$1" label="$2" port="$3"
+  local wd="$WORKROOT/$label"
+  mkdir -p "$wd/data"
+  local cfg="$wd/config.toml" log="$wd/heron.log" metrics="$wd/metrics.json"
+
+  cat > "$cfg" <<TOML
+[[pipeline]]
+name = "soak"
+dispatcher_count = 1
+flow_shard_count = 4
+[pipeline.turn]
+idle_timeout_secs = 4
+sweep_interval_secs = 2
+grace_ms = 500
+shard_count = 1
+[pipeline.metrics]
+shard_count = 1
+[[pipeline.sources]]
+type = "pcap-file"
+path = "$CORPUS_ABS"
+realtime = false
+source_id = "tara-soak"
+[storage]
+backend = "duckdb"
+[storage.duckdb]
+path = "$wd/data/heron.duckdb"
+[storage.sink]
+batch_size = 200
+flush_interval_ms = 500
+[internal_metrics]
+enabled = true
+interval_secs = 2
+[api]
+listen = "127.0.0.1"
+port = $port
+TOML
+
+  echo "tara: [$label] starting $bin on :$port (corpus $(basename "$CORPUS_ABS"))" >&2
+  "$bin" -v -c "$cfg" > "$log" 2>&1 &
+  local pid=$!
+
+  # 1) wait for the API to come up
+  local up=0
+  for _ in $(seq 1 30); do
+    if curl -fsS -m 2 "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then up=1; break; fi
+    kill -0 "$pid" 2>/dev/null || { echo "tara: [$label] heron exited during startup" >&2; break; }
+    sleep 1
+  done
+  if [ "$up" != 1 ]; then
+    echo "{\"label\":\"$label\",\"pass\":false,\"error\":\"heron API never came up\"}"
+    kill -9 "$pid" 2>/dev/null || true
+    return
+  fi
+
+  # 2) wait for the corpus to be fully ingested (pcap-file EOF)
+  for _ in $(seq 1 60); do
+    grep -q "pcap-file: finished reading" "$log" 2>/dev/null && break
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 1
+  done
+
+  # 3) let turns close (idle+grep sweep) and the sink flush, then snapshot
+  sleep 8
+  curl -fsS -m 5 "http://127.0.0.1:$port/api/internal-metrics" > "$metrics" 2>/dev/null \
+    || echo '{}' > "$metrics"
+
+  # 4) graceful stop
+  kill -TERM "$pid" 2>/dev/null || true
+  for _ in $(seq 1 8); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+  kill -9 "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  python3 "$CHECKER" --label "$label" --logfile "$log" \
+    --metrics-file "$metrics" --min-reqs "$MIN_REQS" --min-turns "$MIN_TURNS"
+}
+
+BASE_VERDICT="null"
+if [ -n "$BASELINE" ]; then
+  bv="$(soak_one "$BASELINE" baseline "$PORT_BASE")"
+  BASE_VERDICT="$bv"
+  if ! printf '%s' "$bv" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("pass") else 1)' 2>/dev/null; then
+    # Baseline (last known-good) failed → the corpus or environment is broken,
+    # not the candidate. Emit harness_broken and exit neutral-ish (3).
+    final="$(python3 - "$BASE_VERDICT" <<'PY'
+import json,sys
+base=json.loads(sys.argv[1])
+print(json.dumps({"pass":False,"reason":"harness_broken","candidate":None,"baseline":base},indent=2))
+PY
+)"
+    printf '%s\n' "$final"
+    [ -z "$JSON_OUT" ] || printf '%s\n' "$final" > "$JSON_OUT"
+    echo "tara: HARNESS BROKEN — baseline failed [$(printf '%s' "$bv" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin).get("failed",[])))' 2>/dev/null)]; not blaming candidate" >&2
+    exit 3
+  fi
+fi
+
+CAND_VERDICT="$(soak_one "$BINARY" candidate "$PORT_BASE")"
+
+final="$(python3 - "$CAND_VERDICT" "$BASE_VERDICT" <<'PY'
+import json,sys
+cand=json.loads(sys.argv[1]); base=json.loads(sys.argv[2])
+ok=bool(cand.get("pass"))
+print(json.dumps({
+  "pass": ok,
+  "reason": "ok" if ok else "candidate_regressed",
+  "candidate": cand,
+  "baseline": base,
+}, indent=2))
+PY
+)"
+printf '%s\n' "$final"
+[ -z "$JSON_OUT" ] || printf '%s\n' "$final" > "$JSON_OUT"
+
+if printf '%s' "$CAND_VERDICT" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("pass") else 1)' 2>/dev/null; then
+  echo "tara: PASS — candidate healthy" >&2
+  exit 0
+else
+  echo "tara: FAIL — candidate regressed [$(printf '%s' "$CAND_VERDICT" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin).get("failed",[])))' 2>/dev/null)]" >&2
+  exit 1
+fi

--- a/scripts/staging/tara_invariants.py
+++ b/scripts/staging/tara_invariants.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""tara invariant checker — the judgement half of the soak runner.
+
+Reads a `/api/internal-metrics` snapshot (JSON on stdin) plus the heron log
+path, applies a fixed set of parse / pairing / turn / persistence invariants
+that must hold for any healthy replay of a well-formed LLM-traffic pcap, and
+emits a verdict JSON on stdout.
+
+Kept separate from tara.sh on purpose: pure input→verdict with no I/O beyond
+reading the log, so it is unit-testable by feeding a captured metrics JSON
+(see tests in scripts/staging/tests/).
+
+Exit code mirrors the verdict: 0 = pass, 1 = fail.
+"""
+import argparse
+import json
+import re
+import sys
+
+
+# Log lines that mean the run is structurally broken — any match fails the
+# soak outright (these are the crash / corruption classes past incidents hit).
+FATAL_PATTERNS = [
+    r"panicked at",
+    r"\bFATAL\b",
+    r"exited abnormally",
+    r"pcap-file: read error",
+    r"JoinHandle polled after completion",  # the #79 supervisor double-poll
+    r"broken index",                        # the #50/#52 DuckDB checkpoint class
+]
+
+# Confirms the corpus was fully ingested (not cut short by an early crash).
+INGEST_DONE = re.compile(r"pcap-file: finished reading (\d+) packets")
+
+
+def flatten(metrics_json):
+    """{(name): value} from the pipelines[].metrics[] shape. Metric names are
+    unique across groups for every name this checker asserts on."""
+    out = {}
+    data = metrics_json.get("data", metrics_json)
+    for pipe in data.get("pipelines", []):
+        for m in pipe.get("metrics", []):
+            out[m["name"]] = m.get("value", 0)
+    return out
+
+
+def scan_log(path):
+    fatals = []
+    ingest_pkts = None
+    if not path:
+        return fatals, ingest_pkts
+    try:
+        with open(path, "r", errors="replace") as fh:
+            for line in fh:
+                for pat in FATAL_PATTERNS:
+                    if re.search(pat, line):
+                        fatals.append(line.rstrip()[:300])
+                        break
+                m = INGEST_DONE.search(line)
+                if m:
+                    ingest_pkts = int(m.group(1))
+    except FileNotFoundError:
+        pass
+    return fatals, ingest_pkts
+
+
+def evaluate(m, fatals, ingest_pkts, *, min_reqs, min_turns):
+    """Return a list of {name, ok, detail} invariant results."""
+    g = lambda k: m.get(k, 0)
+    turns_built = g("turns_completed") + g("turns_closed_grace") + g("turns_closed_idle")
+    inv = [
+        ("ingest_finished", ingest_pkts is not None,
+         f"pcap-file read {ingest_pkts} pkts" if ingest_pkts is not None
+         else "no 'finished reading' line — ingest cut short / crashed"),
+        ("no_fatal_logs", len(fatals) == 0,
+         "clean" if not fatals else f"{len(fatals)} fatal line(s): {fatals[0]}"),
+        ("capture_clean",
+         g("read_errors") == 0 and g("pkts_truncated") == 0,
+         f"read_errors={g('read_errors')} truncated={g('pkts_truncated')}"),
+        ("all_routed_parsed",
+         g("pkts_parsed") > 0 and g("pkts_parsed") >= g("pkts_routed"),
+         f"parsed={g('pkts_parsed')} routed={g('pkts_routed')}"),
+        ("no_malformed",
+         g("pkts_dropped_malformed") == 0,
+         f"malformed={g('pkts_dropped_malformed')}"),
+        ("http_seen",
+         g("http_reqs_parsed") >= min_reqs and g("http_resps_parsed") > 0,
+         f"reqs={g('http_reqs_parsed')} resps={g('http_resps_parsed')} (min_reqs={min_reqs})"),
+        ("exchanges_paired",
+         g("http_exchanges_joined") > 0 and g("http_exchanges_unpaired") == 0,
+         f"joined={g('http_exchanges_joined')} unpaired={g('http_exchanges_unpaired')}"),
+        ("llm_detected",
+         g("wires_detected") > 0 and g("generic_session_id_synth_failed") == 0,
+         f"wires={g('wires_detected')} sid_synth_failed={g('generic_session_id_synth_failed')}"),
+        ("calls_ingested",
+         g("calls_ingested") > 0,
+         f"calls_ingested={g('calls_ingested')} (LLM calls reached the turn engine)"),
+        ("turns_built",
+         turns_built >= min_turns,
+         f"turns_built={turns_built} (completed={g('turns_completed')} "
+         f"grace={g('turns_closed_grace')} idle={g('turns_closed_idle')}, min={min_turns})"),
+        ("no_late_drops",
+         g("calls_dropped_late") == 0,
+         f"calls_dropped_late={g('calls_dropped_late')}"),
+    ]
+    return [{"name": n, "ok": bool(ok), "detail": d} for n, ok, d in inv]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", default="run")
+    ap.add_argument("--logfile", default="")
+    ap.add_argument("--min-reqs", type=int, default=1)
+    ap.add_argument("--min-turns", type=int, default=1)
+    ap.add_argument("--metrics-file", default="",
+                    help="read metrics JSON from a file instead of stdin")
+    args = ap.parse_args()
+
+    raw = open(args.metrics_file).read() if args.metrics_file else sys.stdin.read()
+    try:
+        metrics_json = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"label": args.label, "pass": False,
+                          "error": f"metrics JSON unparseable: {e}"}))
+        return 1
+
+    m = flatten(metrics_json)
+    fatals, ingest_pkts = scan_log(args.logfile)
+    invariants = evaluate(m, fatals, ingest_pkts,
+                          min_reqs=args.min_reqs, min_turns=args.min_turns)
+    passed = all(i["ok"] for i in invariants)
+    verdict = {
+        "label": args.label,
+        "pass": passed,
+        "invariants": invariants,
+        "failed": [i["name"] for i in invariants if not i["ok"]],
+        "metrics_summary": {
+            "pkts_received": m.get("pkts_received", 0),
+            "pkts_parsed": m.get("pkts_parsed", 0),
+            "http_reqs_parsed": m.get("http_reqs_parsed", 0),
+            "http_resps_parsed": m.get("http_resps_parsed", 0),
+            "wires_detected": m.get("wires_detected", 0),
+            "calls_ingested": m.get("calls_ingested", 0),
+            "turns_built": (m.get("turns_completed", 0)
+                            + m.get("turns_closed_grace", 0)
+                            + m.get("turns_closed_idle", 0)),
+            "classifier_unknown": m.get("classifier_unknown", 0),
+        },
+        "fatal_lines": fatals,
+    }
+    print(json.dumps(verdict, indent=2))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/staging/tests/test_tara_invariants.py
+++ b/scripts/staging/tests/test_tara_invariants.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Unit tests for tara_invariants — dependency-free (stdlib only), so CI can
+run it without installing pytest.
+
+    python3 scripts/staging/tests/test_tara_invariants.py
+
+The HEALTHY fixture mirrors a real soak of keepalive_2sse_pipelined.pcap
+(captured 2026-06-02 on heron-stage): 534 pkts, 2 exchanges, 2 LLM calls,
+1 turn. Each test perturbs one field and asserts the matching invariant trips.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import tara_invariants as T  # noqa: E402
+
+HEALTHY = {
+    "pkts_received": 534, "pkts_routed": 534, "pkts_parsed": 534, "pkts_truncated": 0,
+    "read_errors": 0, "pkts_dropped_malformed": 0, "http_reqs_parsed": 2,
+    "http_resps_parsed": 2, "http_exchanges_joined": 2, "http_exchanges_unpaired": 0,
+    "wires_detected": 2, "generic_session_id_synth_failed": 0, "calls_ingested": 2,
+    "turns_completed": 1, "turns_closed_grace": 0, "turns_closed_idle": 0,
+    "calls_dropped_late": 0,
+}
+
+
+def ev(m, fatals=(), ingest=534, min_reqs=1, min_turns=0):
+    return T.evaluate(m, list(fatals), ingest, min_reqs=min_reqs, min_turns=min_turns)
+
+
+def failed(invs):
+    return [i["name"] for i in invs if not i["ok"]]
+
+
+def test_healthy_passes():
+    assert failed(ev(HEALTHY)) == [], failed(ev(HEALTHY))
+
+
+def test_malformed_fails():
+    assert "no_malformed" in failed(ev(dict(HEALTHY, pkts_dropped_malformed=3)))
+
+
+def test_unpaired_exchange_fails():
+    assert "exchanges_paired" in failed(ev(dict(HEALTHY, http_exchanges_unpaired=1)))
+
+
+def test_partial_parse_fails():
+    # routed but not all parsed → a parser regression
+    assert "all_routed_parsed" in failed(ev(dict(HEALTHY, pkts_parsed=500)))
+
+
+def test_no_llm_detected_fails():
+    assert "llm_detected" in failed(ev(dict(HEALTHY, wires_detected=0)))
+
+
+def test_sid_synth_failure_fails():
+    assert "llm_detected" in failed(ev(dict(HEALTHY, generic_session_id_synth_failed=2)))
+
+
+def test_no_calls_ingested_fails():
+    assert "calls_ingested" in failed(ev(dict(HEALTHY, calls_ingested=0)))
+
+
+def test_late_drop_fails():
+    assert "no_late_drops" in failed(ev(dict(HEALTHY, calls_dropped_late=4)))
+
+
+def test_read_error_fails():
+    assert "capture_clean" in failed(ev(dict(HEALTHY, read_errors=1)))
+
+
+def test_fatal_log_fails():
+    assert "no_fatal_logs" in failed(ev(HEALTHY, fatals=["thread 'x' panicked at foo.rs:1"]))
+
+
+def test_ingest_cut_short_fails():
+    # no "finished reading" line → ingest never completed (early crash)
+    assert "ingest_finished" in failed(ev(HEALTHY, ingest=None))
+
+
+def test_min_reqs_floor_trips_http_seen():
+    assert "http_seen" in failed(ev(HEALTHY, min_reqs=9999))
+
+
+def test_min_turns_floor_trips_turns_built():
+    assert "turns_built" in failed(ev(HEALTHY, min_turns=99))
+
+
+def test_flatten_from_api_shape():
+    api = {"data": {"pipelines": [{"metrics": [
+        {"name": "pkts_received", "group": "capture", "kind": "counter", "value": 7}]}]}}
+    assert T.flatten(api)["pkts_received"] == 7
+
+
+def test_scan_log_detects_patterns():
+    with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as fh:
+        fh.write("info ok\npcap-file: finished reading 534 packets\n"
+                 "ERROR broken index while merging\n")
+        path = fh.name
+    try:
+        fatals, ingest = T.scan_log(path)
+        assert ingest == 534
+        assert any("broken index" in f for f in fatals)
+    finally:
+        os.unlink(path)
+
+
+def test_cli_exits_nonzero_on_failure():
+    payload = {"data": {"pipelines": [{"metrics": [
+        {"name": k, "value": v}
+        for k, v in dict(HEALTHY, http_exchanges_unpaired=5).items()]}]}}
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump(payload, fh)
+        mf = fh.name
+    try:
+        checker = os.path.join(os.path.dirname(T.__file__), "tara_invariants.py")
+        r = subprocess.run([sys.executable, checker, "--metrics-file", mf],
+                           capture_output=True)
+        assert r.returncode == 1, r.returncode
+    finally:
+        os.unlink(mf)
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except AssertionError as e:
+            fails += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            fails += 1
+            print(f"ERR  {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - fails}/{len(tests)} passed")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds **tara**, the staging soak runner — the last piece of the quality chain
(L7). After a staging deploy is healthy, it replays a known pcap corpus
through the deployed binary and asserts it still parses real wire traffic
correctly. Catches the regression class that compiles + passes unit tests but
mangles live traffic (the **#47** validator-bypass and **#48** storage-
poisoning families).

## How it works — no NIC, no tcpreplay
Uses heron's built-in **`pcap-file`** capture source, so the soak is
deterministic, fast, and needs **no capture capabilities**. Each run is a
throwaway heron on a private port with an isolated DuckDB — it never touches
the deployed `heron.service` or its DB.

After ingest it snapshots `/api/internal-metrics` and asserts: corpus fully
ingested, no FATAL/panic, zero malformed/read errors, every routed packet
parsed, all HTTP exchanges paired, LLM calls detected + ingested, turns built,
no late drops.

**Known-good self-test**: `--baseline <last-good>` runs *both* binaries
through identical load. If the baseline fails, tara reports `harness_broken`
(exit 3) and does **not** blame the candidate — a bad corpus / flaky env never
red-flags a good build.

## Pieces
| File | Role |
|---|---|
| `scripts/staging/tara_invariants.py` | judgement: metrics+log → verdict JSON (pure, unit-testable) |
| `scripts/staging/tara.sh` | orchestrator: start heron on pcap-file, soak, evaluate, stop; dual-binary self-test |
| `scripts/staging/soak-staging.sh` | CI wrapper: resolve VM, ship tara, soak deployed binary |
| `.github/workflows/staging-soak.yml` | `workflow_run` after deploy-staging success |
| `scripts/staging/tests/test_tara_invariants.py` | 16 stdlib-only unit tests, wired into ci.yml |

Chains: `ci(main) → deploy-staging → staging-soak`.

## Validation (end-to-end on heron-stage)
- Real soak: 534 pkts → 2 paired exchanges → 2 LLM calls → 1 turn; **all 11
  invariants green**, exit 0.
- Negative control (`--min-reqs 9999`): exit 1, `candidate_regressed`.
- Self-test (`--baseline` same binary): exit 0, baseline populated.
- `harness_broken` (baseline fails): exit 3, candidate not blamed.
- `soak-staging.sh` wrapper run on the wukong deploy host: resolves the VM,
  ships tara, soaks `/opt/heron/heron`, exit 0.
- Unit tests: 16/16 pass. Leakage linter: clean.

Corpus is the committed `keepalive_2sse_pipelined.pcap` fixture. A richer
corpus (scrubbed dumps / synthesized fixtures) is a later enrichment; the
dual-binary self-test makes swapping it safe.