### PR TITLE
feat(capture): pcap-file loop/duration replay mode (load-soak primitive)

### DIFF
--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -104,6 +104,8 @@ export function defaultFor(type: CaptureSource["type"]): CaptureSource {
     path: "",
     realtime: false,
     source_id: null,
+    loop_count: 1,
+    loop_secs: 0,
   }
 }
 

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -621,6 +621,11 @@ export type CaptureSource =
       path: string
       realtime: boolean
       source_id: string | null
+      // Loop/duration replay (load-soak primitive). Mirror of the Rust
+      // CaptureSourceConfig::PcapFile fields; serde defaults loop_count=1
+      // (single pass) / loop_secs=0 (disabled) so older configs still parse.
+      loop_count: number
+      loop_secs: number
     }
   | {
       type: "cloud-probe"

--- a/server/app/heron/src/main.rs
+++ b/server/app/heron/src/main.rs
@@ -277,6 +277,8 @@ async fn run_pipeline(cli: Cli) {
                 path: pcap_file.to_string_lossy().to_string(),
                 realtime: false,
                 source_id: None,
+                loop_count: 1,
+                loop_secs: 0,
             }],
             ..PipelineDef::default()
         }]

--- a/server/app/heron/tests/pipeline_e2e.rs
+++ b/server/app/heron/tests/pipeline_e2e.rs
@@ -79,6 +79,8 @@ async fn run_pipeline_multi(fixture_names: &[&str]) -> Option<(TempDir, PathBuf)
                 path: p.to_string_lossy().to_string(),
                 realtime: false,
                 source_id: None,
+                loop_count: 1,
+                loop_secs: 0,
             }],
             ..PipelineDef::default()
         })

--- a/server/h-capture/src/factory.rs
+++ b/server/h-capture/src/factory.rs
@@ -33,7 +33,11 @@ pub fn build_source(
             )))
         }
         CaptureSourceConfig::PcapFile {
-            path, source_id, ..
+            path,
+            source_id,
+            loop_count,
+            loop_secs,
+            ..
         } => {
             let sid = source_id.clone().unwrap_or_else(|| {
                 std::path::Path::new(path)
@@ -42,7 +46,10 @@ pub fn build_source(
                     .unwrap_or(path)
                     .to_string()
             });
-            Ok(Box::new(PcapFileSource::new(path.into(), sid, pcap_dump)))
+            Ok(Box::new(
+                PcapFileSource::new(path.into(), sid, pcap_dump)
+                    .with_loop(*loop_count, *loop_secs),
+            ))
         }
         CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => Ok(Box::new(
             CloudProbeSource::new(endpoint.clone(), *recv_hwm, pcap_dump),
@@ -60,6 +67,8 @@ mod tests {
             path: "/tmp/test.pcap".to_string(),
             realtime: false,
             source_id: None,
+            loop_count: 1,
+            loop_secs: 0,
         };
         assert!(build_source(&config, None).is_ok());
     }

--- a/server/h-capture/src/pcap_file.rs
+++ b/server/h-capture/src/pcap_file.rs
@@ -13,11 +13,22 @@ use crate::pcap_dump::{PacketDumper, PacketDumperConfig};
 use crate::routing::RoutingSender;
 use crate::source::CaptureSource;
 
+/// Gap (µs) inserted between loop iterations' timestamps so that flows from a
+/// prior pass exceed the protocol layer's flow-idle timeout (120 s in
+/// `h-protocol`) and get reaped — keeping the flow table bounded across a long
+/// soak. 5 min > 120 s with margin.
+const LOOP_GAP_US: i64 = 300_000_000;
+
 /// Reads packets from a pcap file on a blocking thread.
 pub struct PcapFileSource {
     path: PathBuf,
     source_id: String,
     dump_cfg: Option<PacketDumperConfig>,
+    /// Replay the file this many times (default 1). >1 enables loop mode.
+    loop_count: u32,
+    /// Replay until this many seconds elapse (0 = disabled). Takes precedence
+    /// over `loop_count` when > 0.
+    loop_secs: u64,
 }
 
 impl PcapFileSource {
@@ -26,7 +37,20 @@ impl PcapFileSource {
             path,
             source_id,
             dump_cfg,
+            loop_count: 1,
+            loop_secs: 0,
         }
+    }
+
+    /// Enable loop/duration replay (for the load/longevity soak). Each pass is
+    /// tagged with a fresh per-iteration source_id so its flows are distinct
+    /// (driving real full-pipeline + storage load, not deduped retransmits),
+    /// and its timestamps are offset so prior-pass flows time out → the flow
+    /// table stays bounded. `loop_count` is clamped to ≥ 1.
+    pub fn with_loop(mut self, loop_count: u32, loop_secs: u64) -> Self {
+        self.loop_count = loop_count.max(1);
+        self.loop_secs = loop_secs;
+        self
     }
 }
 
@@ -42,6 +66,9 @@ impl CaptureSource for PcapFileSource {
         let source_id = self.source_id.clone();
         let dump_cfg = self.dump_cfg.clone();
         let dumper_metrics = metrics.clone();
+        let loop_count = self.loop_count.max(1);
+        let loop_secs = self.loop_secs;
+        let looping = loop_secs > 0 || loop_count > 1;
 
         // Run pcap reading on a blocking thread since next_packet() is blocking.
         let result = tokio::task::spawn_blocking(move || -> crate::Result<()> {
@@ -52,70 +79,117 @@ impl CaptureSource for PcapFileSource {
                     None
                 }
             });
-            let mut cap = Capture::from_file(&path)?;
-            let link_type = cap.get_datalink().0 as u32;
 
-            tracing::info!(
-                "pcap-file: opened {} (link_type={})",
-                path.display(),
-                link_type
-            );
-
+            let start = std::time::Instant::now();
             let mut count: u64 = 0;
-            loop {
-                if cancel.is_cancelled() {
-                    tracing::debug!("pcap-file: cancellation requested, stopping");
-                    break;
+            let mut iter: u64 = 0;
+            // Span of the first pass, used to space later passes apart in time.
+            let mut min_ts: i64 = i64::MAX;
+            let mut max_ts: i64 = i64::MIN;
+
+            // Outer loop = one replay pass of the whole file.
+            'replay: loop {
+                // Fresh per-pass source_id when looping → distinct flows (not
+                // deduped as retransmits). Single pass keeps the base id, so
+                // non-loop behavior (and stored source_id) is unchanged.
+                let pass_source_id = if looping {
+                    format!("{source_id}-{iter}")
+                } else {
+                    source_id.clone()
+                };
+                // Monotonic offset so a prior pass's flows age out of the flow
+                // table. min/max are known after pass 0; pass 0 itself = no
+                // offset.
+                let offset = if iter == 0 || max_ts < min_ts {
+                    0
+                } else {
+                    (max_ts - min_ts + LOOP_GAP_US).saturating_mul(iter as i64)
+                };
+
+                let mut cap = Capture::from_file(&path)?;
+                let link_type = cap.get_datalink().0 as u32;
+                if iter == 0 {
+                    tracing::info!(
+                        "pcap-file: opened {} (link_type={}{})",
+                        path.display(),
+                        link_type,
+                        if looping {
+                            format!(", loop_count={loop_count} loop_secs={loop_secs}")
+                        } else {
+                            String::new()
+                        }
+                    );
                 }
 
-                match cap.next_packet() {
-                    Ok(packet) => {
-                        let ts = packet.header.ts;
-                        let timestamp_us = ts.tv_sec as i64 * 1_000_000 + ts.tv_usec as i64;
+                loop {
+                    if cancel.is_cancelled() {
+                        tracing::debug!("pcap-file: cancellation requested, stopping");
+                        break 'replay;
+                    }
 
-                        let raw = RawPacket {
-                            timestamp_us,
-                            caplen: packet.header.caplen,
-                            wirelen: packet.header.len,
-                            link_type,
-                            data: Bytes::copy_from_slice(packet.data),
-                            source_id: source_id.clone(),
-                        };
+                    match cap.next_packet() {
+                        Ok(packet) => {
+                            let ts = packet.header.ts;
+                            let raw_ts = ts.tv_sec as i64 * 1_000_000 + ts.tv_usec as i64;
+                            if iter == 0 {
+                                min_ts = min_ts.min(raw_ts);
+                                max_ts = max_ts.max(raw_ts);
+                            }
 
-                        if let Some(d) = dumper.as_mut() {
-                            d.write(&raw);
+                            let raw = RawPacket {
+                                timestamp_us: raw_ts.saturating_add(offset),
+                                caplen: packet.header.caplen,
+                                wirelen: packet.header.len,
+                                link_type,
+                                data: Bytes::copy_from_slice(packet.data),
+                                source_id: pass_source_id.clone(),
+                            };
+
+                            if let Some(d) = dumper.as_mut() {
+                                d.write(&raw);
+                            }
+
+                            // If the receiver is gone, stop reading.
+                            if tx.blocking_send(raw).is_err() {
+                                tracing::debug!("pcap-file: channel closed, stopping");
+                                break 'replay;
+                            }
+
+                            count += 1;
+                            metrics.counter(Metric::CapturePacketsReceived).add(1);
+                            // Mirror pcap_live's truncation surfacing so that
+                            // replaying a snaplen-truncated dump shows the same
+                            // signal — not a silent re-emergence of the bug.
+                            if packet.header.caplen < packet.header.len {
+                                metrics.counter(Metric::CaptureTruncatedPackets).inc();
+                            }
                         }
-
-                        // If the receiver is gone, stop reading.
-                        if tx.blocking_send(raw).is_err() {
-                            tracing::debug!("pcap-file: channel closed, stopping");
+                        Err(pcap::Error::NoMorePackets) => {
+                            // End of THIS pass.
                             break;
                         }
-
-                        count += 1;
-                        metrics.counter(Metric::CapturePacketsReceived).add(1);
-                        // Mirror pcap_live's truncation surfacing so that
-                        // replaying a snaplen-truncated dump shows the same
-                        // signal — not a silent re-emergence of the bug.
-                        if packet.header.caplen < packet.header.len {
-                            metrics.counter(Metric::CaptureTruncatedPackets).inc();
+                        Err(e) => {
+                            tracing::error!("pcap-file: read error: {e}");
+                            return Err(e.into());
                         }
                     }
-                    Err(pcap::Error::NoMorePackets) => {
-                        tracing::debug!("pcap-file: end of file reached");
+                }
+
+                iter += 1;
+                // Termination: duration takes precedence over count.
+                if loop_secs > 0 {
+                    if start.elapsed().as_secs() >= loop_secs {
                         break;
                     }
-                    Err(e) => {
-                        tracing::error!("pcap-file: read error: {e}");
-                        return Err(e.into());
-                    }
+                } else if iter >= loop_count as u64 {
+                    break;
                 }
             }
 
             if let Some(d) = dumper.as_mut() {
                 d.flush_all();
             }
-            tracing::info!("pcap-file: finished reading {} packets", count);
+            tracing::info!("pcap-file: finished reading {count} packets over {iter} pass(es)");
             Ok(())
         })
         .await;
@@ -277,5 +351,89 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 3, "should have received 3 packets");
+    }
+
+    #[tokio::test]
+    async fn test_single_pass_keeps_base_source_id() {
+        // No loop → original source_id is preserved (backward compatible).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("single.pcap");
+        std::fs::write(&path, build_pcap_file(2)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let source = PcapFileSource::new(path, "base".to_string(), None);
+        Box::new(source)
+            .run(RoutingSender::single(tx), test_metrics(), cancel)
+            .await
+            .unwrap();
+
+        let mut sids = std::collections::BTreeSet::new();
+        while let Ok(pkt) = rx.try_recv() {
+            sids.insert(pkt.source_id);
+        }
+        assert_eq!(sids.into_iter().collect::<Vec<_>>(), vec!["base".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_loop_mode_emits_fresh_flows_per_pass() {
+        // Replay a 3-packet file 3× → 9 packets, each pass tagged with a
+        // distinct source_id ("base-0/1/2") so downstream sees FRESH flows
+        // (FlowKey is keyed by source_id), and timestamps are monotonic across
+        // passes so prior-pass flows age out.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loop.pcap");
+        std::fs::write(&path, build_pcap_file(3)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let source = PcapFileSource::new(path, "base".to_string(), None).with_loop(3, 0);
+        let result = Box::new(source)
+            .run(RoutingSender::single(tx), test_metrics(), cancel)
+            .await;
+        assert!(result.is_ok());
+
+        // Group received packets by source_id.
+        let mut by_sid: std::collections::BTreeMap<String, Vec<i64>> = Default::default();
+        while let Ok(pkt) = rx.try_recv() {
+            by_sid.entry(pkt.source_id.clone()).or_default().push(pkt.timestamp_us);
+        }
+        assert_eq!(
+            by_sid.keys().cloned().collect::<Vec<_>>(),
+            vec!["base-0".to_string(), "base-1".to_string(), "base-2".to_string()],
+            "expected 3 distinct per-pass source_ids"
+        );
+        for (sid, ts) in &by_sid {
+            assert_eq!(ts.len(), 3, "pass {sid} should have 3 packets");
+        }
+        // Monotonic across passes: pass 1 starts strictly after pass 0 ends.
+        let max0 = *by_sid["base-0"].iter().max().unwrap();
+        let min1 = *by_sid["base-1"].iter().min().unwrap();
+        assert!(min1 > max0, "pass 1 timestamps must start after pass 0 ends");
+    }
+
+    #[tokio::test]
+    async fn test_loop_secs_zero_count_one_is_single_pass() {
+        // with_loop(1, 0) must behave exactly like no loop (single pass, base id).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noloop.pcap");
+        std::fs::write(&path, build_pcap_file(4)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let source = PcapFileSource::new(path, "base".to_string(), None).with_loop(1, 0);
+        Box::new(source)
+            .run(RoutingSender::single(tx), test_metrics(), cancel)
+            .await
+            .unwrap();
+
+        let mut count = 0;
+        let mut sids = std::collections::BTreeSet::new();
+        while let Ok(pkt) = rx.try_recv() {
+            count += 1;
+            sids.insert(pkt.source_id);
+        }
+        assert_eq!(count, 4);
+        assert_eq!(sids.into_iter().collect::<Vec<_>>(), vec!["base".to_string()]);
     }
 }

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -275,6 +275,19 @@ pub enum CaptureSourceConfig {
         realtime: bool,
         #[serde(default)]
         source_id: Option<String>,
+        /// Replay the file this many times back-to-back (default 1 = single
+        /// pass, today's behavior). Each pass is tagged with a fresh
+        /// per-iteration source_id so its flows are distinct (not deduped as
+        /// retransmits) — this is what lets the load soak drive sustained
+        /// full-pipeline + storage traffic from one corpus. Ignored when
+        /// `loop_secs` > 0.
+        #[serde(default = "default_loop_count")]
+        loop_count: u32,
+        /// Replay in a loop until this many seconds have elapsed (0 = disabled
+        /// → use `loop_count`). Takes precedence over `loop_count`. Used by the
+        /// duration-bounded load/longevity soak.
+        #[serde(default)]
+        loop_secs: u64,
     },
     CloudProbe {
         #[serde(default = "default_cloud_probe_endpoint")]
@@ -312,6 +325,10 @@ impl CaptureSourceConfig {
 
 fn default_interface() -> String {
     "eth0".to_string()
+}
+
+fn default_loop_count() -> u32 {
+    1
 }
 
 fn default_snaplen() -> u32 {
@@ -1273,6 +1290,8 @@ mod phase2_tests {
             path: "/data/captures/test.pcap".to_string(),
             realtime: false,
             source_id: None,
+            loop_count: 1,
+            loop_secs: 0,
         };
         assert_eq!(pcap_file.resolved_source_id(), Some("test".to_string()));
 

--- a/server/h-common/src/config_edit.rs
+++ b/server/h-common/src/config_edit.rs
@@ -107,12 +107,22 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
             path,
             realtime,
             source_id,
+            loop_count,
+            loop_secs,
         } => {
             t["type"] = value("pcap-file");
             t["path"] = value(path.as_str());
             t["realtime"] = value(*realtime);
             if let Some(id) = source_id {
                 t["source_id"] = value(id.as_str());
+            }
+            // Loop/duration replay knobs are soak-only — emit them only when
+            // non-default so a normal capture source's TOML stays clean.
+            if *loop_count != 1 {
+                t["loop_count"] = value(i64::from(*loop_count));
+            }
+            if *loop_secs != 0 {
+                t["loop_secs"] = value(*loop_secs as i64);
             }
         }
         CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => {


### PR DESCRIPTION
The foundational primitive for the perf/reliability test suite (plan PR1-PR4):
gives `PcapFileSource` sustained-load replay so the upcoming tara load+memory
soak and nightly longevity soak can drive realistic traffic from one bounded
corpus — no NIC, no tcpreplay.

## What
- `loop_count` (replay N times) / `loop_secs` (replay until T seconds elapse)
  on the `PcapFile` source config variant. **Default-off** (`loop_count=1` =
  today's single-pass behavior); serde-default so existing configs are
  unchanged. Builder `with_loop()` keeps `PcapFileSource::new()` 3-arg
  backward-compatible.
- Each pass gets a **fresh per-iteration `source_id`** (`{base}-{iter}`) → its
  flows are DISTINCT. Because `FlowKey` is keyed by `source_id`
  (`h-protocol/src/tcp.rs`), looped traffic drives the **full pipeline + real
  DuckDB writes** instead of being deduped as retransmits.
- Per-pass **timestamps offset monotonically** (pass-0 span + 5-min gap) so
  prior-pass flows exceed the 120 s flow-idle timeout and get reaped → the flow
  table stays **bounded** across a long soak.

## Why this design
pcap-file (not tcpreplay) was the chosen load driver — deterministic, no NIC,
no caps. The only thing it lacked was sustained/fresh-flow load; this adds it
at the source. (Consciously out of scope: the AF_PACKET kernel-drop path, which
needs live capture — documented in the plan.)

## Tests (`cargo test -p h-capture` → 75 pass on wuneng)
- `test_loop_mode_emits_fresh_flows_per_pass` — 3×3 replay yields 3 distinct
  per-pass source_ids, 3 pkts each, monotonic timestamps across passes.
- `test_single_pass_keeps_base_source_id` / `test_loop_secs_zero_count_one_is_single_pass`
  — no-loop and `with_loop(1,0)` preserve the base source_id (backward compat).
- Full workspace `--tests` build green (5 direct `PcapFile{}` construction
  sites updated).