### PR TITLE
refactor(filters): parse agent_kind CSV at the API layer (Vec), not in storage — root-cause fix

### DIFF
--- a/server/h-api/src/params.rs
+++ b/server/h-api/src/params.rs
@@ -135,6 +135,29 @@ mod to_time_range_tests {
     }
 }
 
+#[cfg(test)]
+mod parse_csv_tests {
+    use super::parse_csv;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn splits_trims_and_drops_empties() {
+        // The single CSV-parsing chokepoint for every multi-select filter
+        // (agent_kinds, statuses, finish_reasons, …). Parsing lives HERE, at the
+        // API boundary, so no storage backend ever sees a raw CSV to mis-handle.
+        assert_eq!(parse_csv(&Some("a,b,c".to_string())), v(&["a", "b", "c"]));
+        assert_eq!(parse_csv(&Some("a, b , c".to_string())), v(&["a", "b", "c"]));
+        assert_eq!(parse_csv(&Some("a,,b".to_string())), v(&["a", "b"]));
+        assert_eq!(parse_csv(&Some("single".to_string())), v(&["single"]));
+        assert_eq!(parse_csv(&Some("".to_string())), Vec::<String>::new());
+        assert_eq!(parse_csv(&Some("  ".to_string())), Vec::<String>::new());
+        assert_eq!(parse_csv(&None), Vec::<String>::new());
+    }
+}
+
 pub fn to_dimension_filter(
     wire_api: &Option<String>,
     model: &Option<String>,

--- a/server/h-api/src/routes/agent_sessions.rs
+++ b/server/h-api/src/routes/agent_sessions.rs
@@ -9,7 +9,7 @@ use h_storage::query::{
 use h_storage::StorageBackend;
 
 use crate::extractors::{Path, Query};
-use crate::params::to_time_range;
+use crate::params::{parse_csv, to_time_range};
 use crate::response::{ApiError, ApiResponse};
 
 #[derive(Debug, Deserialize)]
@@ -57,7 +57,9 @@ pub async fn list(
     let query = SessionListQuery {
         time_range: to_time_range(params.start, params.end)?,
         source_id: params.source_id.filter(|s| !s.is_empty()),
-        agent_kind: params.agent_kind.filter(|s| !s.is_empty()),
+        // Parse the CSV multi-select here, at the API boundary, so storage
+        // backends consume a ready Vec (same as statuses/finish_reasons/…).
+        agent_kinds: parse_csv(&params.agent_kind),
         cursor,
         page_size: params.page_size.clamp(1, 200),
     };

--- a/server/h-storage-clickhouse/src/it.rs
+++ b/server/h-storage-clickhouse/src/it.rs
@@ -638,7 +638,7 @@ async fn sessions_reads_smoke() {
         .query_sessions(&SessionListQuery {
             time_range: full_range(),
             source_id: None,
-            agent_kind: None,
+            agent_kinds: vec![],
             cursor: None,
             page_size: 10,
         })

--- a/server/h-storage-clickhouse/src/sessions.rs
+++ b/server/h-storage-clickhouse/src/sessions.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 
 use h_common::error::Result;
 use h_storage::convert::parse_json_string_list;
-use h_storage::dialect::{parse_csv, sql_in_list};
+use h_storage::dialect::sql_in_list;
 use h_storage::query::*;
 
 use crate::client::ch_err;
@@ -100,14 +100,10 @@ impl ClickHouseBackend {
         if let Some(sid) = &query.source_id {
             where_parts.push(format!("source_id = '{}'", escape_str(sid)));
         }
-        if let Some(ak) = &query.agent_kind {
-            // `agent_kind` arrives as a CSV multi-select (e.g. "claude-cli,codex-cli").
-            // Parse + IN-match so multiple kinds union, instead of exact-matching the
-            // whole CSV string (which selects nothing). Mirrors the DuckDB backend.
-            let kinds = parse_csv(ak);
-            if !kinds.is_empty() {
-                where_parts.push(format!("agent_kind IN ({})", sql_in_list(&kinds)));
-            }
+        // agent_kinds is the CSV multi-select, already parsed at the API layer.
+        // IN-match so multiple kinds union; empty = no filter. Mirrors DuckDB.
+        if !query.agent_kinds.is_empty() {
+            where_parts.push(format!("agent_kind IN ({})", sql_in_list(&query.agent_kinds)));
         }
         let where_sql = where_parts.join(" AND ");
 

--- a/server/h-storage-duckdb/src/sessions.rs
+++ b/server/h-storage-duckdb/src/sessions.rs
@@ -2,7 +2,6 @@
 //! grouped by `(source_id, session_id)` — no schema of their own.
 
 use h_common::error::{AppError, Result};
-use h_storage::dialect::parse_csv;
 use h_storage::query::*;
 
 use crate::util::{
@@ -31,11 +30,8 @@ impl DuckDbBackend {
             if let Some(sid) = &query.source_id {
                 where_parts.push(format!("source_id = '{}'", sid.replace('\'', "''")));
             }
-            if let Some(ak) = &query.agent_kind {
-                let kinds = parse_csv(ak);
-                if !kinds.is_empty() {
-                    where_parts.push(format!("agent_kind IN ({})", sql_in_list(&kinds)));
-                }
+            if !query.agent_kinds.is_empty() {
+                where_parts.push(format!("agent_kind IN ({})", sql_in_list(&query.agent_kinds)));
             }
             let where_sql = where_parts.join(" AND ");
 
@@ -680,65 +676,41 @@ mod tests {
             end_us: base + 10_000_000,
         };
 
-        // Test 1: Single kind filter (no regression)
+        // Single kind → only those sessions (no regression).
         let query_single = SessionListQuery {
             time_range: time_range.clone(),
             source_id: None,
-            agent_kind: Some("claude-cli".to_string()),
+            agent_kinds: vec!["claude-cli".to_string()],
             cursor: None,
             page_size: 100,
         };
         let page_single = backend.query_sessions(&query_single).await.unwrap();
         assert_eq!(page_single.items.len(), 2);
-        let kinds: Vec<_> = page_single.items.iter().map(|s| s.agent_kind.as_str()).collect();
-        assert!(kinds.iter().all(|k| *k == "claude-cli"));
+        assert!(page_single.items.iter().all(|s| s.agent_kind == "claude-cli"));
 
-        // Test 2: Multiple kinds (CSV) should return union
+        // Multiple kinds → union. (The bug: a raw-CSV exact-match returns 0 here.)
         let query_multi = SessionListQuery {
             time_range: time_range.clone(),
             source_id: None,
-            agent_kind: Some("claude-cli,codex-cli".to_string()),
+            agent_kinds: vec!["claude-cli".to_string(), "codex-cli".to_string()],
             cursor: None,
             page_size: 100,
         };
         let page_multi = backend.query_sessions(&query_multi).await.unwrap();
         assert_eq!(page_multi.items.len(), 3);
         let kinds: Vec<_> = page_multi.items.iter().map(|s| s.agent_kind.as_str()).collect();
-        assert!(kinds.contains(&"claude-cli"));
-        assert!(kinds.contains(&"codex-cli"));
+        assert!(kinds.contains(&"claude-cli") && kinds.contains(&"codex-cli"));
         assert!(!kinds.contains(&"openclaw"));
 
-        // Test 3: CSV with spaces
-        let query_spaces = SessionListQuery {
+        // Empty Vec → no filter → all sessions. (CSV parsing / trimming / empties
+        // are the API layer's job now; see h-api `parse_csv` tests.)
+        let query_all = SessionListQuery {
             time_range: time_range.clone(),
             source_id: None,
-            agent_kind: Some("claude-cli, codex-cli, openclaw".to_string()),
+            agent_kinds: vec![],
             cursor: None,
             page_size: 100,
         };
-        let page_spaces = backend.query_sessions(&query_spaces).await.unwrap();
-        assert_eq!(page_spaces.items.len(), 4);
-
-        // Test 4: Empty string should match all
-        let query_empty = SessionListQuery {
-            time_range: time_range.clone(),
-            source_id: None,
-            agent_kind: Some("".to_string()),
-            cursor: None,
-            page_size: 100,
-        };
-        let page_empty = backend.query_sessions(&query_empty).await.unwrap();
-        assert_eq!(page_empty.items.len(), 4);
-
-        // Test 5: None should match all
-        let query_none = SessionListQuery {
-            time_range: time_range.clone(),
-            source_id: None,
-            agent_kind: None,
-            cursor: None,
-            page_size: 100,
-        };
-        let page_none = backend.query_sessions(&query_none).await.unwrap();
-        assert_eq!(page_none.items.len(), 4);
+        assert_eq!(backend.query_sessions(&query_all).await.unwrap().items.len(), 4);
     }
 }

--- a/server/h-storage-duckdb/src/turns.rs
+++ b/server/h-storage-duckdb/src/turns.rs
@@ -1279,7 +1279,7 @@ mod tests {
                     end_us: us(60),
                 },
                 source_id: None,
-                agent_kind: None,
+                agent_kinds: vec![],
                 cursor: None,
                 page_size: 10,
             })
@@ -1312,7 +1312,7 @@ mod tests {
                     end_us: us(60),
                 },
                 source_id: None,
-                agent_kind: None,
+                agent_kinds: vec![],
                 cursor: None,
                 page_size: 1,
             })
@@ -1330,7 +1330,7 @@ mod tests {
                     end_us: us(60),
                 },
                 source_id: None,
-                agent_kind: None,
+                agent_kinds: vec![],
                 cursor: Some(decoded),
                 page_size: 1,
             })

--- a/server/h-storage/src/dialect.rs
+++ b/server/h-storage/src/dialect.rs
@@ -19,21 +19,6 @@ pub fn sql_in_list(values: &[String]) -> String {
         .join(", ")
 }
 
-/// Split a comma-separated multi-select filter value (e.g. the `agent_kind`
-/// query param `"claude-cli,codex-cli"`) into trimmed, non-empty parts.
-///
-/// Shared by every storage backend so the CSV → IN-list filter behaves
-/// identically across them — the `agent_kind` multi-select bug recurred
-/// precisely because each backend (and the turns vs sessions paths) kept its
-/// own copy and a fix missed one. One definition, no drift. The API layer has
-/// its own equivalent (`h-api`) for params it parses before they reach storage.
-pub fn parse_csv(s: &str) -> Vec<String> {
-    s.split(',')
-        .map(|v| v.trim().to_string())
-        .filter(|v| !v.is_empty())
-        .collect()
-}
-
 /// Build a WHERE clause segment for dimension filters on an ungrouped query.
 ///
 /// The aggregator (see `h-metrics/src/aggregator.rs:dimension_keys`) only
@@ -120,21 +105,6 @@ fn build_tool_surface_clause(surfaces: &[String]) -> String {
         String::new()
     } else {
         format!(" AND tool_surface IN ({})", sql_in_list(surfaces))
-    }
-}
-
-#[cfg(test)]
-mod parse_csv_tests {
-    use super::parse_csv;
-
-    #[test]
-    fn splits_trims_and_drops_empties() {
-        assert_eq!(parse_csv("a,b,c"), vec!["a", "b", "c"]);
-        assert_eq!(parse_csv("a, b , c"), vec!["a", "b", "c"]);
-        assert_eq!(parse_csv("a,,b"), vec!["a", "b"]);
-        assert_eq!(parse_csv("single"), vec!["single"]);
-        assert_eq!(parse_csv(""), Vec::<String>::new());
-        assert_eq!(parse_csv("  "), Vec::<String>::new());
     }
 }
 

--- a/server/h-storage/src/query.rs
+++ b/server/h-storage/src/query.rs
@@ -623,8 +623,13 @@ pub struct SessionListQuery {
     /// a `source_id` (TurnTracker partition key), so pushing this into the
     /// WHERE clause is safe and does not truncate lifetime aggregates.
     pub source_id: Option<String>,
-    /// Optional agent_kind filter. Also session-stable, so WHERE is safe.
-    pub agent_kind: Option<String>,
+    /// agent_kind multi-select filter, already CSV-parsed at the API layer
+    /// (empty = no filter). Held as a `Vec`, NOT a raw CSV string, so no storage
+    /// backend has to remember to parse it — the omission that made the
+    /// multi-select filter silently match nothing across turns→sessions→
+    /// clickhouse. Matches every other multi-select filter (statuses,
+    /// finish_reasons, …), which the API also parses up front.
+    pub agent_kinds: Vec<String>,
     pub cursor: Option<SessionListCursor>,
     pub page_size: u32,
 }


### PR DESCRIPTION
Root-cause fix for the recurring `agent_kind` multi-select bug (the one #111 +
its follow-ups patched per-site). It kept coming back — turns→sessions, then
duckdb→clickhouse — because `agent_kind` was the **one** multi-select filter
handed to storage as a raw CSV `Option<String>` and parsed **late, in each
backend**. So every backend had to remember to split it, one always forgot, and
the whole `"a,b"` string got exact-matched against a single value → 0 rows.

Every *other* multi-select filter (statuses, finish_reasons, wire_apis, …) is
parsed to a `Vec` at the API boundary; storage just consumes the Vec.
`agent_kind` was the lone exception. This removes the exception.

## Change
- `SessionListQuery.agent_kind: Option<String>` → `agent_kinds: Vec<String>`.
- API (`agent_sessions::list`) parses once via h-api `parse_csv` — the same call
  the turns route already uses — so **storage never sees a raw CSV**.
- Both backends drop their `parse_csv` call: just `agent_kind IN
  (sql_in_list(&query.agent_kinds))` when non-empty. No per-backend parsing left
  to forget → the failure mode is structurally impossible.
- Remove the now-unused `h_storage::dialect::parse_csv` (the interim shared
  helper from #111); the canonical parser is h-api's, at the boundary.
- CSV edge cases (trim / empties / None) move to h-api `parse_csv_tests`; the
  storage test now asserts Vec→IN (single, union, empty).

## Compatibility
HTTP API **unchanged** — `agent_kind=a,b` is still a CSV query param; only the
internal type changed. No frontend change.

## Verified
Full workspace builds (incl. heron app); h-api / h-storage / duckdb
sessions+turns tests green; clickhouse compiles (its `it.rs` needs a live
server); clippy clean on the changed crates; leakage lint green.