### PR TITLE
feat(h-llm): cap stored request/response bodies for 1M-token contexts (#68)

### DIFF
--- a/docs/design/09-body-cap.md
+++ b/docs/design/09-body-cap.md
@@ -1,0 +1,98 @@
+# 09 — Stored-body cap
+
+> Bounds the size of request/response bodies Heron persists, so 1M-token
+> contexts don't pressure capture-node memory. Implemented as a head + tail
+> sampling policy applied **after** extraction. See issue H007.
+
+## Problem
+
+For each LLM call Heron stores the full request and response body
+(`llm_calls.request_body` / `response_body`) for display and re-classification.
+With 2026-era 1M-token context windows a single request body is routinely
+multiple megabytes. Two failure modes follow:
+
+1. **Capture-node memory pressure.** The storage write buffer batches ~1000
+   rows (`[storage.sink].batch_size`) before flushing. At multi-MB per body
+   that is gigabytes held in memory — on a node whose job is to *passively
+   observe* without disturbing the host it runs on. An observer that OOMs the
+   capture node violates Heron's core non-intrusiveness guarantee.
+
+2. **Silent metric loss (the original framing).** The only pre-existing byte
+   bound was `snaplen` (262144, per-*packet*), which truncates reassembly
+   rather than bounding the accumulated body. A snaplen-truncated tail can drop
+   the trailing `usage` block on a large non-streaming response. `snaplen` is
+   owned by `h-capture` and is explicitly out of scope here.
+
+## What the cap does
+
+`h_common::config::BodyCapConfig` (`[body_cap]` in `default.toml`):
+
+| field        | default   | meaning                                            |
+|--------------|-----------|----------------------------------------------------|
+| `enabled`    | `true`    | master switch; `false` ⇒ unbounded (legacy)        |
+| `head_bytes` | `262144`  | bytes retained from the start of each body         |
+| `tail_bytes` | `65536`   | bytes retained from the end of each body           |
+
+A body larger than `head_bytes + tail_bytes` is stored as **first `head_bytes`
++ elision marker + last `tail_bytes`**; the middle is dropped and the dropped
+byte count is recorded in `llm_calls.body_bytes_dropped` (UBIGINT, default 0).
+A body at or below the budget is stored verbatim with `body_bytes_dropped = 0`.
+
+- The **head** holds model, parameters, system prompt, tool schemas, and the
+  first messages.
+- The **tail** holds the final messages and, on non-streaming responses, the
+  trailing `usage` block.
+- Window boundaries are snapped to UTF-8 char boundaries so the stored `String`
+  stays valid.
+
+The cap is **symmetric** (same budget for request and response). The config
+struct is shaped so a separate response budget can be added later without
+breaking existing files.
+
+## Where it runs — and why not in `BodyReader`
+
+H007's suggested approach was to cap inside `h-protocol`'s `BodyReader` at
+accumulation time. We deliberately do **not** do that in this iteration.
+
+Extraction is not tolerant of a sampled body: `h-llm` parses the *full* body as
+JSON (`ParsedJson` → `serde_json::from_slice`) to read usage, model, and agent
+primitives. A head+tail body with the middle elided is not valid JSON, so
+capping before extraction would break usage/model extraction — exactly what
+H007's success criteria forbid. H007's own "tail-aware sampling that parses the
+body to locate the usage event" is explicitly **deferred**.
+
+So the cap is applied at the **storage boundary**, in
+`h_llm::processor::cap_body`, immediately before the `LlmCall` is built and
+*after* every extraction (wire detection, usage/model, token estimation, agent
+classification) has run on the full body. This:
+
+- keeps usage/model/agent accuracy at 100% (they never see the capped body);
+- bounds the **sustained** memory consumer — the storage write buffer and the
+  persisted rows — which is the dominant risk at scale.
+
+```
+h-protocol (full body) ─▶ h-llm extract (full body) ─▶ cap_body ─▶ LlmCall ─▶ write buffer ─▶ DuckDB
+                                                          ▲ head+tail only from here on
+```
+
+### Known limitation (follow-up)
+
+This policy does **not** bound the *transient* peak: a single in-flight body is
+still fully reassembled in `h-protocol` and held through the protocol→joiner→
+processor channels before `cap_body` trims it. That peak is bounded by the
+flow-shard count, not by `head_bytes + tail_bytes`. Bounding the transient peak
+requires capping in `BodyReader` *and* a tail-aware usage parser that can read
+`usage` from a sampled body — H007's deferred item, tracked for a future
+iteration.
+
+## Storage
+
+`llm_calls.body_bytes_dropped UBIGINT NOT NULL DEFAULT 0`, at the table tail.
+The Phase-6 migration adds it to legacy DBs via
+`ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS body_bytes_dropped UBIGINT
+DEFAULT 0` — **without `NOT NULL`**, because DuckDB rejects
+`ALTER ... ADD COLUMN ... NOT NULL DEFAULT` (see `07-schema.md` and the Phase-5
+note in `schema.rs`). The column sits last in both `CREATE TABLE` and the
+`ALTER`, so the positional appender stays aligned on fresh and migrated DBs
+alike. `tests/migrations.rs` covers the migration *and* writes a row through
+the appender to assert the column round-trips (alignment regression guard).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,6 +14,7 @@ For cross-cutting terminology (TTFT/E2E/TPOT, wire_api, agent_kind, HttpExchange
 | 06 | [Storage](06-storage.md) | `ts-storage` | Pluggable backend trait, write buffer, batch flush |
 | 07 | [Schema](07-schema.md) | `ts-storage` | `agent_turns`, `llm_calls`, `llm_metrics` table definitions |
 | 08 | [Internal Metrics](08-internal-metrics.md) | `ts-common` | Operational self-monitoring (counters, gauges) |
+| 09 | [Body cap](09-body-cap.md) | `h-llm` / `h-common` | Stored-body head+tail sampling for 1M-token contexts |
 
 ## Pipeline Flow
 

--- a/server/app/heron/src/main.rs
+++ b/server/app/heron/src/main.rs
@@ -332,6 +332,7 @@ async fn run_pipeline(cli: Cli) {
             internal_metrics: config.internal_metrics.clone(),
             api: config.api.clone(),
             agent_classifier: config.agent_classifier.clone(),
+            body_cap: config.body_cap,
         }),
         config_path: config_path
             .canonicalize()
@@ -551,6 +552,7 @@ async fn run_pipeline(cli: Cli) {
             &mut shared_metrics,
             active_turns.clone(),
             classifier_cfg,
+            config.body_cap,
         );
 
         // Start each per-pipeline MetricsSystem and, if enabled, one

--- a/server/app/heron/src/pipeline.rs
+++ b/server/app/heron/src/pipeline.rs
@@ -120,6 +120,7 @@ impl Pipeline {
     /// `PipelineDef`, registered against that pipeline's `MetricsSystem`).
     /// There is no cross-pipeline metrics stage — the sink is the only truly
     /// shared stage.
+    #[allow(clippy::too_many_arguments)]
     pub fn build(
         pipeline_defs: &[PipelineDef],
         storage_config: &h_storage::StorageSinkConfig,
@@ -128,6 +129,7 @@ impl Pipeline {
         shared_metrics: &mut MetricsSystem,
         active_turns: h_turn::ActiveTurnRegistry,
         classifier_cfg: ClassifierConfig,
+        body_cap: h_common::config::BodyCapConfig,
     ) -> Self {
         // ---- Shared sinks (fan-in across every pipeline) ----
         // Each shared channel takes the max of its dedicated config across
@@ -339,6 +341,7 @@ impl Pipeline {
                 registry.clone(),
                 metrics_sys,
                 classifier_cfg.clone(),
+                body_cap,
             );
             debug_assert_eq!(llm_handles.len(), flow_shards);
             for (j, h) in llm_handles.into_iter().enumerate() {

--- a/server/app/heron/tests/pipeline_e2e.rs
+++ b/server/app/heron/tests/pipeline_e2e.rs
@@ -123,6 +123,7 @@ async fn run_pipeline_multi(fixture_names: &[&str]) -> Option<(TempDir, PathBuf)
         &mut shared_metrics,
         h_turn::new_active_turn_registry(),
         h_llm::agent_classifier::ClassifierConfig::default(),
+        h_common::config::BodyCapConfig::default(),
     );
     let _metrics_svcs: Vec<_> = per_pipeline_metrics
         .into_iter()

--- a/server/config/default.toml
+++ b/server/config/default.toml
@@ -179,3 +179,21 @@ mcp_tool_prefixes       = ["mcp__"]
 # for every default deployment (#85/#93). Keep it empty so the list has a
 # single source of truth and can't drift again.
 known_tool_registry     = []
+
+# ---------------------------------------------------------------------------
+# Stored-body cap — bounds the size of request/response bodies kept for
+# display and re-classification. Usage / model / agent classification are
+# always extracted from the FULL body upstream, so this never reduces metric
+# accuracy; it only samples what is persisted. With 1M-token contexts a single
+# body can be many MB and the write buffer batches ~1000 rows, so an uncapped
+# body is a real capture-node memory risk. The first `head_bytes` and last
+# `tail_bytes` of each body are kept (the head holds model/params/system/tools;
+# the tail holds the trailing `usage` block on non-streaming responses); the
+# middle is elided and the dropped count lands in `llm_calls.body_bytes_dropped`.
+# A body that fits within head+tail is stored verbatim. Set enabled=false to
+# restore unbounded storage.
+# ---------------------------------------------------------------------------
+[body_cap]
+enabled    = true
+head_bytes = 262144   # 256 KiB
+tail_bytes = 65536    # 64 KiB

--- a/server/h-api/tests/duckdb_routes.rs
+++ b/server/h-api/tests/duckdb_routes.rs
@@ -32,6 +32,7 @@ fn test_runtime_config_context() -> ApiRuntimeConfigContext {
             internal_metrics: h_common::config::InternalMetricsConfig::default(),
             api: h_common::config::ApiConfig::default(),
             agent_classifier: h_common::config::ClassifierConfigToml::default(),
+            body_cap: h_common::config::BodyCapConfig::default(),
         }),
         config_path: "test".to_string(),
         loaded_at_ms: 0,

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -62,6 +62,57 @@ pub struct ClassifierConfigToml {
     pub known_tool_registry: Vec<String>,
 }
 
+/// Policy for bounding the size of stored HTTP bodies.
+///
+/// Heron stores each call's request and response body for display and
+/// re-classification. With 2026-era 1M-token contexts a single body can be
+/// many megabytes; the storage write buffer batches ~1000 rows, so holding
+/// full bodies is a real memory-pressure / stability risk on capture nodes.
+///
+/// This policy keeps the first `head_bytes` and last `tail_bytes` of each
+/// stored body (eliding the middle), so the head (model / params / system /
+/// tools / first messages) and the tail (final messages + the trailing
+/// `usage` block on non-streaming responses) are always retained while total
+/// stored bytes are bounded. `LlmCall.body_bytes_dropped` records how many
+/// bytes were elided.
+///
+/// The cap applies **only to what is stored** — usage / model / agent
+/// classification are always extracted from the full body upstream, so the
+/// cap never reduces metric accuracy. It is **symmetric**: the same head/tail
+/// budget applies to request and response bodies. The struct is shaped so a
+/// separate response budget can be added later without breaking configs.
+/// A body that fits within `head_bytes + tail_bytes` is stored verbatim.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BodyCapConfig {
+    /// Master switch. When `false`, bodies are stored verbatim (legacy
+    /// behavior, unbounded).
+    pub enabled: bool,
+    /// Bytes retained from the start of each stored body.
+    pub head_bytes: usize,
+    /// Bytes retained from the end of each stored body. Covers the trailing
+    /// `usage` block on non-streaming responses.
+    pub tail_bytes: usize,
+}
+
+impl Default for BodyCapConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            head_bytes: 256 * 1024, // 256 KiB
+            tail_bytes: 64 * 1024,  // 64 KiB
+        }
+    }
+}
+
+impl BodyCapConfig {
+    /// Total bytes retained per body when the cap is active. A body at or
+    /// below this size is stored verbatim (no bytes dropped).
+    pub fn budget(&self) -> usize {
+        self.head_bytes.saturating_add(self.tail_bytes)
+    }
+}
+
 /// Top-level application configuration.
 ///
 /// Not directly deserializable — use [`AppConfig::load`] or [`AppConfig::from_toml`]
@@ -74,6 +125,8 @@ pub struct AppConfig {
     pub api: ApiConfig,
     #[serde(default)]
     pub agent_classifier: ClassifierConfigToml,
+    /// Stored-body size cap. See [`BodyCapConfig`].
+    pub body_cap: BodyCapConfig,
 }
 
 /// A single pipeline definition bundling sources and pipeline parameters.
@@ -137,6 +190,8 @@ struct RawAppConfig {
     api: ApiConfig,
     #[serde(default)]
     agent_classifier: ClassifierConfigToml,
+    #[serde(default)]
+    body_cap: BodyCapConfig,
 }
 
 #[derive(Deserialize)]
@@ -190,6 +245,7 @@ impl RawAppConfig {
             internal_metrics: self.internal_metrics,
             api: self.api,
             agent_classifier: self.agent_classifier,
+            body_cap: self.body_cap,
         }
     }
 }

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -292,6 +292,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/agents/codex_cli.rs
+++ b/server/h-llm/src/agents/codex_cli.rs
@@ -302,6 +302,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/agents/generic.rs
+++ b/server/h-llm/src/agents/generic.rs
@@ -325,6 +325,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/agents/hermes.rs
+++ b/server/h-llm/src/agents/hermes.rs
@@ -279,6 +279,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/agents/mod.rs
+++ b/server/h-llm/src/agents/mod.rs
@@ -99,6 +99,7 @@ mod priority_tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-llm/src/agents/openclaw.rs
+++ b/server/h-llm/src/agents/openclaw.rs
@@ -379,6 +379,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/agents/opencode.rs
+++ b/server/h-llm/src/agents/opencode.rs
@@ -189,6 +189,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         })
     }
 

--- a/server/h-llm/src/model.rs
+++ b/server/h-llm/src/model.rs
@@ -68,6 +68,13 @@ pub struct LlmCall {
     pub tool_call_count: u32,
     /// Distinct tool names referenced in this call. Copied from `AgentCallInfo`.
     pub tool_names: Vec<String>,
+    /// Bytes elided from the stored `request_body` + `response_body` by the
+    /// body-cap policy (`BodyCapConfig`). `0` when nothing was dropped (body
+    /// fit the budget or the cap was disabled). Non-zero exactly when the
+    /// stored bodies were sampled (head + tail retained, middle elided).
+    /// Extraction (usage/model) always runs on the full body upstream, so a
+    /// non-zero value never implies lost metrics — only a truncated stored body.
+    pub body_bytes_dropped: u64,
 }
 
 /// Per-call agent-side info produced once an `AgentProfile` has matched —
@@ -385,6 +392,7 @@ mod extension_tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         };
         let arc = Arc::new(call);
         let id = AgentCallInfo {
@@ -448,6 +456,7 @@ mod extension_tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         };
         assert!(call.finish_reason.is_none());
     }

--- a/server/h-llm/src/processor.rs
+++ b/server/h-llm/src/processor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde_json::Value;
+use h_common::config::BodyCapConfig;
 use h_common::internal_metrics::{Metric, MetricsWorker};
 use h_protocol::joiner::HttpJoinerEvent;
 use h_protocol::model::{HttpRequestData, HttpResponseData, SseEventData};
@@ -12,6 +13,46 @@ use crate::parsed_json::ParsedJson;
 use crate::profile::{parse_bodies, AgentProfileRegistry, CallCtx};
 use crate::token_estimator::{CL100kEstimator, TokenEstimator};
 use crate::wire_api_registry::WireApiRegistry;
+
+/// Apply the stored-body cap: retain the first `head_bytes` and last
+/// `tail_bytes` of `body` (snapped to UTF-8 char boundaries so the stored
+/// `String` stays valid) and elide the middle, returning the (possibly
+/// sampled) body plus the count of elided bytes.
+///
+/// Returns the body unchanged with `0` dropped when the cap is disabled, the
+/// body is absent, or it already fits within `head_bytes + tail_bytes`. Used
+/// only at the storage boundary — extraction always sees the full body.
+fn cap_body(body: Option<String>, cap: &BodyCapConfig) -> (Option<String>, u64) {
+    let Some(body) = body else {
+        return (None, 0);
+    };
+    if !cap.enabled || body.len() <= cap.budget() {
+        return (Some(body), 0);
+    }
+    // Snap the head end down and the tail start up to char boundaries so a
+    // multi-byte UTF-8 sequence is never split (which would corrupt the
+    // String and panic byte-index slicing).
+    let mut head_end = cap.head_bytes.min(body.len());
+    while head_end > 0 && !body.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = body.len().saturating_sub(cap.tail_bytes);
+    while tail_start < body.len() && !body.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    // After snapping the windows could meet/overlap on a tiny overflow; then
+    // there is nothing worth eliding — keep the body verbatim.
+    if tail_start <= head_end {
+        return (Some(body), 0);
+    }
+    let dropped = (tail_start - head_end) as u64;
+    let marker = format!("\n...[heron body cap: {dropped} bytes elided]...\n");
+    let mut out = String::with_capacity(head_end + marker.len() + (body.len() - tail_start));
+    out.push_str(&body[..head_end]);
+    out.push_str(&marker);
+    out.push_str(&body[tail_start..]);
+    (Some(out), dropped)
+}
 
 /// Processes `HttpJoinerEvent`s and extracts `LlmCall` records. Stateless —
 /// request/response pairing now lives in `h_protocol::joiner::HttpJoiner`.
@@ -25,6 +66,10 @@ pub struct LlmProcessor {
     /// Classifier thresholds and allowlists. Task 8 will wire this from
     /// `AppConfig`; for now it defaults to the compile-time seeds.
     classifier_cfg: ClassifierConfig,
+    /// Stored-body cap. Applied to `request_body`/`response_body` *after*
+    /// extraction, so it never affects usage/model/agent accuracy — only how
+    /// much body is persisted. Wired from `AppConfig.body_cap`.
+    body_cap: BodyCapConfig,
 }
 
 impl LlmProcessor {
@@ -54,6 +99,7 @@ impl LlmProcessor {
             metrics,
             estimator,
             classifier_cfg: ClassifierConfig::default(),
+            body_cap: BodyCapConfig::default(),
         }
     }
 
@@ -61,6 +107,13 @@ impl LlmProcessor {
     /// `ClassifierConfig` with the one loaded from `AppConfig`.
     pub fn with_classifier_cfg(mut self, cfg: ClassifierConfig) -> Self {
         self.classifier_cfg = cfg;
+        self
+    }
+
+    /// Builder-style override for the stored-body cap. Replaces the default
+    /// `BodyCapConfig` with the one loaded from `AppConfig.body_cap`.
+    pub fn with_body_cap(mut self, cfg: BodyCapConfig) -> Self {
+        self.body_cap = cfg;
         self
     }
 
@@ -241,9 +294,18 @@ impl LlmProcessor {
             };
         }
 
-        let request_body = std::str::from_utf8(&request.body)
+        // Body-cap: every extraction above (wire detection, usage/model,
+        // token estimation, agent classification below) ran on the *full*
+        // request and response bodies. From here we only persist them, so
+        // sample head + tail to bound the bytes the storage write buffer and
+        // DB hold under 1M-token contexts. `cap_body` returns the (possibly
+        // sampled) body plus the count of elided bytes.
+        let request_body_full = std::str::from_utf8(&request.body)
             .ok()
             .map(|s| s.to_string());
+        let (request_body, req_body_dropped) = cap_body(request_body_full, &self.body_cap);
+        let (response_body, resp_body_dropped) = cap_body(resp_info.response_body, &self.body_cap);
+        let body_bytes_dropped = req_body_dropped.saturating_add(resp_body_dropped);
 
         let call = LlmCall {
             source_id: request.flow_key.source_id.clone(),
@@ -259,7 +321,7 @@ impl LlmProcessor {
             request_body,
             status_code: Some(response.status),
             finish_reason: resp_info.finish_reason,
-            response_body: resp_info.response_body,
+            response_body,
             input_tokens: resp_info.input_tokens,
             output_tokens: resp_info.output_tokens,
             total_tokens,
@@ -281,6 +343,7 @@ impl LlmProcessor {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped,
         };
 
         let agent = build_agent_call_info_with_parsed(
@@ -627,6 +690,131 @@ mod tests {
                 assert_eq!(call.input_tokens, Some(1));
                 assert_eq!(call.output_tokens, Some(1));
                 assert_eq!(call.total_tokens, Some(2));
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    // ── Stored-body cap (`cap_body`) unit tests ──
+
+    #[test]
+    fn cap_body_keeps_body_within_budget_verbatim() {
+        let cap = BodyCapConfig {
+            enabled: true,
+            head_bytes: 10,
+            tail_bytes: 10,
+        };
+        // 20 bytes == budget → stored verbatim, nothing dropped.
+        let (out, dropped) = cap_body(Some("x".repeat(20)), &cap);
+        assert_eq!(dropped, 0);
+        assert_eq!(out.as_deref(), Some("x".repeat(20).as_str()));
+    }
+
+    #[test]
+    fn cap_body_samples_head_and_tail_of_oversized_body() {
+        let cap = BodyCapConfig {
+            enabled: true,
+            head_bytes: 4,
+            tail_bytes: 4,
+        };
+        let body = format!("HEAD{}TAIL", "x".repeat(100)); // 108 bytes
+        let (out, dropped) = cap_body(Some(body), &cap);
+        // 108 - 4 (head) - 4 (tail) = 100 bytes elided.
+        assert_eq!(dropped, 100);
+        let out = out.unwrap();
+        assert!(out.starts_with("HEAD"), "head retained: {out}");
+        assert!(out.ends_with("TAIL"), "tail retained: {out}");
+        assert!(out.contains("100 bytes elided"), "elision marker present: {out}");
+        assert!(out.len() < 108, "stored body must be smaller than the original");
+    }
+
+    #[test]
+    fn cap_body_disabled_keeps_verbatim() {
+        let cap = BodyCapConfig {
+            enabled: false,
+            head_bytes: 4,
+            tail_bytes: 4,
+        };
+        let big = "y".repeat(10_000);
+        let (out, dropped) = cap_body(Some(big.clone()), &cap);
+        assert_eq!(dropped, 0);
+        assert_eq!(out, Some(big));
+    }
+
+    #[test]
+    fn cap_body_none_is_noop() {
+        let cap = BodyCapConfig::default();
+        let (out, dropped) = cap_body(None, &cap);
+        assert_eq!(out, None);
+        assert_eq!(dropped, 0);
+    }
+
+    #[test]
+    fn cap_body_snaps_to_utf8_char_boundaries() {
+        // Multi-byte chars (each "好" is 3 bytes). Byte offsets 10 and 50 fall
+        // mid-character; cap_body must snap to char boundaries so the produced
+        // String is valid and slicing never panics.
+        let cap = BodyCapConfig {
+            enabled: true,
+            head_bytes: 10,
+            tail_bytes: 10,
+        };
+        let body = "好".repeat(20); // 60 bytes, boundaries at multiples of 3
+        let (out, dropped) = cap_body(Some(body), &cap);
+        let out = out.expect("some body");
+        // head snaps 10 → 9, tail start snaps 50 → 51, so 51 - 9 = 42 elided.
+        assert_eq!(dropped, 42);
+        assert!(out.starts_with("好好好"), "head is whole chars: {out}");
+        assert!(out.ends_with("好好好"), "tail is whole chars: {out}");
+    }
+
+    #[test]
+    fn exchange_caps_huge_request_body_but_still_extracts_usage() {
+        // Success criterion (#68): a >1 MB request body must be sampled for
+        // storage (body_bytes_dropped > 0) WITHOUT breaking usage extraction —
+        // extraction runs on the full body upstream, the cap only trims what
+        // is persisted.
+        use serde_json::json;
+        let mut proc = LlmProcessor::new(wire_apis(), empty_registry(), test_metrics())
+            .with_body_cap(BodyCapConfig::default());
+        let huge = "x".repeat(1_100_000); // ~1.1 MB user message → body > 320 KiB budget
+        let req_body = json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": huge}]
+        });
+        let original_len = req_body.to_string().len();
+        let req = openai_request(&req_body);
+        let resp_body = json!({
+            "id": "chatcmpl-huge",
+            "model": "gpt-4",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1234, "completion_tokens": 56, "total_tokens": 1290}
+        });
+        let (request, response) = exchange_parts(req, Bytes::from(resp_body.to_string()), false);
+        let events = proc.process(HttpJoinerEvent::Exchange {
+            id: "xchg-huge".to_string(),
+            request,
+            response: Arc::new(response),
+            sse_events: vec![],
+        });
+        match &events[0] {
+            LlmEvent::Complete { call, .. } => {
+                // Wire usage extracted exactly (estimator did NOT run, and the
+                // cap did not corrupt extraction).
+                assert_eq!(call.input_tokens, Some(1234), "usage survives request-body cap");
+                assert_eq!(call.output_tokens, Some(56));
+                assert_eq!(call.total_tokens, Some(1290));
+                // Request body was sampled.
+                assert!(call.body_bytes_dropped > 0, "huge request body must be capped");
+                let stored = call.request_body.as_ref().expect("request_body stored");
+                assert!(
+                    stored.len() < original_len,
+                    "stored body ({}) must be smaller than original ({original_len})",
+                    stored.len()
+                );
+                assert!(stored.contains("bytes elided"), "stored body carries the cap marker");
+                // Small response stayed verbatim → all dropped bytes are the request's.
+                assert_eq!(call.response_body.as_deref(), Some(resp_body.to_string().as_str()));
             }
             _ => panic!("expected Complete"),
         }
@@ -981,6 +1169,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-llm/src/profile.rs
+++ b/server/h-llm/src/profile.rs
@@ -249,6 +249,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-llm/src/stage.rs
+++ b/server/h-llm/src/stage.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+use h_common::config::BodyCapConfig;
 use h_common::internal_metrics::{Metric, MetricsSystem};
 
 /// Metrics registered for every `llm.{i}` worker. SINGLE SOURCE OF TRUTH:
@@ -61,6 +62,7 @@ use crate::wire_api_registry::WireApiRegistry;
 ///   reaches storage regardless of agent attribution).
 /// * `LlmEvent::Complete` with `agent.is_some()` → one turn shard, chosen
 ///   by `hash(session_id) % turn_shard_txs.len()`.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_llm_stage(
     event_rxs: Vec<mpsc::Receiver<HttpJoinerEvent>>,
     turn_shard_txs: Vec<mpsc::Sender<TurnShardInput>>,
@@ -70,6 +72,7 @@ pub fn spawn_llm_stage(
     registry: Arc<AgentProfileRegistry>,
     metrics_sys: &mut MetricsSystem,
     classifier_cfg: ClassifierConfig,
+    body_cap: BodyCapConfig,
 ) -> Vec<JoinHandle<()>> {
     assert!(
         !metrics_shard_txs.is_empty(),
@@ -94,7 +97,8 @@ pub fn spawn_llm_stage(
         handles.push(tokio::spawn(async move {
             let shard = i;
             let mut processor = LlmProcessor::new(wire_apis, reg, worker_metrics.clone())
-                .with_classifier_cfg(classifier_cfg);
+                .with_classifier_cfg(classifier_cfg)
+                .with_body_cap(body_cap);
             let reason = 'main: loop {
                 let event = match rx.recv().await {
                     Some(e) => e,
@@ -358,6 +362,7 @@ mod tests {
             Arc::new(build_default_registry()),
             &mut metrics_sys,
             ClassifierConfig::default(),
+            BodyCapConfig::default(),
         );
         let _svc = metrics_sys.start();
 
@@ -417,6 +422,7 @@ mod tests {
             Arc::new(build_default_registry()),
             &mut metrics_sys,
             ClassifierConfig::default(),
+            BodyCapConfig::default(),
         );
         let _svc = metrics_sys.start();
 
@@ -471,6 +477,7 @@ mod tests {
             Arc::new(build_default_registry()),
             &mut metrics_sys,
             ClassifierConfig::default(),
+            BodyCapConfig::default(),
         );
         let _svc = metrics_sys.start();
 

--- a/server/h-llm/src/test_support.rs
+++ b/server/h-llm/src/test_support.rs
@@ -43,5 +43,6 @@ pub fn empty_llm_call() -> LlmCall {
         agent_topology: None,
         tool_call_count: 0,
         tool_names: vec![],
+        body_bytes_dropped: 0,
     }
 }

--- a/server/h-metrics/src/aggregator.rs
+++ b/server/h-metrics/src/aggregator.rs
@@ -443,6 +443,7 @@ mod tests {
                 agent_topology: None,
                 tool_call_count: 0,
                 tool_names: vec![],
+                body_bytes_dropped: 0,
             }),
             agent: None,
         }

--- a/server/h-metrics/src/bucket.rs
+++ b/server/h-metrics/src/bucket.rs
@@ -400,6 +400,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-metrics/src/stage.rs
+++ b/server/h-metrics/src/stage.rs
@@ -159,6 +159,7 @@ mod tests {
                 agent_topology: None,
                 tool_call_count: 0,
                 tool_names: vec![],
+                body_bytes_dropped: 0,
             }),
             agent: Some(AgentCallInfo {
                 agent_kind: "x",

--- a/server/h-metrics/tests/dimensions.rs
+++ b/server/h-metrics/tests/dimensions.rs
@@ -61,6 +61,7 @@ fn make_completed_call(request_time: i64, tool_surface: Option<ToolSurface>) -> 
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }),
         agent: None,
     }

--- a/server/h-storage-duckdb/src/calls.rs
+++ b/server/h-storage-duckdb/src/calls.rs
@@ -48,6 +48,7 @@ struct PreparedCall {
     agent_topology: Option<String>,
     tool_call_count: u32,
     tool_names_json: String,
+    body_bytes_dropped: u64,
 }
 
 fn prepare_call(call: LlmCall) -> PreparedCall {
@@ -90,6 +91,7 @@ fn prepare_call(call: LlmCall) -> PreparedCall {
         tool_call_count: call.tool_call_count,
         tool_names_json: serde_json::to_string(&call.tool_names)
             .unwrap_or_else(|_| "[]".to_string()),
+        body_bytes_dropped: call.body_bytes_dropped,
     }
 }
 
@@ -305,6 +307,7 @@ impl DuckDbBackend {
                         p.agent_topology,
                         p.tool_call_count,
                         p.tool_names_json,
+                        p.body_bytes_dropped,
                     ])
                     .map_err(|e| AppError::Storage(format!("failed to append call: {e}")))?;
             }
@@ -749,6 +752,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-storage-duckdb/src/concurrent_tests.rs
+++ b/server/h-storage-duckdb/src/concurrent_tests.rs
@@ -49,6 +49,7 @@ fn mk_call(i: usize) -> LlmCall {
         agent_topology: None,
         tool_call_count: 0,
         tool_names: vec![],
+        body_bytes_dropped: 0,
     }
 }
 

--- a/server/h-storage-duckdb/src/retention.rs
+++ b/server/h-storage-duckdb/src/retention.rs
@@ -150,6 +150,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-storage-duckdb/src/schema.rs
+++ b/server/h-storage-duckdb/src/schema.rs
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS llm_calls (
     tool_surface      VARCHAR,
     agent_topology    VARCHAR,
     tool_call_count   UINTEGER NOT NULL DEFAULT 0,
-    tool_names_json   VARCHAR
+    tool_names_json   VARCHAR,
+    body_bytes_dropped UBIGINT NOT NULL DEFAULT 0
 );
 ";
 
@@ -334,6 +335,26 @@ pub(crate) async fn init(backend: &DuckDbBackend) -> Result<()> {
                 Err(e) => tracing::info!(
                     "phase5 migration: llm_calls agent columns add skipped: {e} (sql: {stmt})"
                 ),
+            }
+        }
+
+        // Phase 6 migration: add `body_bytes_dropped` to llm_calls — the
+        // count of request+response body bytes elided by the stored-body cap
+        // (`BodyCapConfig`). Added WITHOUT `NOT NULL` for the exact reason
+        // documented on the Phase 5 block above (DuckDB rejects
+        // `ALTER ... ADD COLUMN ... NOT NULL DEFAULT`, verified on 1.10501.0).
+        // Nullable-with-default is metadata-only and behaviorally equivalent:
+        // the writer always supplies a value, and the column sits at the tail
+        // of the table in both CREATE and ALTER so the appender's positional
+        // writes stay aligned. Fresh installs get NOT NULL via CREATE TABLE.
+        match conn.execute_batch(
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS body_bytes_dropped UBIGINT DEFAULT 0;",
+        ) {
+            Ok(()) => tracing::debug!(
+                "phase6 migration: llm_calls.body_bytes_dropped added (or already present)"
+            ),
+            Err(e) => {
+                tracing::info!("phase6 migration: llm_calls.body_bytes_dropped add skipped: {e}")
             }
         }
 

--- a/server/h-storage-duckdb/src/turns.rs
+++ b/server/h-storage-duckdb/src/turns.rs
@@ -869,6 +869,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-storage-duckdb/src/util.rs
+++ b/server/h-storage-duckdb/src/util.rs
@@ -210,6 +210,7 @@ pub(crate) fn extract_full_text(
         agent_topology: None,
         tool_call_count: 0,
         tool_names: vec![],
+        body_bytes_dropped: 0,
     };
     let (req, resp) = parse_bodies(&call);
     let ctx = CallCtx::new(&call, req.as_ref(), resp.as_ref());
@@ -320,6 +321,7 @@ pub(crate) fn extract_full_text_batch(
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         };
         let (req, resp) = parse_bodies(&call);
         let ctx = CallCtx::new(&call, req.as_ref(), resp.as_ref());

--- a/server/h-storage-duckdb/tests/migrations.rs
+++ b/server/h-storage-duckdb/tests/migrations.rs
@@ -20,14 +20,58 @@
 //! `testdata/golden-dbs/README.md` for the binary-fixture flow if/when
 //! per-tag fixtures become necessary.
 
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use duckdb::Connection;
 use tempfile::TempDir;
 
+use h_llm::model::{ApiType, LlmCall};
 use h_storage::query::{DimensionFilter, TimeRange, TurnsQuery};
 use h_storage::StorageBackend;
 use h_storage_duckdb::DuckDbBackend;
+
+/// Minimal `LlmCall` for write-path round-trip assertions. `tool_call_count`
+/// and `body_bytes_dropped` are set to distinct sentinels so a positional
+/// appender misalignment (writing one tail column into another) is caught.
+fn sample_call(id: &str, tool_call_count: u32, body_bytes_dropped: u64) -> LlmCall {
+    LlmCall {
+        source_id: "test".into(),
+        id: id.into(),
+        wire_api: "openai-chat",
+        model: "gpt-test".into(),
+        api_type: ApiType::Chat,
+        request_time: 1_000_000,
+        response_time: Some(1_000_500),
+        complete_time: Some(1_001_000),
+        request_path: "/v1/chat/completions".into(),
+        is_stream: false,
+        request_body: Some("{}".into()),
+        status_code: Some(200),
+        finish_reason: Some("stop".into()),
+        response_body: Some("{}".into()),
+        input_tokens: Some(10),
+        output_tokens: Some(20),
+        total_tokens: Some(30),
+        cache_read_input_tokens: None,
+        cache_creation_input_tokens: None,
+        ttft_ms: Some(5.0),
+        e2e_latency_ms: Some(10.0),
+        client_ip: IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        client_port: 1234,
+        server_ip: IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2)),
+        server_port: 443,
+        response_id: Some("resp-1".into()),
+        request_headers: vec![],
+        response_headers: vec![],
+        is_agent_request: false,
+        tool_surface: None,
+        agent_topology: None,
+        tool_call_count,
+        tool_names: vec![],
+        body_bytes_dropped,
+    }
+}
 
 /// Schema shape immediately before Phase 5 added the agent-classification
 /// columns to `llm_calls`. Used to drive the
@@ -62,6 +106,48 @@ CREATE TABLE llm_calls (
     response_id       VARCHAR,
     request_headers   VARCHAR,
     response_headers  VARCHAR
+);
+";
+
+/// Schema shape immediately before Phase 6 added `body_bytes_dropped` to
+/// `llm_calls` — i.e. the full v0.4.0 layout (agent columns present) but
+/// without the body-cap counter. Drives the
+/// `phase6_adds_body_bytes_dropped_*` test.
+const LEGACY_LLM_CALLS_PRE_PHASE6: &str = "
+CREATE TABLE llm_calls (
+    id                VARCHAR NOT NULL PRIMARY KEY,
+    source_id         VARCHAR NOT NULL DEFAULT '',
+    client_ip         VARCHAR NOT NULL,
+    client_port       USMALLINT NOT NULL,
+    server_ip         VARCHAR NOT NULL,
+    server_port       USMALLINT NOT NULL,
+    request_time      TIMESTAMP NOT NULL,
+    response_time     TIMESTAMP,
+    complete_time     TIMESTAMP,
+    wire_api          VARCHAR NOT NULL,
+    model             VARCHAR NOT NULL,
+    api_type          VARCHAR NOT NULL,
+    is_stream         BOOLEAN NOT NULL,
+    request_path      VARCHAR NOT NULL,
+    status_code       USMALLINT,
+    finish_reason     VARCHAR,
+    input_tokens      UINTEGER,
+    output_tokens     UINTEGER,
+    total_tokens      UINTEGER,
+    cache_read_input_tokens   UINTEGER,
+    cache_creation_input_tokens UINTEGER,
+    ttft_ms           DOUBLE,
+    e2e_latency_ms    DOUBLE,
+    request_body      VARCHAR,
+    response_body     VARCHAR,
+    response_id       VARCHAR,
+    request_headers   VARCHAR,
+    response_headers  VARCHAR,
+    is_agent_request  BOOLEAN  NOT NULL DEFAULT FALSE,
+    tool_surface      VARCHAR,
+    agent_topology    VARCHAR,
+    tool_call_count   UINTEGER NOT NULL DEFAULT 0,
+    tool_names_json   VARCHAR
 );
 ";
 
@@ -199,6 +285,75 @@ async fn phase5_adds_agent_not_null_columns_to_llm_calls_on_legacy_db() {
             "post-migration llm_calls must contain {expected}, got: {cols:?}"
         );
     }
+}
+
+// Phase-6 migration: `body_bytes_dropped` must be added to a legacy
+// (pre-Phase-6) `llm_calls`, AND the positional appender must keep writing
+// the right columns afterward. The ALTER appends the new column at the table
+// tail; the CREATE TABLE also places it last, so a fresh-vs-migrated DB share
+// one column order and the positional `append_row` stays aligned. This test
+// proves alignment end-to-end by writing distinct sentinels into the two
+// trailing NOT-NULL-with-default columns (`tool_call_count`,
+// `body_bytes_dropped`) and reading both back — exactly the "PR#48 class"
+// regression that a same-name-only assertion would miss.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn phase6_adds_body_bytes_dropped_and_appender_stays_aligned_on_legacy_db() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_LLM_CALLS_PRE_PHASE6]);
+
+    // Pre-condition: the body-cap counter is absent on the legacy DB.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_calls");
+        assert!(
+            !cols.iter().any(|c| c == "body_bytes_dropped"),
+            "synth pre-condition: body_bytes_dropped must be absent in pre-Phase-6 DB, got: {cols:?}"
+        );
+    }
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    // Column landed.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_calls");
+        assert!(
+            cols.iter().any(|c| c == "body_bytes_dropped"),
+            "post-migration llm_calls must contain body_bytes_dropped, got: {cols:?}"
+        );
+    }
+
+    // Write a call through the real appender into the just-migrated table and
+    // read both trailing columns back. Distinct sentinels (7 vs 4242) catch a
+    // positional swap.
+    backend
+        .write_calls(vec![sample_call("call-phase6", 7, 4242)])
+        .await
+        .expect("write_calls must succeed against a migrated table");
+
+    // Close the backend (checkpoints DuckDB to the file) before reading via a
+    // fresh connection — a second live connection sees the pre-write snapshot.
+    drop(backend);
+
+    let conn = Connection::open(&path).unwrap();
+    let (tool_call_count, body_bytes_dropped): (u32, u64) = conn
+        .query_row(
+            "SELECT tool_call_count, body_bytes_dropped FROM llm_calls WHERE id = 'call-phase6'",
+            [],
+            |r| Ok((r.get::<_, u32>(0)?, r.get::<_, u64>(1)?)),
+        )
+        .expect("row must be present after write_calls");
+    assert_eq!(
+        tool_call_count, 7,
+        "tool_call_count must round-trip (appender column alignment)"
+    );
+    assert_eq!(
+        body_bytes_dropped, 4242,
+        "body_bytes_dropped must round-trip into the migrated column (appender alignment)"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/h-storage/src/sink.rs
+++ b/server/h-storage/src/sink.rs
@@ -556,6 +556,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-turn/src/stage.rs
+++ b/server/h-turn/src/stage.rs
@@ -214,6 +214,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-turn/src/test_support.rs
+++ b/server/h-turn/src/test_support.rs
@@ -79,6 +79,7 @@ pub fn make_call(
         agent_topology: None,
         tool_call_count,
         tool_names: tool_names.iter().map(|s| s.to_string()).collect(),
+        body_bytes_dropped: 0,
     };
     let agent = AgentCallInfo {
         agent_kind: "test",

--- a/server/h-turn/src/tracker.rs
+++ b/server/h-turn/src/tracker.rs
@@ -1086,6 +1086,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 
@@ -1134,6 +1135,7 @@ mod tests {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-turn/tests/integration.rs
+++ b/server/h-turn/tests/integration.rs
@@ -106,6 +106,7 @@ async fn run_pcap_full_sharded(
         registry,
         &mut metrics_sys,
         h_llm::agent_classifier::ClassifierConfig::default(),
+        h_common::config::BodyCapConfig::default(),
     );
 
     h_turn::spawn_turn_stage(
@@ -236,6 +237,7 @@ async fn run_pcap_collecting_calls(
         registry,
         &mut metrics_sys,
         h_llm::agent_classifier::ClassifierConfig::default(),
+        h_common::config::BodyCapConfig::default(),
     );
 
     h_turn::spawn_turn_stage(
@@ -849,6 +851,7 @@ async fn generic_profile_anthropic_two_call_session() {
             agent_topology: None,
             tool_call_count: 0,
             tool_names: vec![],
+            body_bytes_dropped: 0,
         }
     }
 

--- a/server/h-turn/tests/reorder.rs
+++ b/server/h-turn/tests/reorder.rs
@@ -124,6 +124,7 @@ fn anthropic_call(
         agent_topology: None,
         tool_call_count: 0,
         tool_names: vec![],
+        body_bytes_dropped: 0,
     }
 }
 


### PR DESCRIPTION
Closes #68 (H007).

## Problem
Heron stores each call's full request/response body. With 2026-era 1M-token
contexts a single body is routinely multiple MB; the storage write buffer
batches ~1000 rows, so uncapped bodies are a real memory-pressure / stability
risk on capture nodes — and an observer that OOMs the host it watches breaks
Heron's non-intrusiveness guarantee.

## Approach — cap at the storage boundary, after extraction
A configurable head+tail sampling policy (`BodyCapConfig`): keep the first
`head_bytes` (model / params / system / tools / first messages) and the last
`tail_bytes` (final messages + the trailing `usage` block on non-streaming
responses), elide the middle, and record the dropped byte count in
`llm_calls.body_bytes_dropped`. A body within budget is stored verbatim.

**Why not in `BodyReader` (deviates from the issue's suggested approach):**
extraction parses the *full* body as JSON (`ParsedJson` / `serde_json`) to read
usage/model/agent primitives. A head+tail body with the middle elided is not
valid JSON, so capping before extraction would break usage extraction — which
the success criteria forbid, and the issue's tail-aware parser is explicitly
deferred. So the cap runs in `h-llm`'s `cap_body()` at the storage boundary,
*after* every extraction has seen the full body. This keeps usage/model 100%
accurate and bounds the dominant **sustained** consumer (the write buffer + DB
rows). Documented, with the transient-peak limitation, in
`docs/design/09-body-cap.md`.

## Changes
- **h-common**: `BodyCapConfig { enabled, head_bytes=256KiB, tail_bytes=64KiB }`
  + `[body_cap]` in `default.toml`; threaded through `AppConfig` two-phase parse.
- **h-llm**: `LlmCall.body_bytes_dropped`; `cap_body()` (UTF-8-boundary safe);
  `LlmProcessor::with_body_cap` wired `spawn_llm_stage` → `Pipeline::build` →
  `AppConfig.body_cap`.
- **h-storage-duckdb**: `llm_calls.body_bytes_dropped UBIGINT`; Phase-6 migration
  adds it **nullable-with-default** on `ALTER` (DuckDB rejects
  `ADD COLUMN NOT NULL DEFAULT` — same lesson as Phase 5); bound last in the
  positional appender (column sits at the table tail in both CREATE and ALTER).

## Design decisions (open questions in #68)
- **Symmetric cap** (same head/tail for request + response); config shaped so a
  separate response budget can be added later. *Override welcome.*
- **Fixed tail window** is assumed sufficient to hold the `usage` block on
  non-streaming responses; SSE usage arrives via the event path and is never
  capped. Tail-aware parsing remains deferred.

## Test plan
- `cargo test --workspace` — all green (incl. h-llm 389, h-storage-duckdb 95).
- `cap_body` unit tests: within-budget verbatim, oversized head+tail sampling,
  disabled, `None`, UTF-8 boundary snapping.
- `exchange_caps_huge_request_body_but_still_extracts_usage`: a >1MB request body
  is sampled (`body_bytes_dropped > 0`) yet wire `usage` extracts exactly — the
  #68 success criterion.
- `migrations.rs::phase6_…`: legacy (pre-Phase-6) DB → migrate → write via the
  real appender → read back two trailing sentinels, asserting column alignment.
- leakage lint: clean.

🤖 Implemented by **wiwi_pro** • issue author: @rivercg