### PR TITLE
CI hygiene (§5): scrub internal CI backend model identifier from workflow + script comments (follow-up to #100)

### DIFF
--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: [self-hosted, heron]
     # 120-minute fence. A clean, well-scoped wiwi run (per the triage
     # gates: <300 LOC, <10 files) typically completes in 10-25 min; the
-    # 120-min cap absorbs slower LiteLLM ↔ GLM-5 round-trips on busy
+    # 120-min cap absorbs slower model gateway ↔ model backend round-trips on busy
     # days and gives wiwi room to iterate when `cargo build` finds
     # something it has to fix mid-run. If you ever see this fence
     # actually hit, the triage gate is probably mis-sized — file an

--- a/.github/workflows/pr-review-probe.yml
+++ b/.github/workflows/pr-review-probe.yml
@@ -89,7 +89,7 @@ jobs:
             "$ANTHROPIC_BASE_URL/v1/models" \
             | python3 -c 'import sys,json; d=json.load(sys.stdin); print("models seen:", len(d["data"])); [print(" ", m["id"]) for m in d["data"][:8]]'
 
-      - name: Round-trip claude → LiteLLM → GLM-5
+      - name: Round-trip claude → model gateway → model backend
         run: |
           OUT="$(timeout 60 claude --print --model "$ANTHROPIC_MODEL" --max-turns 1 --output-format text "say PONG, nothing else" 2>&1)"
           echo "agent response: $OUT"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: pr-review
 
 # Headless code-review agent. Fires AFTER the `ci` workflow completes
-# successfully on a PR — that gate keeps the agent from wasting GLM-5
+# successfully on a PR — that gate keeps the agent from wasting model backend
 # cycles on PRs that don't even compile, and ensures the review the
 # author sees is "tests are green, here's what to look at next".
 #

--- a/scripts/agent-bot/run_wiwi.sh
+++ b/scripts/agent-bot/run_wiwi.sh
@@ -49,7 +49,7 @@ You are **wiwi**, the dev agent. Implement the change requested by issue
 - **You may be a RESUMED run.** If \`git log origin/main..HEAD\` shows
   existing commits OR \`git status\` shows uncommitted edits when you
   start, the previous attempt crashed mid-run (typically a LiteLLM /
-  GLM-5 hiccup) and the driver is retrying. Treat that state as your
+  model backend hiccup) and the driver is retrying. Treat that state as your
   starting point: do NOT redo work that's already committed; do
   verify the partial state makes sense (read the diffs, build, run
   tests); then continue toward the issue's acceptance criteria. If
@@ -66,7 +66,7 @@ Issue title: ${ISSUE_TITLE}
 EOF
 
 # Wait for LiteLLM to be reachable before launching claude. Without
-# this, a transient GLM-5 / LiteLLM restart that happens during the
+# this, a transient model backend / LiteLLM restart that happens during the
 # (often-15+ min) self-hosted runner queue wait kills the run
 # immediately and wastes the queue wait + branch-prep work. Caps at
 # 30 min by default; configurable via MAX_LITELLM_WAIT_SECONDS.

--- a/scripts/lib/litellm-wait.sh
+++ b/scripts/lib/litellm-wait.sh
@@ -2,7 +2,7 @@
 # configured API key, with exponential backoff. Source from any
 # agent script that's about to invoke `claude --print` (or any
 # OpenAI-compatible client) — the helper makes the agent tolerant of
-# LiteLLM / GLM-5 restarts that happen DURING a workflow's queue
+# LiteLLM / model backend restarts that happen DURING a workflow's queue
 # time. Without it, a transient backend hiccup causes the run to
 # exit immediately and the work (and 15-min queue wait, on a busy
 # self-hosted runner) is wasted.

--- a/scripts/pr-review/run_review.sh
+++ b/scripts/pr-review/run_review.sh
@@ -30,7 +30,7 @@ export PR_NUMBER HEAD_SHA BASE_REF
 envsubst < "$WORKDIR/prompt.md" > "$PROMPT"
 
 # Pre-flight: wait until LiteLLM is reachable AND our API key is
-# accepted. The wait covers the common case where GLM-5 / LiteLLM
+# accepted. The wait covers the common case where model backend / LiteLLM
 # is restarting when this workflow fires; if it's still down after
 # 30 min (MAX_LITELLM_WAIT_SECONDS) the function returns 2 and we
 # pass through with the same diagnostic shape as before. Shared


### PR DESCRIPTION
# Summary

Scrubbed internal model backend identifier from workflow and script comments, completing the CI hygiene cleanup (§5) that started with #100.

## Changes

Replaced internal model backend identifier (GLM-5) with generic terms (`model backend`, `model gateway`) in 7 locations across 6 files:

- `.github/workflows/pr-review.yml:4` — comment about avoiding wasted cycles
- `.github/workflows/pr-review-probe.yml:92` — step name for round-trip verification
- `.github/workflows/issue-implement.yml:34` — comment about timeout absorption
- `scripts/pr-review/run_review.sh:33` — comment about pre-flight wait
- `scripts/lib/litellm-wait.sh:5` — comment about restart tolerance
- `scripts/agent-bot/run_wiwi.sh:52` — comment about resumed runs
- `scripts/agent-bot/run_wiwi.sh:69` — comment about transient restarts

All substitutions use terminology consistent with the post-#100 documentation style in `docs/pr-review-agent.md`.

## Verification

- Pure text substitution, no behavior changes
- `scripts/lint/check-leakage.sh` passes
- No remaining instances of the identifier in `.github/` or `scripts/`

Closes #108
---
🤖 Implemented by **wiwi** • issue author: @vaderyang
Eligible for auto-merge on vivi APPROVE.
