### PR TITLE
feat(agent-bot): wiwi auto-revises on vivi CHANGES_REQUESTED (bounded loop)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -108,16 +108,19 @@ jobs:
       - name: Fetch base for diff
         run: git fetch origin "${{ steps.pr.outputs.base_ref }}" --depth 200
 
-      - name: Overlay reviewer scripts from default branch
-        # PRs older than the AI-reviewer feature don't carry
-        # scripts/pr-review/ on their head. Always overlay the latest
-        # reviewer scripts from the default branch so we run a single
-        # canonical reviewer regardless of PR vintage. The PR head's
-        # source tree is left otherwise untouched — the agent still
-        # sees the code under review, not main's code.
+      - name: Overlay reviewer + agent-bot scripts from default branch
+        # PRs older than a given agent-bot feature don't carry the matching
+        # scripts on their head. Always overlay the canonical versions from
+        # the default branch so the reviewer (scripts/pr-review), the
+        # auto-merge gate and the revise dispatcher (scripts/agent-bot) run
+        # one canonical implementation regardless of PR vintage. The PR
+        # head's source tree is left otherwise untouched — the agent still
+        # sees the code under review, not main's code. (Safe here because
+        # this workflow never commits; pr-revise.yml, which does, fetches its
+        # driver to /tmp instead.)
         run: |
           git fetch origin "${{ github.event.repository.default_branch }}" --depth 1
-          git checkout "origin/${{ github.event.repository.default_branch }}" -- scripts/pr-review
+          git checkout "origin/${{ github.event.repository.default_branch }}" -- scripts/pr-review scripts/agent-bot
 
       - name: Run review agent
         id: review
@@ -152,6 +155,20 @@ jobs:
           GH_TOKEN:  ${{ secrets.AGENT_GH_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: bash scripts/agent-bot/auto_merge.sh
+
+      - name: Dispatch revise if vivi requested changes
+        # Mirror of the auto-merge gate for the other verdict: when vivi
+        # REQUEST_CHANGES a wiwi PR (label `auto-agent`), kick off the
+        # pr-revise workflow so wiwi addresses the feedback automatically.
+        # Idempotent + safe for every PR — bails for human PRs, non-blocking
+        # verdicts, and once the round cap is hit (then it escalates to a
+        # human). Needs AGENT_GH_TOKEN: a `gh workflow run` from GITHUB_TOKEN
+        # would be suppressed by GitHub's anti-recursion rule.
+        if: ${{ steps.review.outcome == 'success' }}
+        env:
+          GH_TOKEN:  ${{ secrets.AGENT_GH_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: bash scripts/agent-bot/revise_dispatch.sh
 
       - name: Cleanup transient files
         if: always()

--- a/.github/workflows/pr-revise.yml
+++ b/.github/workflows/pr-revise.yml
@@ -1,0 +1,105 @@
+name: pr-revise
+
+# wiwi REVISION pass. Dispatched by pr-review.yml's tail (via
+# scripts/agent-bot/revise_dispatch.sh) when vivi posts a CHANGES_REQUESTED
+# review on a wiwi PR (label `auto-agent`) and the round cap isn't hit.
+#
+# It checks out the PR head branch, runs run_revise.sh to address vivi's
+# blocking feedback, and pushes back — which re-triggers ci → pr-review, so
+# vivi re-reviews the revised PR. The loop is bounded by the cap enforced in
+# revise_dispatch.sh (default 3 CHANGES_REQUESTED rounds → escalate to human).
+#
+# Dispatch-only (workflow_dispatch): the trigger comes from a PAT-authenticated
+# `gh workflow run`, because a review posted by GITHUB_TOKEN cannot start a new
+# workflow run (GitHub anti-recursion).
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to revise
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # One revision in flight per PR; a fresh dispatch supersedes it.
+  group: pr-revise-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  revise:
+    runs-on: [self-hosted, heron]
+    # Agent pool (not ci-pool): run_revise.sh drives the `claude` CLI against
+    # the internal model gateway, which only this pool can reach.
+    timeout-minutes: 120
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+      ANTHROPIC_API_KEY:  ${{ secrets.LITELLM_API_KEY }}
+      ANTHROPIC_MODEL:    claude-3-5-sonnet-20241022
+    steps:
+      - name: Configure no_proxy for the model gateway
+        run: |
+          {
+            echo "no_proxy=${{ secrets.LITELLM_NO_PROXY }}"
+            echo "NO_PROXY=${{ secrets.LITELLM_NO_PROXY }}"
+          } >> "$GITHUB_ENV"
+
+      - name: Resolve PR head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REF=$(gh pr view "${{ inputs.pr_number }}" \
+                  --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+          [ -n "$REF" ] || { echo "::error::cannot resolve PR head branch"; exit 1; }
+          echo "head_ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          fetch-depth: 0
+
+      - name: Use AGENT_GH_TOKEN for git push (so ci / pr-review re-trigger)
+        env:
+          AGENT_GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+        run: |
+          if [ -z "$AGENT_GH_TOKEN" ]; then
+            echo "::warning::AGENT_GH_TOKEN unset; revise push would use GITHUB_TOKEN and downstream ci/pr-review would be suppressed." >&2
+            exit 0
+          fi
+          # Same extraheader dance as issue-implement.yml: clear the
+          # checkout-installed GITHUB_TOKEN basic-auth header so the
+          # PAT-embedded push URL (which has `workflow` scope) is the sole
+          # credential on push.
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git remote set-url --push origin \
+            "https://x-access-token:${AGENT_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Fetch driver scripts from the default branch
+        # The PR head may predate this feature and not carry run_revise.sh /
+        # lib helpers. Extract the canonical driver from the default branch
+        # into /tmp (NOT the worktree, so it can't be accidentally committed
+        # by run_revise.sh's `git add -A`).
+        run: |
+          git fetch origin "${{ github.event.repository.default_branch }}" --depth 1
+          mkdir -p /tmp/revise-driver
+          git archive "origin/${{ github.event.repository.default_branch }}" \
+            scripts/agent-bot scripts/lib | tar -x -C /tmp/revise-driver
+
+      - name: Revise per vivi's review
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GH_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: bash /tmp/revise-driver/scripts/agent-bot/run_revise.sh
+
+      - name: Cleanup transient files
+        if: always()
+        run: rm -f /tmp/wiwi-revise-*.md /tmp/wiwi-revise-*.log /tmp/wiwi-revise-*.txt || true

--- a/docs/pr-review-agent.md
+++ b/docs/pr-review-agent.md
@@ -115,6 +115,42 @@ If the merge fails (merge conflict, branch protection surprise,
 …) it's logged but the workflow stays green — the review is
 already posted, an operator can finish the merge by hand.
 
+## Auto-revise on CHANGES_REQUESTED (wiwi follow-up)
+
+The mirror image of auto-merge. When vivi's verdict is
+**REQUEST_CHANGES** on a **wiwi** PR (label `auto-agent`),
+`scripts/agent-bot/revise_dispatch.sh` (run from pr-review.yml's tail)
+dispatches the **`pr-revise`** workflow. That workflow checks out the PR
+head branch, runs `scripts/agent-bot/run_revise.sh` to feed vivi's
+blocking feedback + the diff back to the dev agent, and — once the build
+is green — commits and pushes. The push re-triggers `ci` → `pr-review`,
+so vivi re-reviews the revised PR. On the next APPROVE the existing
+auto-merge gate lands it; no human in the loop for the happy path.
+
+```
+vivi REQUEST_CHANGES (auto-agent PR)
+  → revise_dispatch.sh → gh workflow run pr-revise
+  → run_revise.sh: address review · build green · commit · push
+  → ci → pr-review (vivi re-review) ──┐
+        APPROVE → auto-merge          │
+        REQUEST_CHANGES again ────────┘  (loop, bounded)
+```
+
+Two implementation constraints worth knowing:
+
+- **PAT, not GITHUB_TOKEN.** The dispatch uses `AGENT_GH_TOKEN`. A
+  `gh workflow run` (or a review) issued with the default `GITHUB_TOKEN`
+  is dropped by GitHub's anti-recursion rule, and the dispatched run must
+  itself be able to push and re-trigger `ci`/`pr-review`.
+- **Bounded loop.** `revise_dispatch.sh` counts vivi's
+  CHANGES_REQUESTED reviews on the PR; at `MAX_REVISE_ROUNDS` (default 3)
+  it stops dispatching, adds a `needs-human` label, and comments — so a
+  wiwi ↔ vivi disagreement can't spin forever. Remove the label and
+  re-run `pr-revise` to resume.
+
+The agent pool (`heron`) runs `pr-revise` because `run_revise.sh` drives
+the model gateway, same as the reviewer and wiwi.
+
 ## Cost / latency
 
 The model runs on a locally-served backend. No per-request cost; the

--- a/scripts/agent-bot/revise_dispatch.sh
+++ b/scripts/agent-bot/revise_dispatch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Called from the tail of pr-review.yml AFTER vivi posts her review.
+# If vivi REQUEST_CHANGES'd a wiwi PR (label `auto-agent`), dispatch the
+# `pr-revise` workflow so wiwi addresses the feedback automatically — unless
+# the round cap is reached, in which case hand off to a human.
+#
+# Idempotent + safe to call for every PR: it bails out for human PRs, for
+# non-CHANGES_REQUESTED verdicts, and for closed PRs.
+#
+# REQUIRES AGENT_GH_TOKEN (a PAT) as GH_TOKEN. A `gh workflow run` issued with
+# the default GITHUB_TOKEN would be dropped by GitHub's anti-recursion rule
+# (events from GITHUB_TOKEN don't start new workflow runs), and the dispatched
+# revise run must itself be able to push + re-trigger ci/pr-review.
+set -euo pipefail
+
+PR="${PR_NUMBER:?PR_NUMBER required}"
+# Number of times vivi may block a PR before we stop auto-revising and
+# escalate. Counts CHANGES_REQUESTED reviews already on the PR (including the
+# one just posted), so cap=3 gives wiwi two automated revision attempts.
+MAX_REVISE_ROUNDS="${MAX_REVISE_ROUNDS:-3}"
+
+meta=$(gh pr view "$PR" --json labels,reviews,state)
+
+[ "$(echo "$meta" | jq -r '.state')" = "OPEN" ] || { echo "PR #$PR not open; skip"; exit 0; }
+echo "$meta" | jq -r '.labels[].name' | grep -qx auto-agent || { echo "PR #$PR not auto-agent; skip"; exit 0; }
+
+# vivi review states in chronological order. Identify vivi the same way
+# auto_merge.sh does (login OR the vivi footer in the body).
+vivi_states=$(echo "$meta" | jq -r '
+  [ .reviews[]
+    | select(.author.login=="vivi" or ((.body // "") | contains("vivi")))
+    | .state ] | .[]')
+
+latest=$(printf '%s\n' "$vivi_states" | grep -v '^$' | tail -1 || true)
+if [ "$latest" != "CHANGES_REQUESTED" ]; then
+  echo "vivi latest verdict=${latest:-none} (not CHANGES_REQUESTED); skip"
+  exit 0
+fi
+
+rounds=$(printf '%s\n' "$vivi_states" | grep -c CHANGES_REQUESTED || true)
+
+if [ "$rounds" -ge "$MAX_REVISE_ROUNDS" ]; then
+  echo "revise rounds=$rounds ≥ cap=$MAX_REVISE_ROUNDS — escalating PR #$PR to a human"
+  gh label create needs-human --color B60205 \
+    --description "Auto-agent loop paused; needs a human" 2>/dev/null || true
+  gh pr edit "$PR" --add-label needs-human >/dev/null 2>&1 || true
+  gh pr comment "$PR" --body "🤖 vivi has requested changes ${rounds}× — at the auto-revise cap (\`${MAX_REVISE_ROUNDS}\`). Pausing the wiwi ↔ vivi loop and handing off to a human. To resume an automated pass, remove the \`needs-human\` label and re-run the \`pr-revise\` workflow for this PR."
+  exit 0
+fi
+
+echo "vivi REQUEST_CHANGES on auto-agent PR #$PR (round $rounds/$MAX_REVISE_ROUNDS) → dispatching pr-revise"
+gh workflow run pr-revise.yml -f pr_number="$PR"

--- a/scripts/agent-bot/run_revise.sh
+++ b/scripts/agent-bot/run_revise.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# wiwi REVISION pass. Dispatched (via pr-revise.yml) when vivi posts a
+# CHANGES_REQUESTED review on a wiwi PR (label `auto-agent`). Runs inside a
+# checkout of the PR head branch, feeds vivi's blocking feedback + the diff
+# to claude, ensures the build is green, then commits + pushes back — which
+# re-triggers ci → pr-review (vivi re-review). Mirrors run_wiwi.sh's
+# LiteLLM-wait + claude-retry plumbing so the two agents behave identically
+# under a flaky backend.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PR="${PR_NUMBER:?PR_NUMBER required}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+
+git config user.email "wiwi-agent@noreply.local"
+git config user.name  "wiwi"
+
+# --- gather vivi's feedback + the diff for the prompt ---------------------
+# Latest CHANGES_REQUESTED review body. Identify vivi the same way
+# auto_merge.sh does (author login OR the vivi footer), so attribution
+# quirks between bot accounts don't drop the review.
+REVIEW_BODY=$(gh api "repos/$REPO/pulls/$PR/reviews" --jq '
+  [ .[]
+    | select(.user.login=="vivi" or ((.body // "") | contains("vivi")))
+    | select(.state=="CHANGES_REQUESTED") ]
+  | last | .body // ""' 2>/dev/null || true)
+
+# Inline (file/line) review comments, if any.
+INLINE=$(gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq '
+  .[] | "- \(.path):\(.line // .original_line // "?") — \((.body // "") | gsub("\n"; " "))"' \
+  2>/dev/null || true)
+
+# The diff under review (truncated — the agent also has the working tree).
+DIFF=$(gh pr diff "$PR" 2>/dev/null | head -c 60000 || true)
+
+if [ -z "${REVIEW_BODY//[[:space:]]/}" ]; then
+  echo "::warning::no CHANGES_REQUESTED review body found for PR #$PR; nothing to revise" >&2
+  exit 0
+fi
+
+PROMPT=$(mktemp)
+cat > "$PROMPT" <<EOF
+You are **wiwi**, the dev agent, doing a REVISION pass on PR #${PR}. The
+reviewer **vivi** requested changes. The PR's head branch is already checked
+out in the current working tree. Address the review here. Constraints:
+
+- Fix EVERY **Blocking** item vivi listed. Apply Suggestions where they are
+  cheap and clearly correct; if you deliberately skip one, say why in the
+  commit message. Don't argue with the review — change the code (or, when the
+  reviewer is factually wrong, fix the misleading code/comment that led them
+  there).
+- Keep scope to the review. Do NOT introduce unrelated changes, refactors,
+  new dependencies, new secrets, or new network calls.
+- Do NOT modify CI workflows, branch protection, or the agent-bot scripts.
+- Keep and extend deterministic tests. After edits run \`just build\` (or
+  \`cargo check\` + \`bun run build\` in console/) — it MUST be green before
+  you stop.
+- YOU are responsible for committing. Run \`git add -A && git commit -m "..."\`
+  with a message describing what you changed in response to the review. At
+  least one new commit MUST exist before you exit, or the run is dropped.
+- **You may be a RESUMED run** (a prior attempt crashed mid-revision). If
+  \`git status\` shows uncommitted edits when you start, treat them as your
+  starting point: read the diffs, build, continue — do not redo work.
+- If you cannot satisfy a blocking item without exceeding the PR's scope,
+  STOP, write the reason to /tmp/wiwi-revise-abort.txt, and exit non-zero so
+  a human can take over.
+
+=== vivi's review (CHANGES_REQUESTED) ===
+${REVIEW_BODY}
+
+=== inline review comments ===
+${INLINE:-(none)}
+
+=== PR diff under review (truncated) ===
+${DIFF}
+EOF
+
+# Wait for the model gateway before launching claude — a transient backend
+# restart during the runner queue wait would otherwise kill the run.
+LITELLM_WAIT="$(cd "$HERE/../lib" && pwd)/litellm-wait.sh"
+# shellcheck source=../lib/litellm-wait.sh
+source "$LITELLM_WAIT"
+wait_for_litellm || exit $?
+
+# Stream claude to both the workflow log and a file; retry on transient
+# backend-down failures (same policy as run_wiwi.sh).
+CLAUDE_RETRY_MAX="${CLAUDE_RETRY_MAX:-2}"
+attempt=0
+claude_exit=0
+while true; do
+    set +e
+    stdbuf -oL claude --print \
+      --allowed-tools Bash Read Write Edit Grep Glob \
+      --model "${ANTHROPIC_MODEL:-claude-3-5-sonnet-20241022}" \
+      < "$PROMPT" 2>&1 | stdbuf -oL tee /tmp/wiwi-revise-run.log
+    claude_exit=${PIPESTATUS[0]}
+    set -e
+
+    [ "$claude_exit" -eq 0 ] && break
+    if ! litellm_appears_down; then break; fi
+    if [ "$attempt" -ge "$CLAUDE_RETRY_MAX" ]; then
+        echo "::error::wiwi revise: claude died $((attempt+1))× with gateway down; giving up" >&2
+        break
+    fi
+    attempt=$((attempt + 1))
+    echo "::warning::wiwi revise: claude exited $claude_exit, gateway down; waiting + retrying ($((attempt+1))/$((CLAUDE_RETRY_MAX+1)))" >&2
+    wait_for_litellm || break
+done
+
+if [ "$claude_exit" != "0" ]; then
+  echo "wiwi revise failed (claude exit=$claude_exit; see /tmp/wiwi-revise-run.log)" >&2
+  gh pr comment "$PR" --body "🤖 wiwi could not complete the revision (see workflow log). Leaving vivi's review for a human."
+  exit 1
+fi
+
+if [ -f /tmp/wiwi-revise-abort.txt ]; then
+  gh pr comment "$PR" --body "🤖 wiwi paused the revision: $(cat /tmp/wiwi-revise-abort.txt)"
+  exit 0
+fi
+
+# Defensive fallback: salvage any uncommitted edits so a crashed-before-commit
+# run isn't lost to workspace cleanup.
+if ! git diff --quiet || ! git diff --cached --quiet || \
+   [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  echo "wiwi revise: auto-committing leftover edits (fallback)" >&2
+  git add -A
+  git commit -m "wiwi: revision for PR #${PR} (auto-commit fallback)" \
+             -m "claude finished the revision without committing; this captures the working-tree state so the review feedback isn't lost. Reviewer: squash/reword as needed."
+fi
+
+# Nothing new to push? Then the revision produced no change — say so and stop
+# rather than silently re-triggering an identical review. Compare HEAD against
+# its upstream (origin/<branch>); equal ⇒ no new commit this pass.
+upstream=$(git rev-parse '@{u}' 2>/dev/null || echo none)
+if [ "$(git rev-parse HEAD)" = "$upstream" ]; then
+  echo "wiwi revise: no new commits; nothing to push" >&2
+  gh pr comment "$PR" --body "🤖 wiwi made no changes on this revision pass — vivi's feedback may need a human. Pausing the loop."
+  exit 0
+fi
+
+git push
+gh pr comment "$PR" --body "🤖 **wiwi** pushed a revision addressing vivi's review. CI + re-review run automatically."


### PR DESCRIPTION
## What

Closes the missing edge in the agent loop: today when **vivi** posts **CHANGES_REQUESTED** on a **wiwi** PR, it just waits for a human. This makes wiwi address the feedback automatically, then vivi re-reviews — a bounded `wiwi ↔ vivi` loop that lands on the next APPROVE via the existing auto-merge gate.

```
vivi REQUEST_CHANGES (auto-agent PR)
  → revise_dispatch.sh → gh workflow run pr-revise
  → run_revise.sh: address review · build green · commit · push
  → ci → pr-review (vivi re-review) ──┐
        APPROVE → auto-merge          │
        REQUEST_CHANGES again ────────┘  (bounded by cap)
```

## Pieces

- **`scripts/agent-bot/revise_dispatch.sh`** — runs from `pr-review.yml`'s tail, the mirror of the auto-merge gate. On REQUEST_CHANGES for an `auto-agent` PR → `gh workflow run pr-revise`. Idempotent; bails for human PRs / non-blocking verdicts.
- **`.github/workflows/pr-revise.yml`** — `workflow_dispatch`; checks out the PR head branch, runs the revise driver on the `heron` agent pool (needs the model gateway).
- **`scripts/agent-bot/run_revise.sh`** — feeds vivi's blocking feedback + inline comments + the diff to the dev agent, ensures the build is green, commits + pushes (re-triggering ci → pr-review). Reuses `run_wiwi.sh`'s gateway-wait + claude-retry plumbing.
- **`pr-review.yml`** — adds the dispatch step and extends the script overlay to `scripts/agent-bot` so old PR heads run the canonical gate/dispatcher.
- **docs/pr-review-agent.md** — new "Auto-revise on CHANGES_REQUESTED" section.

## Design decisions (tunable)

- **Fully automatic** (matches the existing issue→wiwi→vivi→auto-merge philosophy). If you'd rather it be opt-in per PR, gate `revise_dispatch.sh` on a label instead of dispatching unconditionally.
- **Bounded:** `MAX_REVISE_ROUNDS` (default **3** vivi blocks). Past the cap → `needs-human` label + comment, no further dispatch. Tune via the env var.
- **PAT, not GITHUB_TOKEN:** dispatch uses `AGENT_GH_TOKEN`, because a review/dispatch from `GITHUB_TOKEN` is dropped by GitHub's anti-recursion rule and the dispatched run must push + re-trigger ci/pr-review.

## Safety

- Only acts on `auto-agent` (wiwi) PRs; human PRs untouched.
- The final merge still goes through the unchanged vivi-APPROVE + `auto_merge.sh` (team-author) gates.
- run_revise.sh is told to keep scope, not touch CI/workflows/agent-bot, keep the build green, and escalate (abort) if it can't satisfy a blocking item within scope.
- `bash -n` + YAML parse + `check-leakage.sh` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)