### PR TITLE
feat(mara): confirm-debounce — a deploy/restart blip no longer files a phantom incident

### DIFF
--- a/scripts/agent-bot/mara.README.md
+++ b/scripts/agent-bot/mara.README.md
@@ -68,10 +68,28 @@ journalctl -u mara.service -f      # watch polls
 | `MARA_REPO` | `Netis/heron` | repo to file into |
 | `MARA_LABELS` | `mara,incident` | issue labels |
 | `MARA_DEDUP_SECS` | `21600` | refile suppression window |
+| `MARA_CONFIRM_POLLS` | `3` | polls that must ALL fail before filing (`1` = off) |
+| `MARA_CONFIRM_DELAY_SECS` | `10` | seconds between confirm polls |
 | `MARA_DRY_RUN` | `0` | `1` → print instead of filing (no token needed) |
+
+## Confirm-debounce (no phantom incidents on deploy)
+
+A single failed poll is **not** filed on its own. A prod deploy restarts heron —
+`/api/health` is briefly unreachable, and the pipeline reads `running=false`
+until capture resumes (observed ~10 s) — which is indistinguishable from a
+one-off network hiccup. So on a failure mara re-polls `MARA_CONFIRM_POLLS`
+times; if **any** poll recovers, the hit was transient and nothing is filed.
+Only an all-polls-failed run opens an incident (the issue records
+`failed N/N consecutive polls`). Defaults (3 polls × 10 s) span ~20 s, covering
+the observed restart window. This is a *reducing* filter, not airtight: an
+unusually long restart could still straddle every poll — pair with a
+deploy-time maintenance-window sentinel if that ever bites.
+
+Tested by `tests/test_mara.py` (stdlib-only stub-server integration:
+transient-recovers→no-file, all-fail→file, off-switch).
 
 ## Status
 
-v1 = health-based DOWN/PARKED detection + scrubbed context + dedup. Not yet:
-a `/api/ops/heartbeat` push side, metric-regression detection, or the `/ops`
-dashboard — see the quality-infra plan.
+v1 = health-based DOWN/PARKED detection + scrubbed context + dedup +
+confirm-debounce. Not yet: a `/api/ops/heartbeat` push side, metric-regression
+detection, or the `/ops` dashboard — see the quality-infra plan.

--- a/scripts/agent-bot/mara.sh
+++ b/scripts/agent-bot/mara.sh
@@ -24,8 +24,18 @@
 #   MARA_LABELS       issue labels (comma-sep)             (default mara,incident)
 #   MARA_STATE_DIR    dedup state dir                      (default $HOME/.mara)
 #   MARA_DEDUP_SECS   don't refile same signature within   (default 21600 = 6h)
+#   MARA_CONFIRM_POLLS    polls that must ALL fail to file (default 3, 1=off)
+#   MARA_CONFIRM_DELAY_SECS  seconds between confirm polls  (default 10)
 #   MARA_DRY_RUN      "1" → print the issue instead of filing (needs no token)
 #   GH_TOKEN          PAT for `gh` (from the unit's EnvironmentFile) unless dry-run
+#
+# A single failed poll is NOT filed on its own: a prod deploy restarts heron
+# (health is briefly down, and the pipeline reads running=false until capture
+# resumes — observed ~10 s), and a one-off network hiccup looks identical. mara
+# re-polls and only files when EVERY poll fails, so a deploy/restart blip never
+# opens a phantom incident. (For an airtight deploy guard, pair with a
+# maintenance-window sentinel — A reduces but can't fully eliminate the window
+# for an unusually long restart.)
 set -uo pipefail
 
 HEALTH_URL="${MARA_HEALTH_URL:?set MARA_HEALTH_URL}"
@@ -35,6 +45,8 @@ REPO="${MARA_REPO:-Netis/heron}"
 LABELS="${MARA_LABELS:-mara,incident}"
 STATE_DIR="${MARA_STATE_DIR:-$HOME/.mara}"
 DEDUP_SECS="${MARA_DEDUP_SECS:-21600}"
+CONFIRM_POLLS="${MARA_CONFIRM_POLLS:-3}"
+CONFIRM_DELAY="${MARA_CONFIRM_DELAY_SECS:-10}"
 DRY_RUN="${MARA_DRY_RUN:-0}"
 GH_BIN="${GH_BIN:-$(command -v gh || echo "$HOME/bin/gh")}"
 
@@ -67,33 +79,59 @@ scrub() {
 }
 
 # ---- probe health -------------------------------------------------------
-hbody="$(curl -s -m 8 -w '\n%{http_code}' "$HEALTH_URL" 2>/dev/null || printf '\n000')"
-code="${hbody##*$'\n'}"
-json="${hbody%$'\n'*}"
-
-signature=""
-summary=""
-if [ "$code" != "200" ]; then
-  signature="prod-heron-down"
-  summary="heron /api/health unreachable or non-200 (HTTP ${code})"
-else
-  running="$(printf '%s' "$json" | python3 -c 'import sys,json
+# One health probe. Sets globals: code, json, signature, summary.
+# Empty `signature` = healthy.
+probe_once() {
+  local hbody running
+  hbody="$(curl -s -m 8 -w '\n%{http_code}' "$HEALTH_URL" 2>/dev/null || printf '\n000')"
+  code="${hbody##*$'\n'}"
+  json="${hbody%$'\n'*}"
+  signature=""
+  summary=""
+  if [ "$code" != "200" ]; then
+    signature="prod-heron-down"
+    summary="heron /api/health unreachable or non-200 (HTTP ${code})"
+  else
+    running="$(printf '%s' "$json" | python3 -c 'import sys,json
 try:
     d=json.load(sys.stdin)["data"]; print(str(d["pipelines"][0]["running"]).lower())
 except Exception: print("parseerror")' 2>/dev/null)"
-  if [ "$running" = "false" ]; then
-    signature="prod-heron-parked"
-    summary="heron is up (health=ready) but the pipeline has stopped (running=false) — capture silently halted"
-  elif [ "$running" = "parseerror" ]; then
-    signature="prod-heron-healthbad"
-    summary="heron /api/health returned 200 but an unparseable body"
+    if [ "$running" = "false" ]; then
+      signature="prod-heron-parked"
+      summary="heron is up (health=ready) but the pipeline has stopped (running=false) — capture silently halted"
+    elif [ "$running" = "parseerror" ]; then
+      signature="prod-heron-healthbad"
+      summary="heron /api/health returned 200 but an unparseable body"
+    fi
   fi
-fi
+}
 
+probe_once
 if [ -z "$signature" ]; then
   echo "mara: prod heron OK (HTTP $code, pipeline running) — no incident"
   exit 0
 fi
+
+# ---- confirm the failure is SUSTAINED, not a transient blip -------------
+# Re-poll up to MARA_CONFIRM_POLLS times; if ANY confirmation comes back
+# healthy, the first hit was transient (deploy/restart window, one-off network
+# hiccup) → do NOT file. Only a failure on EVERY poll is reported, using the
+# freshest snapshot. CONFIRM_POLLS=1 disables this (file on first failure).
+first_sig="$signature"
+n=1
+while [ "$n" -lt "$CONFIRM_POLLS" ]; do
+  sleep "$CONFIRM_DELAY"
+  n=$((n + 1))
+  probe_once
+  if [ -z "$signature" ]; then
+    echo "mara: '$first_sig' cleared on confirm poll $n/$CONFIRM_POLLS — transient (likely a deploy/restart blip), not filing"
+    exit 0
+  fi
+  echo "mara: failure persists on confirm poll $n/$CONFIRM_POLLS (signature=$signature)" >&2
+done
+# Confirmed sustained. Refresh `now` so dedup/SEEN reflect confirm time, not the
+# first probe (the confirm polls added a few seconds).
+now=$(date +%s)
 
 # ---- dedup: skip if filed within the window ----------------------------
 last="$(awk -F'\t' -v s="$signature" '$1==s{print $2}' "$SEEN" | tail -1)"
@@ -120,6 +158,7 @@ body="$(cat <<EOF
 - **Health URL**: ${HEALTH_URL}
 - **HTTP**: ${code}
 - **Observed (UTC)**: ${stamp}
+- **Confirmed**: failed ${CONFIRM_POLLS}/${CONFIRM_POLLS} consecutive polls (~${CONFIRM_DELAY}s apart) — not a transient/deploy blip
 
 ### Health response
 \`\`\`json

--- a/scripts/agent-bot/tests/test_mara.py
+++ b/scripts/agent-bot/tests/test_mara.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Integration test for mara.sh's confirm-debounce (option A) — stdlib only, so
+CI can run it without installing anything:
+
+    python3 scripts/agent-bot/tests/test_mara.py
+
+Spins up a stub `/api/health` server whose responses follow a per-test script
+(one entry per request; the last entry repeats once the script is exhausted),
+then runs mara.sh in DRY_RUN with CONFIRM_DELAY=0 and asserts whether it would
+file. The point under test: a single failed poll that recovers on a later poll
+(a deploy/restart blip) must NOT open an incident; only an all-polls-failed
+run does.
+
+Exit 0 = all pass, 1 = a failure.
+"""
+import http.server
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MARA = os.path.join(os.path.dirname(HERE), "mara.sh")
+
+# Response script the handler walks through. Each entry is one of:
+#   {"code": 503}                      → down (non-200)
+#   {"code": 200, "running": True}     → healthy
+#   {"code": 200, "running": False}    → parked
+#   {"code": 200, "body": "<garbage>"} → unparseable 200
+_script = []
+_reqs = [0]
+_lock = threading.Lock()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        with _lock:
+            i = _reqs[0]
+            _reqs[0] += 1
+            spec = _script[min(i, len(_script) - 1)] if _script else {"code": 200, "running": True}
+        code = spec.get("code", 200)
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        if code == 200:
+            if "body" in spec:
+                payload = spec["body"]
+            else:
+                payload = json.dumps(
+                    {"data": {"pipelines": [{"running": spec.get("running", True)}]}}
+                )
+            self.wfile.write(payload.encode())
+
+    def log_message(self, *_a):  # silence per-request logging
+        pass
+
+
+def _set_script(script):
+    with _lock:
+        _script[:] = script
+        _reqs[0] = 0
+
+
+def _run_mara(script, **env_over):
+    """Set the stub script, run mara.sh (DRY_RUN), return combined output."""
+    _set_script(script)
+    tmp = tempfile.mkdtemp(prefix="mara-test-")
+    env = dict(os.environ)
+    env.update(
+        {
+            "MARA_HEALTH_URL": f"http://127.0.0.1:{PORT}/api/health",
+            "MARA_DRY_RUN": "1",
+            "MARA_CONFIRM_DELAY_SECS": "0",
+            "MARA_CONFIRM_POLLS": "3",
+            "MARA_STATE_DIR": tmp,
+            "MARA_LOG_HOST": "",  # no ssh log-context fetch
+        }
+    )
+    env.update(env_over)
+    r = subprocess.run(
+        ["bash", MARA], capture_output=True, text=True, env=env, timeout=30
+    )
+    return r.stdout + r.stderr
+
+
+# ---- tests ----------------------------------------------------------------
+
+def test_healthy_no_file():
+    out = _run_mara([{"code": 200, "running": True}])
+    assert "prod heron OK" in out, out
+    assert "would file" not in out, out
+
+
+def test_transient_down_then_up_does_not_file():
+    # poll1 = down (a restart blip), poll2 = healthy → transient, no incident.
+    out = _run_mara([{"code": 503}, {"code": 200, "running": True}])
+    assert "transient" in out and "not filing" in out, out
+    assert "would file" not in out, out
+
+
+def test_sustained_down_files():
+    # every poll fails → real outage → would file prod-heron-down.
+    out = _run_mara([{"code": 503}])
+    assert "would file" in out, out
+    assert "prod-heron-down" in out, out
+    assert "3/3 consecutive polls" in out, out
+
+
+def test_transient_parked_then_running_does_not_file():
+    # pipeline briefly running=false during deploy, then resumes → no incident.
+    out = _run_mara([{"code": 200, "running": False}, {"code": 200, "running": True}])
+    assert "transient" in out and "not filing" in out, out
+    assert "would file" not in out, out
+
+
+def test_sustained_parked_files():
+    out = _run_mara([{"code": 200, "running": False}])
+    assert "would file" in out, out
+    assert "prod-heron-parked" in out, out
+
+
+def test_confirm_polls_1_files_on_first_failure():
+    # CONFIRM_POLLS=1 disables debounce → first failure files immediately.
+    out = _run_mara([{"code": 503}, {"code": 200, "running": True}], MARA_CONFIRM_POLLS="1")
+    assert "would file" in out, out
+    assert "prod-heron-down" in out, out
+
+
+def main():
+    global PORT
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    PORT = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except AssertionError as e:
+            fails += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            fails += 1
+            print(f"ERR  {t.__name__}: {type(e).__name__}: {e}")
+    srv.shutdown()
+    print(f"\n{len(tests) - fails}/{len(tests)} passed")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
mara files a GitHub incident on a **single** failed health poll. But the gated
`deploy-prod` we just landed **restarts heron** on every release: `/api/health`
is briefly unreachable and the pipeline reports `running=false` until capture
resumes — observed **~10 s** on this afternoon's prod deploy health gate. On its
5-min timer, mara will eventually land a poll inside that window and open a
phantom `prod-heron-down` / `prod-heron-parked` issue. A one-off network hiccup
looks identical.

## Fix (option A — confirm sustained failure)
On a failure, re-poll `MARA_CONFIRM_POLLS` times (default **3**), `MARA_CONFIRM_DELAY_SECS`
apart (default **10** → ~20 s span, comfortably covers the observed restart).
If **any** confirm poll recovers → transient → exit without filing. Only an
all-polls-failed run files, with the freshest snapshot; the issue records
`failed N/N consecutive polls`. `CONFIRM_POLLS=1` disables it (old behavior).

- `probe_once()` factored out; confirm loop added before dedup; `now` refreshed
  post-confirm so dedup/SEEN reflect confirm time.
- README: new env knobs + a "confirm-debounce" section.

## Honest scope
A **reducing** filter, not airtight — an unusually long restart could still
straddle every poll. The complete fix is a deploy-time maintenance-window
sentinel (noted in the README as the follow-up if this ever bites).

## Tests
`scripts/agent-bot/tests/test_mara.py` — **first** test harness for mara
(stdlib-only stub `/api/health` server, runs in CI without pytest):
transient down→up = no file, all-fail = file (+ `N/N` line), parked→running =
no file, `CONFIRM_POLLS=1` off-switch. **6/6 pass.** `bash -n` clean; repo
leakage/secret linters green.

> Takes effect once mara.sh is re-synced to its observer host (separate from the
> heron binary deploy).