### PR TITLE
feat(perf): tara load + memory soak — the pre-deploy perf/reliability gate (PR1)

### DIFF
--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -106,6 +106,7 @@ export function defaultFor(type: CaptureSource["type"]): CaptureSource {
     source_id: null,
     loop_count: 1,
     loop_secs: 0,
+    rate_pps: 0,
   }
 }
 

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -621,11 +621,13 @@ export type CaptureSource =
       path: string
       realtime: boolean
       source_id: string | null
-      // Loop/duration replay (load-soak primitive). Mirror of the Rust
+      // Loop/duration/rate replay (load-soak primitive). Mirror of the Rust
       // CaptureSourceConfig::PcapFile fields; serde defaults loop_count=1
-      // (single pass) / loop_secs=0 (disabled) so older configs still parse.
+      // (single pass) / loop_secs=0 / rate_pps=0 (disabled) so older configs
+      // still parse.
       loop_count: number
       loop_secs: number
+      rate_pps: number
     }
   | {
       type: "cloud-probe"

--- a/scripts/staging/soak-staging.sh
+++ b/scripts/staging/soak-staging.sh
@@ -31,6 +31,16 @@
 #   HERON_STAGE_BASELINE   pin an explicit baseline, overriding the rolling
 #                          known-good (manual/debug; unset → use known-good)
 #   HERON_STAGE_NO_PROMOTE set to 1 to soak without advancing the known-good
+#   HERON_STAGE_LOAD_SECS  load-soak window seconds        (default 45)
+#   HERON_STAGE_LOAD_PPS   load-soak steady rate (pkts/s)  (default 500)
+#   HERON_STAGE_LOAD_ENFORCE  1 → a load-soak regression fails the deploy
+#                          (default 0 = informational until thresholds are
+#                          calibrated on this VM's CPU; the dual-binary baseline
+#                          still flags relative regressions meanwhile)
+#
+# After the correctness soak passes, a deeper sustained-LOAD soak runs (steady
+# rate_pps replay; perf + reliability invariants). It is informational by
+# default — see HERON_STAGE_LOAD_ENFORCE.
 #
 # Exit: 0 pass · 1 candidate regressed · 2 setup error. A tara `harness_broken`
 # (baseline itself failed → corpus/env problem, never the candidate) is logged
@@ -92,6 +102,30 @@ remote "cat $RD/out.json 2>/dev/null" || echo "(no verdict file — tara aborted
 case "$rc" in
   0)
     echo "==> SOAK PASS — staging binary healthy under replay"
+
+    # Deeper check: a sustained-load soak (steady rate_pps replay for a window),
+    # asserting perf + reliability invariants — queue depth bounded, zero
+    # backpressure drops, RSS growth bounded, no flush errors. Runs only after
+    # the correctness soak is green. INFORMATIONAL by default: the absolute
+    # queue/RSS thresholds still need one calibration pass on this VM's CPU, so
+    # a load regression is logged + warned but does NOT fail the deploy yet (the
+    # dual-binary baseline still flags a *relative* regression). Flip to a hard
+    # gate with HERON_STAGE_LOAD_ENFORCE=1 once calibrated.
+    echo "==> running tara LOAD soak inside the VM (informational)"
+    set +e
+    remote "cd $RD && bash tara.sh --binary '$STAGE_BIN' --corpus '$CORPUS_VM' $base_arg --load --duration ${HERON_STAGE_LOAD_SECS:-45} --rate-pps ${HERON_STAGE_LOAD_PPS:-500} --json-out $RD/load.json"
+    lrc=$?
+    set -e
+    echo "==> load verdict:"
+    remote "cat $RD/load.json 2>/dev/null" || echo "(no load verdict file)"
+    if [ "$lrc" != 0 ] && [ "$lrc" != 3 ]; then
+      if [ "${HERON_STAGE_LOAD_ENFORCE:-0}" = 1 ]; then
+        echo "::error::LOAD SOAK FAILED (tara rc=$lrc) and HERON_STAGE_LOAD_ENFORCE=1 — failing deploy; known-good UNCHANGED"
+        exit 1
+      fi
+      echo "::warning::load soak reported a regression (tara rc=$lrc) — INFORMATIONAL only (set HERON_STAGE_LOAD_ENFORCE=1 to gate). Promotion below uses the correctness soak."
+    fi
+
     if [ "$PROMOTE" = 1 ]; then
       if remote "sudo install -m 0755 '$STAGE_BIN' '$LAST_GOOD'"; then
         echo "==> known-good advanced → $LAST_GOOD (next soak compares against this build)"

--- a/scripts/staging/tara.sh
+++ b/scripts/staging/tara.sh
@@ -20,6 +20,10 @@
 #   tara.sh --binary <heron> --corpus <pcap> [--baseline <heron>]
 #           [--json-out <file>] [--port <base>] [--workdir <dir>]
 #           [--min-reqs N] [--min-turns N] [--keep]
+#   Load/soak mode (perf + reliability instead of single-pass correctness):
+#   tara.sh --binary <heron> --corpus <pcap> --load [--duration 60]
+#           [--rate-pps 1000] [--max-queue-pct 80] [--max-rss-growth-pct 50]
+#           [--min-pkts 10000] [--baseline <heron>]
 #
 # Exit: 0 pass · 1 candidate regressed · 2 usage/setup · 3 harness_broken
 set -uo pipefail
@@ -29,6 +33,8 @@ CHECKER="$HERE/tara_invariants.py"
 
 BINARY="" CORPUS="" BASELINE="" JSON_OUT="" PORT_BASE=4599 WORKROOT="" KEEP=0
 MIN_REQS=1 MIN_TURNS=0
+# Load-mode knobs (only used with --load):
+LOAD=0 DURATION=60 MAX_QUEUE_PCT=80 MAX_RSS_GROWTH_PCT=50 MIN_PKTS=10000 RATE_PPS=1000
 while [ $# -gt 0 ]; do
   case "$1" in
     --binary)    BINARY="$2"; shift 2;;
@@ -39,6 +45,16 @@ while [ $# -gt 0 ]; do
     --workdir)   WORKROOT="$2"; shift 2;;
     --min-reqs)  MIN_REQS="$2"; shift 2;;
     --min-turns) MIN_TURNS="$2"; shift 2;;
+    # Load/soak mode: loop the corpus for <duration> s at a steady <rate-pps>
+    # and assert perf + reliability invariants (drops, queue depth, RSS growth,
+    # throughput) instead of single-pass correctness. Needs a binary with
+    # pcap-file loop + rate support (loop_secs / rate_pps).
+    --load)      LOAD=1; shift;;
+    --duration)  DURATION="$2"; shift 2;;
+    --rate-pps)  RATE_PPS="$2"; shift 2;;
+    --max-queue-pct)      MAX_QUEUE_PCT="$2"; shift 2;;
+    --max-rss-growth-pct) MAX_RSS_GROWTH_PCT="$2"; shift 2;;
+    --min-pkts)  MIN_PKTS="$2"; shift 2;;
     --keep)      KEEP=1; shift;;
     *) echo "tara: unknown arg '$1'" >&2; exit 2;;
   esac
@@ -63,6 +79,16 @@ soak_one() {
   local wd="$WORKROOT/$label"
   mkdir -p "$wd/data"
   local cfg="$wd/config.toml" log="$wd/heron.log" metrics="$wd/metrics.json"
+  local samples="$wd/samples.jsonl"
+  # In load mode, drive the binary's pcap-file loop replay for the window at a
+  # steady rate. rate_pps keeps the load prod-like instead of an as-fast-as-
+  # possible firehose that just saturates the channels (which would fail the
+  # queues-bounded invariant by design, not by regression).
+  local loop_line="" rate_line=""
+  if [ "$LOAD" = 1 ]; then
+    loop_line="loop_secs = $DURATION"
+    rate_line="rate_pps = $RATE_PPS"
+  fi
 
   cat > "$cfg" <<TOML
 [[pipeline]]
@@ -81,6 +107,8 @@ type = "pcap-file"
 path = "$CORPUS_ABS"
 realtime = false
 source_id = "tara-soak"
+$loop_line
+$rate_line
 [storage]
 backend = "duckdb"
 [storage.duckdb]
@@ -113,17 +141,36 @@ TOML
     return
   fi
 
-  # 2) wait for the corpus to be fully ingested (pcap-file EOF)
-  for _ in $(seq 1 60); do
-    grep -q "pcap-file: finished reading" "$log" 2>/dev/null && break
-    kill -0 "$pid" 2>/dev/null || break
-    sleep 1
-  done
+  if [ "$LOAD" = 1 ]; then
+    # 2L) sustained-load: sample /api/internal-metrics + process RSS every ~2 s
+    # while the binary loops the corpus. The series feeds the load invariants.
+    : > "$samples"
+    local t_end=$(( $(date +%s) + DURATION ))
+    while [ "$(date +%s)" -lt "$t_end" ]; do
+      kill -0 "$pid" 2>/dev/null || { echo "tara: [$label] heron died mid-load" >&2; break; }
+      local rss_kb m
+      rss_kb="$(awk '/^VmRSS:/{print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
+      m="$(curl -fsS -m 5 "http://127.0.0.1:$port/api/internal-metrics" 2>/dev/null || echo '{}')"
+      printf '{"ts":%s,"rss_kb":%s,"metrics":%s}\n' "$(date +%s)" "${rss_kb:-0}" "$m" >> "$samples"
+      sleep 2
+    done
+    # loop_secs has elapsed → the source stops; let the pipeline drain + flush.
+    sleep 6
+    curl -fsS -m 5 "http://127.0.0.1:$port/api/internal-metrics" > "$metrics" 2>/dev/null \
+      || echo '{}' > "$metrics"
+  else
+    # 2) wait for the corpus to be fully ingested (pcap-file EOF)
+    for _ in $(seq 1 60); do
+      grep -q "pcap-file: finished reading" "$log" 2>/dev/null && break
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 1
+    done
 
-  # 3) let turns close (idle+grep sweep) and the sink flush, then snapshot
-  sleep 8
-  curl -fsS -m 5 "http://127.0.0.1:$port/api/internal-metrics" > "$metrics" 2>/dev/null \
-    || echo '{}' > "$metrics"
+    # 3) let turns close (idle+sweep) and the sink flush, then snapshot
+    sleep 8
+    curl -fsS -m 5 "http://127.0.0.1:$port/api/internal-metrics" > "$metrics" 2>/dev/null \
+      || echo '{}' > "$metrics"
+  fi
 
   # 4) graceful stop
   kill -TERM "$pid" 2>/dev/null || true
@@ -131,8 +178,14 @@ TOML
   kill -9 "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
 
-  python3 "$CHECKER" --label "$label" --logfile "$log" \
-    --metrics-file "$metrics" --min-reqs "$MIN_REQS" --min-turns "$MIN_TURNS"
+  if [ "$LOAD" = 1 ]; then
+    python3 "$CHECKER" --label "$label" --logfile "$log" --metrics-file "$metrics" \
+      --load --samples "$samples" --max-queue-pct "$MAX_QUEUE_PCT" \
+      --max-rss-growth-pct "$MAX_RSS_GROWTH_PCT" --min-pkts "$MIN_PKTS"
+  else
+    python3 "$CHECKER" --label "$label" --logfile "$log" \
+      --metrics-file "$metrics" --min-reqs "$MIN_REQS" --min-turns "$MIN_TURNS"
+  fi
 }
 
 BASE_VERDICT="null"

--- a/scripts/staging/tara_invariants.py
+++ b/scripts/staging/tara_invariants.py
@@ -106,6 +106,131 @@ def evaluate(m, fatals, ingest_pkts, *, min_reqs, min_turns):
     return [{"name": n, "ok": bool(ok), "detail": d} for n, ok, d in inv]
 
 
+def flatten_caps(metrics_json):
+    """name -> (value, capacity_or_None) from the /api/internal-metrics shape."""
+    out = {}
+    data = metrics_json.get("data", metrics_json)
+    for pipe in data.get("pipelines", []):
+        for m in pipe.get("metrics", []):
+            out[m["name"]] = (m.get("value", 0), m.get("capacity"))
+    return out
+
+
+# Backpressure drop counters — any non-zero means a stage couldn't keep up.
+BACKPRESSURE_DROPS = [
+    "batches_dropped_zmq", "flow_heartbeats_dropped",
+    "turn_heartbeats_dropped", "metrics_heartbeats_dropped",
+]
+
+
+def evaluate_load(samples, final_m, fatals, *, max_queue_pct, max_rss_growth_pct, min_pkts):
+    """Load/soak invariants from a time series of (rss, metrics) samples + the
+    final snapshot. Returns (invariants, summary)."""
+    g = lambda k: final_m.get(k, 0)
+
+    # Worst queue-depth utilisation seen across the whole window (any gauge that
+    # carries a capacity — the q_* channels).
+    worst_q = ("", 0.0)
+    for s in samples:
+        for name, (value, cap) in flatten_caps(s.get("metrics", {})).items():
+            if cap:
+                pct = 100.0 * value / cap
+                if pct > worst_q[1]:
+                    worst_q = (name, pct)
+
+    # RSS series (KB), skipping a 25% warm-up so one-time startup growth isn't
+    # mistaken for a leak.
+    rss = [s.get("rss_kb", 0) for s in samples if s.get("rss_kb", 0) > 0]
+    warm = rss[len(rss) // 4:] if len(rss) >= 4 else rss
+    rss_base = min(warm) if warm else 0
+    rss_peak = max(warm) if warm else 0
+    rss_growth_pct = (100.0 * (rss_peak - rss_base) / rss_base) if rss_base > 0 else 0.0
+
+    inv = [
+        ("no_fatal_logs", len(fatals) == 0,
+         "clean" if not fatals else f"{len(fatals)} fatal line(s): {fatals[0]}"),
+        ("load_ran",
+         g("pkts_received") >= min_pkts,
+         f"pkts_received={g('pkts_received')} (min {min_pkts}) — confirms sustained load"),
+        ("no_backpressure_drops",
+         all(g(k) == 0 for k in BACKPRESSURE_DROPS),
+         ", ".join(f"{k}={g(k)}" for k in BACKPRESSURE_DROPS)),
+        ("queues_bounded",
+         worst_q[1] < max_queue_pct,
+         f"worst {worst_q[0] or '-'}={worst_q[1]:.1f}% (limit {max_queue_pct}%)"),
+        ("capture_clean",
+         g("read_errors") == 0 and g("pkts_truncated") == 0
+         and g("pkts_dropped_malformed") == 0,
+         f"read_errors={g('read_errors')} truncated={g('pkts_truncated')} "
+         f"malformed={g('pkts_dropped_malformed')}"),
+        ("storage_no_flush_errors",
+         g("flush_errors") == 0,
+         f"flush_errors={g('flush_errors')}"),
+        ("rss_stable",
+         rss_growth_pct < max_rss_growth_pct,
+         f"RSS {rss_base}->{rss_peak} KB = +{rss_growth_pct:.1f}% post-warmup "
+         f"(limit {max_rss_growth_pct}%)"),
+    ]
+    invariants = [{"name": n, "ok": bool(ok), "detail": d} for n, ok, d in inv]
+    summary = {
+        "samples": len(samples),
+        "pkts_received": g("pkts_received"),
+        "pkts_parsed": g("pkts_parsed"),
+        "flushed_calls": g("flushed_calls"),
+        "worst_queue": {"metric": worst_q[0], "pct": round(worst_q[1], 1)},
+        "rss_kb": {"base": rss_base, "peak": rss_peak, "growth_pct": round(rss_growth_pct, 1)},
+    }
+    return invariants, summary
+
+
+def run_load(args):
+    samples = []
+    if args.samples:
+        try:
+            with open(args.samples) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        try:
+                            samples.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+        except FileNotFoundError:
+            pass
+
+    final_m = {}
+    if args.metrics_file:
+        try:
+            final_m = flatten(json.load(open(args.metrics_file)))
+        except Exception:  # noqa: BLE001
+            final_m = {}
+    if not final_m and samples:
+        final_m = flatten(samples[-1].get("metrics", {}))
+
+    fatals, _ = scan_log(args.logfile)
+    invariants, summary = evaluate_load(
+        samples, final_m, fatals,
+        max_queue_pct=args.max_queue_pct,
+        max_rss_growth_pct=args.max_rss_growth_pct,
+        min_pkts=args.min_pkts,
+    )
+    if not samples:
+        invariants.append({"name": "has_samples", "ok": False,
+                           "detail": "no load samples collected"})
+    passed = all(i["ok"] for i in invariants)
+    verdict = {
+        "label": args.label,
+        "pass": passed,
+        "mode": "load",
+        "invariants": invariants,
+        "failed": [i["name"] for i in invariants if not i["ok"]],
+        "load_summary": summary,
+        "fatal_lines": fatals,
+    }
+    print(json.dumps(verdict, indent=2))
+    return 0 if passed else 1
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--label", default="run")
@@ -114,7 +239,17 @@ def main():
     ap.add_argument("--min-turns", type=int, default=1)
     ap.add_argument("--metrics-file", default="",
                     help="read metrics JSON from a file instead of stdin")
+    # Load/soak mode (--load): assert perf+reliability invariants from a sample
+    # series instead of single-pass correctness.
+    ap.add_argument("--load", action="store_true")
+    ap.add_argument("--samples", default="", help="JSONL of {ts,rss_kb,metrics} samples")
+    ap.add_argument("--max-queue-pct", type=float, default=80.0)
+    ap.add_argument("--max-rss-growth-pct", type=float, default=50.0)
+    ap.add_argument("--min-pkts", type=int, default=10000)
     args = ap.parse_args()
+
+    if args.load:
+        return run_load(args)
 
     raw = open(args.metrics_file).read() if args.metrics_file else sys.stdin.read()
     try:

--- a/scripts/staging/tests/test_tara_invariants.py
+++ b/scripts/staging/tests/test_tara_invariants.py
@@ -124,6 +124,70 @@ def test_cli_exits_nonzero_on_failure():
         os.unlink(mf)
 
 
+# --- load-mode invariants -------------------------------------------------
+
+def load_sample(rss_kb, q_pct=10, drops=0, pkts=50000, flush_errors=0):
+    """One /api/internal-metrics-shaped load sample."""
+    metrics = [
+        {"name": "pkts_received", "value": pkts},
+        {"name": "pkts_parsed", "value": pkts},
+        {"name": "q_raw_pkts", "value": int(4096 * q_pct / 100), "capacity": 4096},
+        {"name": "batches_dropped_zmq", "value": drops},
+        {"name": "flow_heartbeats_dropped", "value": 0},
+        {"name": "turn_heartbeats_dropped", "value": 0},
+        {"name": "metrics_heartbeats_dropped", "value": 0},
+        {"name": "flush_errors", "value": flush_errors},
+        {"name": "read_errors", "value": 0},
+        {"name": "pkts_truncated", "value": 0},
+        {"name": "pkts_dropped_malformed", "value": 0},
+    ]
+    return {"ts": 0, "rss_kb": rss_kb,
+            "metrics": {"data": {"pipelines": [{"metrics": metrics}]}}}
+
+
+def ev_load(samples, **kw):
+    kw.setdefault("max_queue_pct", 80.0)
+    kw.setdefault("max_rss_growth_pct", 50.0)
+    kw.setdefault("min_pkts", 10000)
+    final = T.flatten(samples[-1]["metrics"]) if samples else {}
+    invs, _ = T.evaluate_load(samples, final, [], **kw)
+    return [i["name"] for i in invs if not i["ok"]]
+
+
+def test_load_healthy_passes():
+    s = [load_sample(100000, q_pct=10, pkts=50000) for _ in range(8)]
+    assert ev_load(s) == [], ev_load(s)
+
+
+def test_load_queue_over_limit_fails():
+    s = [load_sample(100000, q_pct=10) for _ in range(7)]
+    s.append(load_sample(100000, q_pct=95))  # one spike > 80%
+    assert "queues_bounded" in ev_load(s)
+
+
+def test_load_rss_growth_trips_leak():
+    # RSS climbs 100MB→240MB across the window → leak.
+    s = [load_sample(100000 + i * 20000, q_pct=10) for i in range(8)]
+    assert "rss_stable" in ev_load(s)
+
+
+def test_load_backpressure_drop_fails():
+    s = [load_sample(100000, q_pct=10) for _ in range(7)]
+    s.append(load_sample(100000, q_pct=10, drops=5))
+    assert "no_backpressure_drops" in ev_load(s)
+
+
+def test_load_insufficient_pkts_fails():
+    s = [load_sample(100000, q_pct=10, pkts=100) for _ in range(8)]
+    assert "load_ran" in ev_load(s)
+
+
+def test_load_flush_errors_fail():
+    s = [load_sample(100000, q_pct=10) for _ in range(7)]
+    s.append(load_sample(100000, q_pct=10, flush_errors=2))
+    assert "storage_no_flush_errors" in ev_load(s)
+
+
 def main():
     tests = [v for k, v in sorted(globals().items())
              if k.startswith("test_") and callable(v)]

--- a/server/app/heron/src/main.rs
+++ b/server/app/heron/src/main.rs
@@ -279,6 +279,7 @@ async fn run_pipeline(cli: Cli) {
                 source_id: None,
                 loop_count: 1,
                 loop_secs: 0,
+                rate_pps: 0,
             }],
             ..PipelineDef::default()
         }]

--- a/server/app/heron/tests/pipeline_e2e.rs
+++ b/server/app/heron/tests/pipeline_e2e.rs
@@ -81,6 +81,7 @@ async fn run_pipeline_multi(fixture_names: &[&str]) -> Option<(TempDir, PathBuf)
                 source_id: None,
                 loop_count: 1,
                 loop_secs: 0,
+                rate_pps: 0,
             }],
             ..PipelineDef::default()
         })

--- a/server/h-capture/src/factory.rs
+++ b/server/h-capture/src/factory.rs
@@ -37,6 +37,7 @@ pub fn build_source(
             source_id,
             loop_count,
             loop_secs,
+            rate_pps,
             ..
         } => {
             let sid = source_id.clone().unwrap_or_else(|| {
@@ -48,7 +49,8 @@ pub fn build_source(
             });
             Ok(Box::new(
                 PcapFileSource::new(path.into(), sid, pcap_dump)
-                    .with_loop(*loop_count, *loop_secs),
+                    .with_loop(*loop_count, *loop_secs)
+                    .with_rate_pps(*rate_pps),
             ))
         }
         CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => Ok(Box::new(
@@ -69,6 +71,7 @@ mod tests {
             source_id: None,
             loop_count: 1,
             loop_secs: 0,
+            rate_pps: 0,
         };
         assert!(build_source(&config, None).is_ok());
     }

--- a/server/h-capture/src/pcap_file.rs
+++ b/server/h-capture/src/pcap_file.rs
@@ -29,6 +29,12 @@ pub struct PcapFileSource {
     /// Replay until this many seconds elapse (0 = disabled). Takes precedence
     /// over `loop_count` when > 0.
     loop_secs: u64,
+    /// Target sustained emission rate in packets/sec (0 = unthrottled = today's
+    /// behavior). When > 0, the reader paces packet emission to this aggregate
+    /// rate across all passes so a load soak drives a *steady, prod-like* load
+    /// instead of an as-fast-as-possible firehose that just saturates the
+    /// channels (which only exercises backpressure, not steady-state health).
+    rate_pps: u32,
 }
 
 impl PcapFileSource {
@@ -39,6 +45,7 @@ impl PcapFileSource {
             dump_cfg,
             loop_count: 1,
             loop_secs: 0,
+            rate_pps: 0,
         }
     }
 
@@ -50,6 +57,14 @@ impl PcapFileSource {
     pub fn with_loop(mut self, loop_count: u32, loop_secs: u64) -> Self {
         self.loop_count = loop_count.max(1);
         self.loop_secs = loop_secs;
+        self
+    }
+
+    /// Pace emission to a target aggregate packets/sec (0 = unthrottled).
+    /// Pairs with `with_loop` to drive a steady sustained load from a small
+    /// corpus for the load/longevity soak.
+    pub fn with_rate_pps(mut self, rate_pps: u32) -> Self {
+        self.rate_pps = rate_pps;
         self
     }
 }
@@ -68,6 +83,7 @@ impl CaptureSource for PcapFileSource {
         let dumper_metrics = metrics.clone();
         let loop_count = self.loop_count.max(1);
         let loop_secs = self.loop_secs;
+        let rate_pps = self.rate_pps;
         let looping = loop_secs > 0 || loop_count > 1;
 
         // Run pcap reading on a blocking thread since next_packet() is blocking.
@@ -113,8 +129,10 @@ impl CaptureSource for PcapFileSource {
                         "pcap-file: opened {} (link_type={}{})",
                         path.display(),
                         link_type,
-                        if looping {
-                            format!(", loop_count={loop_count} loop_secs={loop_secs}")
+                        if looping || rate_pps > 0 {
+                            format!(
+                                ", loop_count={loop_count} loop_secs={loop_secs} rate_pps={rate_pps}"
+                            )
                         } else {
                             String::new()
                         }
@@ -162,6 +180,31 @@ impl CaptureSource for PcapFileSource {
                             // signal — not a silent re-emergence of the bug.
                             if packet.header.caplen < packet.header.len {
                                 metrics.counter(Metric::CaptureTruncatedPackets).inc();
+                            }
+
+                            // Rate pacing: keep cumulative emission on a steady
+                            // `rate_pps` schedule. Referencing absolute (count vs
+                            // elapsed-since-start) instead of per-packet sleeps
+                            // avoids drift and naturally absorbs a slow burst.
+                            // Sleep in bounded chunks so cancellation (and a low
+                            // rate) stay responsive.
+                            if rate_pps > 0 {
+                                let target_ns =
+                                    count as u128 * 1_000_000_000u128 / rate_pps as u128;
+                                let elapsed_ns = start.elapsed().as_nanos();
+                                if target_ns > elapsed_ns {
+                                    let mut remaining = (target_ns - elapsed_ns) as u64;
+                                    while remaining > 0 {
+                                        if cancel.is_cancelled() {
+                                            break 'replay;
+                                        }
+                                        let chunk = remaining.min(50_000_000); // ≤50ms
+                                        std::thread::sleep(std::time::Duration::from_nanos(
+                                            chunk,
+                                        ));
+                                        remaining -= chunk;
+                                    }
+                                }
                             }
                         }
                         Err(pcap::Error::NoMorePackets) => {
@@ -435,5 +478,59 @@ mod tests {
         }
         assert_eq!(count, 4);
         assert_eq!(sids.into_iter().collect::<Vec<_>>(), vec!["base".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_rate_pps_paces_emission() {
+        // 6 packets @ 20 pps → schedule target ≈ 300 ms. Assert a clearly-
+        // throttled floor (≥200 ms). Lower-bound only: pacing sleeps can never
+        // make the replay FASTER, so this is robust on a loaded runner —
+        // unthrottled (rate_pps=0) the same replay finishes in ~1 ms.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate.pcap");
+        std::fs::write(&path, build_pcap_file(6)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let source = PcapFileSource::new(path, "base".to_string(), None).with_rate_pps(20);
+        let t0 = std::time::Instant::now();
+        Box::new(source)
+            .run(RoutingSender::single(tx), test_metrics(), cancel)
+            .await
+            .unwrap();
+        let elapsed = t0.elapsed();
+
+        let mut count = 0;
+        while rx.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(count, 6, "all packets still delivered under rate control");
+        assert!(
+            elapsed >= std::time::Duration::from_millis(200),
+            "rate-paced replay should take ≥200ms, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_pps_zero_is_unthrottled() {
+        // rate_pps=0 (default) must not pace — functional check that the path
+        // is a no-op (all packets delivered, no hang).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("norate.pcap");
+        std::fs::write(&path, build_pcap_file(5)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let cancel = CancellationToken::new();
+        let source = PcapFileSource::new(path, "base".to_string(), None).with_rate_pps(0);
+        Box::new(source)
+            .run(RoutingSender::single(tx), test_metrics(), cancel)
+            .await
+            .unwrap();
+
+        let mut count = 0;
+        while rx.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(count, 5);
     }
 }

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -288,6 +288,12 @@ pub enum CaptureSourceConfig {
         /// duration-bounded load/longevity soak.
         #[serde(default)]
         loop_secs: u64,
+        /// Pace emission to this many packets/sec (0 = unthrottled = today's
+        /// behavior). Lets the load soak drive a steady, prod-like rate from a
+        /// looped corpus instead of an as-fast-as-possible firehose that just
+        /// saturates the channels. Applies across all passes.
+        #[serde(default)]
+        rate_pps: u32,
     },
     CloudProbe {
         #[serde(default = "default_cloud_probe_endpoint")]
@@ -1292,6 +1298,7 @@ mod phase2_tests {
             source_id: None,
             loop_count: 1,
             loop_secs: 0,
+            rate_pps: 0,
         };
         assert_eq!(pcap_file.resolved_source_id(), Some("test".to_string()));
 

--- a/server/h-common/src/config_edit.rs
+++ b/server/h-common/src/config_edit.rs
@@ -109,6 +109,7 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
             source_id,
             loop_count,
             loop_secs,
+            rate_pps,
         } => {
             t["type"] = value("pcap-file");
             t["path"] = value(path.as_str());
@@ -116,13 +117,16 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
             if let Some(id) = source_id {
                 t["source_id"] = value(id.as_str());
             }
-            // Loop/duration replay knobs are soak-only — emit them only when
-            // non-default so a normal capture source's TOML stays clean.
+            // Loop/duration/rate replay knobs are soak-only — emit them only
+            // when non-default so a normal capture source's TOML stays clean.
             if *loop_count != 1 {
                 t["loop_count"] = value(i64::from(*loop_count));
             }
             if *loop_secs != 0 {
                 t["loop_secs"] = value(*loop_secs as i64);
+            }
+            if *rate_pps != 0 {
+                t["rate_pps"] = value(i64::from(*rate_pps));
             }
         }
         CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => {


### PR DESCRIPTION
The first of the perf-suite PRs (PR1–PR4 in the quality-infra plan). Closes the
biggest remaining gap: the deploy chain gated **correctness only** — tara
replayed one 367 KB pcap single-pass and asserted parse/pairing/turn invariants;
nothing tested behavior **under sustained load**. For a capture server, dropping
packets or OOM-ing the host *is* the failure (the 2026-06-02 prod outage was
exactly this untested class).

## Two commits

**1. `rate_pps` emission throttle** (`server/h-capture/src/pcap_file.rs` + config)
The missing half of the load-soak primitive (loop-mode landed in #99). A target
sustained packets/sec knob (default 0 = unthrottled = today). Without it, replay
is an as-fast-as-possible firehose that saturates the channels in seconds
(`q_raw_pkts`→100%, RSS climbs, storage never flushes) — which only exercises
backpressure, never steady-state, so a "queues bounded / RSS stable / zero
drops" soak can't pass. Cumulative-schedule pacing (target = count/rate vs
elapsed) self-corrects without drift; sleeps in ≤50ms chunks stay
cancellation-responsive. TS mirror updated (same schema-drift class vivi flagged
on #99). Tests: rate-paced replay ≥ schedule floor (lower-bound, runner-robust)
+ rate=0 no-op.

**2. tara `--load` soak + deploy-gate wiring** (`scripts/staging/`)
`--load --duration <s> --rate-pps <n>` loops the corpus at a steady rate,
samples `/api/internal-metrics` + RSS every ~2s, and asserts: no_fatal_logs,
load_ran (throughput floor), no_backpressure_drops, **queues_bounded** (every
`q_*` < N% of capacity), capture_clean, storage_no_flush_errors, **rss_stable**
(post-warmup growth < N% — the leak detector). Reuses the dual-binary
`--baseline` self-test. Wired into `soak-staging.sh` after the correctness soak,
**informational by default** (`HERON_STAGE_LOAD_ENFORCE=1` to gate) because the
absolute queue/RSS thresholds want one calibration pass on the VM's CPU — until
then the dual-binary baseline still catches *relative* regressions, and a
too-aggressive rate surfaces as `harness_broken` (env), never a false
candidate-reject.

## Validation
- End-to-end locally (debug heron, in-repo fixture, 10s @ 200 pps): verdict
  **pass** — `pkts_received≈2136` (rate held ~213 pps, **not** a firehose),
  `queues_bounded` worst **0.0%** (vs 100% unthrottled), drops=0,
  flush_errors=0.
- `cargo test`: h-capture **77**, h-common **69**. tara_invariants **22/22**.
  Full heron build + clippy clean on new code. Leakage/secret linters green.
  (RSS sampling is Linux-/proc-only — real on the staging VM, trivially 0 on
  macOS.)

## Consciously deferred (documented, not silently omitted)
The live-capture / AF_PACKET kernel-drop path (`pkts_dropped_kernel`) — pcap-file
can't exercise the kernel ring; covering it later needs tcpreplay→veth→live
capture. PR2 (criterion benches), PR3 (chaos-under-load), PR4 (nightly
longevity) follow as their own PRs.