### PR TITLE
fix(deploy-prod): supersede older waiting runs (cancel-in-progress: true) — kills the pile-up wedge

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,9 +23,19 @@ on:
         description: commit to deploy (default origin/main)
         required: false
 
+# Supersede, don't pile up. Every merge to main triggers a deploy-prod that
+# parks in `waiting` for manual approval. With cancel-in-progress: false those
+# unapproved runs accumulated, and because a waiting run holds the group, the
+# FIRST un-approved one blocked every later one as `pending` forever (the prod
+# pipeline wedge of 2026-06-03 — manual `gh run cancel` was the only way out).
+# cancel-in-progress: true makes a newer deploy-prod cancel the older waiting
+# one, so there is always exactly ONE waiting run — the latest main — ready to
+# approve. (deploy-prod.sh builds before touching the service and is health-
+# gated + auto-rollback, so a cancel during the brief approved-and-running
+# window is safe; the next run redeploys latest cleanly.)
 concurrency:
   group: deploy-prod
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## The structural cause of the 2026-06-03 prod-pipeline wedge

Every merge to main triggers a `deploy-prod` run that parks in **`waiting`** for
manual approval. With `cancel-in-progress: false`, those un-approved runs
**accumulate**, and a `waiting` run **holds** the `deploy-prod` concurrency
group — so the first un-approved one blocks every later run as `pending`
**forever**. That's exactly what happened: a deploy-prod left `waiting` since the
morning stalled all afternoon deploys; new merges (and even manual dispatches)
sat `pending` with a free runner, and the only fix was `gh run cancel` by hand.
Clearing it once doesn't help — the very next merge re-wedges.

## Fix
`cancel-in-progress: true` → a newer deploy-prod **cancels** the older `waiting`
one. There's always exactly **one** waiting run — the latest `main` — ready to
approve. Deploying the latest is what you want anyway; older waiting runs are
superseded by definition.

**Safety:** `deploy-prod.sh` builds *before* touching the service (a cancel
mid-build leaves prod untouched) and is health-gated with auto-rollback, so a
cancel during the brief approved-and-running window is safe; the next run
redeploys latest cleanly.

Verified: YAML parses. Pairs with #115 (which fixed the *other* half — the
`gh`-not-found that was spuriously failing the soak and blocking the gate).