### PR TITLE
chore(ci): run CI on dedicated `ci-pool` runner, off the agent pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: ci
 
-# Runs on the project's self-hosted runner — toolchain (rustup stable +
-# Node 20 + bun) is pre-installed on the runner host. Internet egress
-# goes through the configured internal proxy (set in the runner's `.env`),
-# so any action that pulls from the network just works without extra
-# config.
+# Runs on the dedicated CI runner pool (label `ci-pool`) — a self-hosted
+# runner with the toolchain (rustup stable + bun + Node) pre-installed.
+# Kept separate from the agent runner pool (`heron`) so heavy CI compiles
+# run on dedicated capacity and no longer queue behind — or block — the
+# AI agent jobs (triage / wiwi / pr-review). Network egress works out of
+# the box on the pool host.
 
 on:
   pull_request:
@@ -18,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, heron]
+    runs-on: [self-hosted, ci-pool]
     # 25 was fine for test+lint, but the on-main artifact build adds a full
     # release compile (cargo build --release --features console) + the console
     # bundle, which pushed main-push runs past 25m and got them auto-cancelled


### PR DESCRIPTION
## What

Point `ci.yml` at the **`ci-pool`** self-hosted runner label instead of `heron`.

## Why

Today every workflow — `ci`, `pr-review`, `issue-triage`, `issue-implement` (wiwi), `pr-review-probe` — targets the single `heron` runner, so they all serialize on one machine. A long CI compile (or a soak job) head-of-lines the short AI agent jobs, which is exactly the queue stall we hit (wiwi/pr-review waiting behind CI).

This moves CI onto dedicated capacity:
- **`ci`** → `ci-pool` (a self-hosted runner provisioned with the full toolchain: rustup stable + clippy, bun, Node, python3, libpcap-dev).
- **agent workflows** → unchanged (`heron`), so they now have that runner to themselves and no longer queue behind CI.

## Notes

- No behavior/logic change to the CI steps themselves — only `runs-on`.
- Agent jobs must stay on `heron` (they reach an internal model gateway only that runner can route to), so they are intentionally **not** moved.
- This PR's own CI run executes on the new `ci-pool` runner — a live smoke test of the pool.
- Follow-up (optional): add a second `ci-pool` runner for CI redundancy/parallelism so a single pool host is not a SPOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)