### PR TITLE
feat(prod): gated auto-deploy to production (deploy-prod — quality-chain tail)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,57 @@
+name: deploy-prod
+
+# Promote a staging-soaked build to PRODUCTION. Gated two ways:
+#   1. a manual approval — the `production` GitHub Environment's required
+#      reviewers must approve before the job runs;
+#   2. a post-deploy health gate with automatic rollback (deploy-prod.sh).
+#
+# Chains after the staging pipeline:
+#   ci(main) → deploy-staging → staging-soak → [approval] → deploy-prod
+#
+# Security: runs ONLY on the `prod-deploy` self-hosted runner ON the prod host
+# and ONLY after a successful staging-soak (or manual dispatch). The label is
+# not shared with PR CI, so PR/fork code never reaches the prod host. The prod
+# checkout path comes from a repo Variable, never committed source.
+on:
+  workflow_run:
+    workflows: [staging-soak]
+    types: [completed]
+  # Manual lever: deploy a chosen commit (default origin/main) on demand.
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: commit to deploy (default origin/main)
+        required: false
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: [self-hosted, prod-deploy]
+    # Requires manual approval — the `production` environment is configured
+    # with required reviewers. GitHub pauses here until a reviewer approves.
+    environment: production
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: resolve commit to deploy
+        id: pick
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.sha }}" ]; then
+            sha="${{ github.event.inputs.sha }}"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            sha="${{ github.event.workflow_run.head_sha }}"
+          else
+            sha="origin/main"
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "deploying commit: $sha"
+
+      - name: deploy to prod + health gate (rollback on failure)
+        env:
+          HERON_PROD_REPO_DIR: ${{ vars.HERON_PROD_REPO_DIR }}
+        run: bash scripts/prod/deploy-prod.sh "${{ steps.pick.outputs.sha }}"

--- a/scripts/prod/README.md
+++ b/scripts/prod/README.md
@@ -53,6 +53,18 @@ PR CI, so PR/fork code never executes on the prod host. Same trust model as the
 - `deploy-prod.sh` env knobs: `HERON_PROD_SERVICE` (default `heron.service`),
   `HERON_PROD_PORT` (4500), `HEALTH_TIMEOUT_SECS` (120), `CARGO_BIN`.
 
+Unlike staging (which ships `scripts/staging/{config.toml,heron.service}`), the
+**prod config and systemd unit are provisioned on the host, not in this repo** —
+they hold host-specific paths/ports and live at `~/.config/heron/config.toml`
+and `/etc/systemd/system/heron.service` on the prod box. `deploy-prod.sh` only
+swaps the binary + restarts the existing unit; it never templates either file.
+The unit must grant capture caps via `AmbientCapabilities=CAP_NET_RAW
+CAP_NET_ADMIN` (so a rebuild needs no `setcap`) and set `Restart=on-failure`.
+
+> Health gate: requires `status=ready`; if a capture pipeline is configured it
+> must be `running`. An empty `pipelines` array (API-only / maintenance) is
+> treated as healthy rather than failing the deploy.
+
 ## Manual deploy / dispatch
 
 ```bash

--- a/scripts/prod/README.md
+++ b/scripts/prod/README.md
@@ -1,0 +1,64 @@
+# Production deploy
+
+Gated promotion of a staging-soaked build to **production** (the live heron on
+the prod host). This is the tail of the quality chain — everything upstream
+(CI → staging deploy → soak) has already validated the binary; this stage puts
+it on prod behind a human approval and an automatic health gate.
+
+## Chain
+
+```
+ci(main) → deploy-staging → staging-soak (tara)
+   │  all green
+   ▼
+deploy-prod.yml   (workflow_run on staging-soak success, OR manual dispatch)
+   │
+   ├─ runs on the `prod-deploy` self-hosted runner ON the prod host
+   ├─ environment: production  ──►  PAUSES for a required-reviewer approval
+   └─ deploy-prod.sh <sha>
+          ├─ git fetch + checkout the validated commit
+          ├─ snapshot the current binary (for rollback)
+          ├─ cargo build --release --features console   (warm-cache incremental)
+          ├─ smoke `heron --version`
+          ├─ sudo systemctl restart heron.service
+          ├─ health gate: status=ready AND pipeline running (≤120s)
+          └─ rollback to the snapshot + restart if the gate fails
+```
+
+The build happens BEFORE the service is touched, so a build failure leaves prod
+untouched. `heron.service` grants capture caps via `AmbientCapabilities`, so no
+`setcap` is ever needed.
+
+## Why a manual approval (not fully automatic)
+
+Prod captures real LLM-proxy traffic — a bigger blast radius than the staging
+VM. The synthetic-corpus soak (L7) can't see real-traffic shapes/volume, so
+until a shadow-canary stage (L8) validates the build against *live* traffic, a
+human approves the prod flip. Once the canary lands, the approval can relax to
+automatic (canary-green → promote).
+
+## The `prod-deploy` runner
+
+A self-hosted runner on the prod host (systemd service, runs as the deploy
+user). It is **only** used by `deploy-prod.yml` — its label is not shared with
+PR CI, so PR/fork code never executes on the prod host. Same trust model as the
+`staging-deploy` runner, but on the prod host because the deploy is local
+(build + `systemctl`), with no SSH/VM hop.
+
+## Config (no machine-specifics in source)
+
+- Repo Variable `HERON_PROD_REPO_DIR` — the persistent heron checkout on the
+  prod host (warm cargo cache). The workflow passes it to `deploy-prod.sh`;
+  the script requires it (no hardcoded path).
+- `deploy-prod.sh` env knobs: `HERON_PROD_SERVICE` (default `heron.service`),
+  `HERON_PROD_PORT` (4500), `HEALTH_TIMEOUT_SECS` (120), `CARGO_BIN`.
+
+## Manual deploy / dispatch
+
+```bash
+# On the prod host, deploy a specific commit (or origin/main):
+HERON_PROD_REPO_DIR=<checkout> scripts/prod/deploy-prod.sh <git-sha>
+
+# Or trigger the gated workflow (still requires the environment approval):
+gh workflow run deploy-prod.yml --repo Netis/heron -f sha=<git-sha>
+```

--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -70,10 +70,15 @@ echo "==> health gate (<= ${HEALTH_TIMEOUT_SECS}s): status=ready AND pipeline ru
 deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SECS ))
 ok=0
 while [ "$(date +%s)" -lt "$deadline" ]; do
+  # status must be ready, and IF a capture pipeline is configured it must be
+  # running. Empty `pipelines` (API-only / maintenance) → treat as healthy
+  # (the process is up; there is nothing to supervise) rather than IndexError-
+  # crashing into a false rollback of a healthy deploy.
   res="$(curl -s -m 5 "http://127.0.0.1:${PORT}/api/health" 2>/dev/null \
         | python3 -c 'import json,sys
 try:
-    d=json.load(sys.stdin)["data"]; print(d["status"]+"|"+str(d["pipelines"][0]["running"]).lower())
+    d=json.load(sys.stdin)["data"]; pl=d.get("pipelines") or []
+    print(d["status"]+"|"+str(pl[0]["running"] if pl else True).lower())
 except Exception: print("|")' 2>/dev/null || echo "|")"
   if [ "${res%%|*}" = "ready" ] && [ "${res##*|}" = "true" ]; then ok=1; break; fi
   sleep 5

--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Deploy heron to PRODUCTION and gate on health, rolling back on failure.
+#
+# Runs on the `prod-deploy` self-hosted runner ON the prod host, so the deploy
+# is LOCAL (build + systemctl restart) — no SSH/VM hop. It is pinned to a
+# specific commit (the one that passed staging-soak) so prod gets exactly the
+# validated source, and it builds in the PERSISTENT checkout (warm cargo cache
+# → incremental, fast) rather than a fresh runner workspace.
+#
+# Safety:
+#   - builds BEFORE touching the running service, so a build failure leaves
+#     prod untouched;
+#   - snapshots the current binary first and rolls back + restarts if the
+#     post-restart health gate fails;
+#   - heron.service grants capture caps via AmbientCapabilities, so no setcap.
+#
+# Usage:
+#   deploy-prod.sh [<git-sha>]        (default: origin/main HEAD)
+#
+# Env:
+#   HERON_PROD_REPO_DIR  REQUIRED  persistent heron checkout (warm cargo cache)
+#   HERON_PROD_SERVICE   systemd unit             (default: heron.service)
+#   HERON_PROD_PORT      heron API port           (default: 4500)
+#   HEALTH_TIMEOUT_SECS  health-gate budget secs  (default: 120)
+#   CARGO_BIN            cargo path               (default: ~/.cargo/bin/cargo)
+#
+# Exit: 0 = deployed + healthy; non-zero = failed (rolled back if possible).
+set -euo pipefail
+
+SHA="${1:-origin/main}"
+REPO="${HERON_PROD_REPO_DIR:?set HERON_PROD_REPO_DIR (persistent heron checkout on the prod host)}"
+SERVICE="${HERON_PROD_SERVICE:-heron.service}"
+PORT="${HERON_PROD_PORT:-4500}"
+HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-120}"
+CARGO="${CARGO_BIN:-$HOME/.cargo/bin/cargo}"
+
+[ -d "$REPO/.git" ] || { echo "::error::HERON_PROD_REPO_DIR not a git checkout: $REPO" >&2; exit 1; }
+[ -x "$CARGO" ] || { echo "::error::cargo not executable at $CARGO" >&2; exit 1; }
+cd "$REPO"
+
+BIN="$REPO/server/target/release/heron"
+BAK="$BIN.rollback"
+
+echo "==> fetch + checkout $SHA"
+git fetch origin --quiet
+git checkout --quiet "$SHA"
+echo "    HEAD: $(git log --oneline -1)"
+
+# Snapshot the currently-running binary BEFORE the build overwrites it in place.
+if [ -x "$BIN" ]; then
+  echo "==> snapshotting current binary → $(basename "$BAK")"
+  cp -fp "$BIN" "$BAK"
+  HAVE_BAK=1
+else
+  echo "    (no existing binary to back up — first deploy)"
+  HAVE_BAK=0
+fi
+
+echo "==> build (release + console, incremental — MUST pass --features console)"
+( cd server && "$CARGO" build --release --bin heron --features console )
+[ -x "$BIN" ] || { echo "::error::build produced no binary at $BIN" >&2; exit 1; }
+
+echo "==> smoke: heron --version"
+"$BIN" --version || { echo "::error::freshly built binary does not run" >&2; exit 1; }
+
+echo "==> restarting $SERVICE"
+sudo systemctl restart "$SERVICE"
+
+echo "==> health gate (<= ${HEALTH_TIMEOUT_SECS}s): status=ready AND pipeline running"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SECS ))
+ok=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  res="$(curl -s -m 5 "http://127.0.0.1:${PORT}/api/health" 2>/dev/null \
+        | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)["data"]; print(d["status"]+"|"+str(d["pipelines"][0]["running"]).lower())
+except Exception: print("|")' 2>/dev/null || echo "|")"
+  if [ "${res%%|*}" = "ready" ] && [ "${res##*|}" = "true" ]; then ok=1; break; fi
+  sleep 5
+done
+
+if [ "$ok" = 1 ]; then
+  echo "==> OK prod heron healthy on :${PORT} (status=ready, capturing)"
+  rm -f "$BAK"
+  exit 0
+fi
+
+echo "::error::health gate FAILED after ${HEALTH_TIMEOUT_SECS}s" >&2
+if [ "$HAVE_BAK" = 1 ]; then
+  echo "==> rolling back to the previous binary + restarting"
+  cp -fp "$BAK" "$BIN"
+  sudo systemctl restart "$SERVICE"
+  sleep 5
+  rb="$(curl -s -m 5 "http://127.0.0.1:${PORT}/api/health" 2>/dev/null | python3 -c 'import json,sys
+try: print(json.load(sys.stdin)["data"]["status"])
+except Exception: print("?")' 2>/dev/null || echo "?")"
+  echo "    rollback health: status=$rb"
+  rm -f "$BAK"
+else
+  echo "::error::no rollback binary available (first deploy)" >&2
+fi
+exit 1


### PR DESCRIPTION
Closes the CD loop. After the staging pipeline is green, promote the validated
build to **prod** behind a human approval + an automatic health gate with
rollback.

```
ci(main) → deploy-staging → staging-soak → [approval] → deploy-prod
```

## Pieces
| File | Role |
|---|---|
| `scripts/prod/deploy-prod.sh` | LOCAL prod deploy: fetch+checkout validated SHA → snapshot binary → build `--features console` (warm-cache incremental) → smoke → restart `heron.service` → health-gate (ready+capturing ≤120s) → rollback on failure |
| `.github/workflows/deploy-prod.yml` | `workflow_run` after staging-soak success (+ dispatch); runs on `prod-deploy` runner ON the prod host; `environment: production` approval gate |
| `scripts/prod/README.md` | chain, approval rationale, runner trust model |

## Safety
- Builds **before** touching the service → a build failure leaves prod untouched.
- Snapshots the running binary → rolls back + restarts if the health gate fails.
- No `setcap` (heron.service grants caps via `AmbientCapabilities`).
- `environment: production` with a required reviewer → GitHub **pauses for
  manual approval** before any prod change.
- `prod-deploy` runner label is not shared with PR CI → PR/fork code never
  runs on the prod host (same trust model as `staging-deploy`).
- No machine-specifics in source: prod checkout path is repo Variable
  `HERON_PROD_REPO_DIR`; the script requires it via env (no hardcoded path).

## Why manual approval (not fully auto)
Prod captures real LLM-proxy traffic the synthetic soak can't see. The approval
stands in for the not-yet-built shadow canary (L8); once the canary validates
against live traffic, the approval can relax to automatic.

## Validation
`deploy-prod.sh` run end-to-end on the prod host: checkout → incremental build
(16s) → smoke → restart → health gate `ready`+capturing → exit 0, rollback
binary staged then cleared. Leakage linter clean.