### PR TITLE
ci(staging): stamp `staging-soaked` commit status — prod go/no-go signal

### DIFF
--- a/.github/workflows/staging-soak.yml
+++ b/.github/workflows/staging-soak.yml
@@ -29,11 +29,49 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, staging-deploy]
     timeout-minutes: 15
+    # statuses:write lets the final step stamp a `staging-soaked` commit
+    # status — the single authoritative "staging is green, safe to promote"
+    # signal an approver checks before approving the prod deployment.
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
 
       - name: tara soak the deployed staging binary
+        id: soak
         env:
           HERON_STAGE_VM: ${{ vars.HERON_STAGE_VM }}
           HERON_STAGE_USER: ${{ vars.HERON_STAGE_USER }}
         run: bash scripts/staging/soak-staging.sh
+
+      # Authoritative go/no-go signal for the prod-approval gate. Only the
+      # workflow_run path carries the exact deployed commit; a skipped chain
+      # (CI not green) never reaches this job, so a commit with NO
+      # `staging-soaked` status simply hasn't been soaked — don't promote it.
+      - name: Stamp `staging-soaked` commit status
+        if: ${{ always() && github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          OUTCOME: ${{ steps.soak.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$OUTCOME" = "success" ]; then
+            state="success"; desc="tara soak passed — safe to promote to prod"
+          else
+            state="failure"; desc="tara soak ${OUTCOME} — do NOT promote"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$state" \
+            -f context="staging-soaked" \
+            -f description="$desc" \
+            -f target_url="$RUN_URL" >/dev/null
+          {
+            echo "### staging-soak → \`staging-soaked\` = **${state}**"
+            echo ""
+            echo "- commit: \`${SHA}\`"
+            echo "- $desc"
+            echo ""
+            echo "Promote to prod only when this commit shows \`staging-soaked\` ✅."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/staging/README.md
+++ b/scripts/staging/README.md
@@ -87,6 +87,17 @@ This catches the regression class that compiles and passes unit tests but
 mangles live traffic — the PR#47 (validator bypassed by a direct caller) and
 PR#48 (storage poisoning under load) families.
 
+**Prod go/no-go signal.** On every real soak the workflow stamps a
+`staging-soaked` **commit status** on the soaked commit — `success` when the
+soak passed, `failure` when it didn't. This is the single authoritative thing
+to check before approving the `production` deployment: a commit showing
+`staging-soaked ✅` cleared `ci → deploy-staging → staging-soak` end to end; a
+commit with **no** `staging-soaked` status was never actually soaked (its
+chain skipped because CI wasn't green yet) — don't promote it. Don't rely on
+the mere existence of a pending `deploy-prod` run: during a merge burst those
+appear and get superseded/cancelled, and a skipped chain can't reach the
+approval gate anyway (`deploy-prod`'s `if` requires a *successful* soak).
+
 How it works — no NIC, no `tcpreplay`:
 
 - [`tara.sh`](tara.sh) starts a throwaway heron instance on a private port


### PR DESCRIPTION
## Why
"Is staging green for the build I'm about to approve for prod?" had no one-glance answer. You had to reason about skipped-vs-success cascade runs, and a transient pending `deploy-prod` (which gets superseded/cancelled during merge bursts) is **not** a reliable signal.

## What
On every **real** tara soak, `staging-soak.yml` now stamps a `staging-soaked` **commit status** on the soaked commit:
- **`success`** → `ci → deploy-staging → staging-soak` all passed end-to-end for that commit → safe to approve prod.
- **`failure`** → soak failed → do not promote.
- **no status at all** → the chain skipped (CI wasn't green yet) → the commit was never soaked → don't promote.

Plus a job summary on the soak run spelling out the commit + verdict.

## The signal, from now on
> Approve the `production` deployment only when the commit shows **`staging-soaked` ✅**.

## Note on the "pending deploy-prod" worry
No correctness bug there: `deploy-prod`'s `if: workflow_run.conclusion == 'success'` already means a skipped/un-soaked chain can't reach the approval gate (the pendings we saw resolve to cancelled when superseded). This PR doesn't change that gate — it just adds the **visible** signal that was missing. (Optional follow-up if you want belt-and-suspenders: have `deploy-prod` re-check the `staging-soaked` status before deploying.)

Workflow-only change; documented in `scripts/staging/README.md`.