### PR TITLE
feat(test): pcap regression corpus framework (scrub + manifest + golden, git-LFS)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Curated pcap corpus is stored via git-LFS (large binary wire captures).
+# Only testdata/pcaps/corpus/ is LFS-tracked; the legacy hand-distributed
+# fixtures under testdata/pcaps/*.pcap stay gitignored, and the small plain
+# protocol fixture under server/h-protocol/tests/fixtures/ stays committed
+# in-tree (unchanged).
+testdata/pcaps/corpus/*.pcap filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Pull the git-LFS pcap corpus (testdata/pcaps/corpus/*.pcap) so the
+          # corpus_golden regression tests run instead of skipping. Needs
+          # git-lfs on the runner; if a fixture stays an unsmudged pointer the
+          # harness skips it rather than parsing the pointer as a pcap.
+          lfs: true
 
       - name: Toolchain versions
         run: |
@@ -72,6 +78,12 @@ jobs:
         # IP or a private-key PEM block. The PR-review agent carries the
         # semantic half (plaintext passwords, internal hostnames, paths).
         run: bash scripts/lint/check-leakage.sh
+
+      - name: lint — pcap corpus (manifest consistency + binary leakage)
+        # check-leakage.sh skips binary files, so committed corpus pcaps are
+        # NOT scanned there — this is the secret gate for the binary corpus,
+        # plus manifest↔file↔golden consistency.
+        run: bash scripts/lint/check-pcap-corpus.sh
 
       - name: lint — leakage linter self-test
         # Guards the leakage gate itself: a regression in check-leakage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,12 @@ server/data/
 *.duckdb
 *.duckdb.wal
 
-# Test pcap fixtures (large; not checked in)
+# Legacy hand-distributed pcap fixtures (large; not checked in). The curated,
+# scrubbed corpus under testdata/pcaps/corpus/ IS committed (via git-LFS — see
+# .gitattributes) and is deliberately NOT matched by this top-level-only glob.
 /testdata/pcaps/*.pcap
+# Scratch area for raw, unscrubbed captures — never commit these.
+/testdata/pcaps/raw/
 
 # Build artifacts
 *.o

--- a/justfile
+++ b/justfile
@@ -96,3 +96,17 @@ loc *args:
 # Run on the host where ClickHouse is on loopback. Env: CLICKHOUSE_URL, CALLS, …
 bench-storage:
     @bash scripts/bench-storage.sh
+
+# 🧪 PCAP regression corpus (test | bless | lint)
+#   just corpus test    Replay corpus/*.pcap, assert goldens (skips absent/LFS-pointer)
+#   just corpus bless   Regenerate goldens (review the diff before committing)
+#   just corpus lint    Manifest consistency + binary-payload leakage scan
+corpus action="test":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{action}}" in
+      test)  cd server && cargo test -p h-turn --test corpus_golden -- --nocapture ;;
+      bless) cd server && HERON_BLESS_GOLDENS=1 cargo test -p h-turn --test corpus_golden -- --nocapture ;;
+      lint)  bash scripts/lint/check-pcap-corpus.sh ;;
+      *) echo "usage: just corpus [test|bless|lint]"; exit 2 ;;
+    esac

--- a/scripts/lint/check-pcap-corpus.sh
+++ b/scripts/lint/check-pcap-corpus.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Corpus integrity + secret gate. `check-leakage.sh` skips binary files
+# (grep -I), so committed .pcap fixtures are NOT scanned by it — THIS is the
+# secret guard for the binary corpus, plus manifest↔file consistency.
+#
+# Checks:
+#   1. Every active corpus.toml entry has a committed corpus/<file> and a
+#      golden/<id>.json.
+#   2. No orphan corpus/*.pcap that no manifest entry references.
+#   3. Payload leakage scan over corpus/*.pcap bytes (RFC1918 IPs, provider
+#      keys, JWTs, PEM private keys, /Users|/home/<user> paths).
+#
+# Portable to bash 3.2 (no mapfile / associative arrays).
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+MANIFEST="$ROOT/testdata/pcaps/corpus.toml"
+CORPUS="$ROOT/testdata/pcaps/corpus"
+GOLDEN="$ROOT/testdata/pcaps/golden"
+
+[ -f "$MANIFEST" ] || { echo "missing $MANIFEST"; exit 1; }
+
+fail=0
+note() { echo "check-pcap-corpus: $*"; }
+
+ROWS_TMP=$(mktemp)
+REF_TMP=$(mktemp)
+trap 'rm -f "$ROWS_TMP" "$REF_TMP"' EXIT
+
+# --- parse manifest (id|file|status); dependency-free, no tomllib (py3.8+) ---
+python3 - "$MANIFEST" > "$ROWS_TMP" <<'PY'
+import sys, re
+rows, cur, capture = [], None, False
+for line in open(sys.argv[1], encoding="utf-8"):
+    s = line.strip()
+    if s == "[[fixture]]":
+        if cur is not None:
+            rows.append(cur)
+        cur, capture = {"id": "", "file": "", "status": "active"}, True
+        continue
+    if s.startswith("["):  # any nested sub-table ([fixture.expect] etc.)
+        capture = False
+        continue
+    if cur is not None and capture:
+        m = re.match(r'(\w+)\s*=\s*"(.*?)"', s)
+        if m and m.group(1) in ("id", "file", "status"):
+            cur[m.group(1)] = m.group(2)
+if cur is not None:
+    rows.append(cur)
+for r in rows:
+    print(f"{r['id']}|{r['file']}|{r['status']}")
+PY
+
+while IFS='|' read -r id file status; do
+  [ -n "$id" ] || continue
+  if [ "$id" = "ERR" ]; then echo "manifest parse error"; exit 1; fi
+  if [ -z "$file" ]; then note "entry '$id' missing file"; fail=1; continue; fi
+  echo "$file" >> "$REF_TMP"
+  if [ "${status:-active}" = "active" ]; then
+    [ -f "$CORPUS/$file" ] || { note "ACTIVE '$id' references missing corpus/$file"; fail=1; }
+    [ -f "$GOLDEN/$id.json" ] || { note "ACTIVE '$id' missing golden/$id.json (run 'just corpus bless')"; fail=1; }
+  fi
+done < "$ROWS_TMP"
+
+# --- no orphan pcaps --------------------------------------------------------
+if [ -d "$CORPUS" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    base=$(basename "$p")
+    grep -qxF "$base" "$REF_TMP" || { note "orphan corpus/$base not in manifest"; fail=1; }
+  done < <(find "$CORPUS" -name '*.pcap' 2>/dev/null)
+fi
+
+# --- payload leakage scan (skip git-LFS pointer files) ----------------------
+scan_one() {
+  f="$1"
+  if head -c 64 "$f" 2>/dev/null | grep -q "version https://git-lfs"; then
+    note "skip leakage scan (LFS pointer, not smudged): $(basename "$f")"; return 0
+  fi
+  hits=$(LC_ALL=C grep -aoE \
+    'sk-(ant-)?[A-Za-z0-9_-]{12,}|eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|\b(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3})\b' \
+    "$f" 2>/dev/null | grep -avE '^X+$' | sort -u | head -20 || true)
+  paths=$(LC_ALL=C grep -aoE '/(Users|home)/[A-Za-z0-9._-]+' "$f" 2>/dev/null | grep -avE '/(Users|home)/X+$' | sort -u | head -10 || true)
+  if [ -n "$hits" ] || [ -n "$paths" ]; then
+    note "LEAKAGE in $(basename "$f"):"
+    [ -n "$hits" ] && echo "$hits" | sed 's/^/    /'
+    [ -n "$paths" ] && echo "$paths" | sed 's/^/    /'
+    return 1
+  fi
+  return 0
+}
+
+if [ -d "$CORPUS" ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    scan_one "$f" || fail=1
+  done < <(find "$CORPUS" -name '*.pcap' 2>/dev/null)
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-pcap-corpus: ✗ FAILED"
+  exit 1
+fi
+echo "check-pcap-corpus: ✓ manifest consistent, no leakage in corpus/*.pcap"

--- a/scripts/lint/check-pcap-corpus.sh
+++ b/scripts/lint/check-pcap-corpus.sh
@@ -77,10 +77,13 @@ scan_one() {
   if head -c 64 "$f" 2>/dev/null | grep -q "version https://git-lfs"; then
     note "skip leakage scan (LFS pointer, not smudged): $(basename "$f")"; return 0
   fi
+  # IP class MUST stay in sync with check-leakage.sh PRIV_IP_RE (RFC1918 + CGNAT
+  # 100.64/10). CGNAT matters here — the host's tailscale range (100.x) is the
+  # kind of internal addr a real capture could carry.
   hits=$(LC_ALL=C grep -aoE \
-    'sk-(ant-)?[A-Za-z0-9_-]{12,}|eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|\b(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3})\b' \
+    'sk-(ant-)?[A-Za-z0-9_-]{12,}|eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|\b(10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}|192\.168\.[0-9]{1,3}\.[0-9]{1,3}|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3})\b' \
     "$f" 2>/dev/null | grep -avE '^X+$' | sort -u | head -20 || true)
-  paths=$(LC_ALL=C grep -aoE '/(Users|home)/[A-Za-z0-9._-]+' "$f" 2>/dev/null | grep -avE '/(Users|home)/X+$' | sort -u | head -10 || true)
+  paths=$(LC_ALL=C grep -aoE '/(Users|home|root)/[A-Za-z0-9._-]+' "$f" 2>/dev/null | grep -avE '/(Users|home|root)/X+$' | sort -u | head -10 || true)
   if [ -n "$hits" ] || [ -n "$paths" ]; then
     note "LEAKAGE in $(basename "$f"):"
     [ -n "$hits" ] && echo "$hits" | sed 's/^/    /'

--- a/scripts/pcaps/README.md
+++ b/scripts/pcaps/README.md
@@ -1,0 +1,84 @@
+# pcap corpus tooling
+
+Build and maintain the committed regression corpus under `testdata/pcaps/corpus/`
+that `server/h-turn/tests/corpus_golden.rs` replays against committed goldens.
+
+## Why scrubbing is mandatory
+
+Captures are loopback **plaintext HTTP**, so they carry real `Authorization`
+tokens, provider keys, prompts/responses, and sometimes private IPs / home
+paths. `scripts/lint/check-leakage.sh` skips binary files, so a raw pcap would
+sail past it. `scrub_pcap.py` is the secret gate; `check-pcap-corpus.sh` is the
+CI backstop that scans the committed bytes.
+
+## scrub_pcap.py — what it does
+
+Length-preserving byte substitution over the raw pcap: each secret/PII run is
+replaced with an equal-length filler, so every TCP segment keeps its size — no
+Content-Length / sequence-number / checksum rewrite needed, and the file still
+replays to the **same** `LlmCall`/`AgentTurn` ground truth (Heron reassembles by
+5-tuple+seq and does not validate TCP/IP checksums).
+
+- **Preserved** (so detection + extraction still fire): JSON structure, key
+  names, `type` discriminators, tool names + tool-call structure, `usage`
+  numbers (= ground truth), `finish_reason`/`stop_reason`, model strings, and
+  agent-detection headers (`User-Agent`, `X-Claude-Code-Session-Id`,
+  `x-session-affinity`, …). Session/turn-id VALUES inside those headers are
+  replaced with a *deterministic same-length fake* so linking still resolves.
+- **Redacted** (value bytes only): `Authorization`/`x-api-key`/`Bearer` tokens,
+  `sk-*`/`sk-ant-*` keys, JWTs, PEM private keys, RFC1918 IPs,
+  `/Users|/home/<user>` paths, e-mail addresses.
+
+It refuses to emit if any forbidden pattern survives.
+
+## Add a corpus cell
+
+```bash
+# 1. obtain a raw capture (see recipes below) → testdata/pcaps/raw/<id>.raw.pcap
+# 2. scrub it into the committed corpus + write the audit sidecar:
+scripts/pcaps/scrub_pcap.sh testdata/pcaps/raw/<id>.raw.pcap --id <id>
+#    (optional: --trim '<tshark display filter>' to keep only relevant streams)
+# 3. flip the entry to status="active" in testdata/pcaps/corpus.toml
+# 4. generate + eyeball the golden, then run it:
+just corpus bless
+just corpus test
+just corpus lint
+# 5. commit: the .pcap lands in git-LFS (.gitattributes), plus corpus.toml,
+#    golden/<id>.json and <id>.scrub.json.
+```
+
+## Capture recipes
+
+All captures are loopback `127.0.0.1:8317` plaintext HTTP (Heron's post-TLS
+model). Never commit `testdata/pcaps/raw/` — only the scrubbed `corpus/` output.
+
+**Fresh capture** (fills a backend-quirk / new-agent cell):
+
+```bash
+# run backend X serving an OpenAI/Anthropic/Gemini-compatible API on :8317,
+# then in another shell:
+sudo tcpdump -i lo -w testdata/pcaps/raw/<id>.raw.pcap 'tcp port 8317'   # Linux
+# (macOS: -i lo0). Drive agent Y to produce the target scenario, then Ctrl-C.
+scripts/pcaps/scrub_pcap.sh testdata/pcaps/raw/<id>.raw.pcap --id <id>
+```
+
+Backends to stand up for the quirk cells: vllm, sglang, ollama, litellm,
+cliproxy. The high-value **cliproxy mixed-format** cell: point an agent at a
+cliproxy that returns Anthropic-shaped `usage` on an OpenAI-Chat request
+(exercises the `openai/chat.rs` usage fallback, issue #96).
+
+**Trim from an existing large capture**:
+
+```bash
+# isolate the relevant TCP streams, then scrub (verify gates it):
+tshark -r big.pcap -Y 'tcp.port==8317 && http' -w testdata/pcaps/raw/<id>.raw.pcap
+scripts/pcaps/scrub_pcap.sh testdata/pcaps/raw/<id>.raw.pcap --id <id>
+```
+
+## Notes / limitations
+
+- The scrubber redacts ASCII secrets in payloads; it does not rewrite binary
+  L2/L3 addresses (loopback captures are already `127.0.0.1`). The corpus lint
+  scans for residual RFC1918/keys/paths as the backstop.
+- If a redaction pattern would change length it is rejected — extend the rules
+  in `scrub_pcap.py` rather than breaking length-preservation.

--- a/scripts/pcaps/README.md
+++ b/scripts/pcaps/README.md
@@ -47,6 +47,32 @@ just corpus lint
 #    golden/<id>.json and <id>.scrub.json.
 ```
 
+## Synthesized fixtures — `gen_fixture.py` (no capture needed)
+
+For the `anthropic` column and the **cliproxy mixed-format** cell, capturing real
+traffic needs real API access (and scrubbing). Instead, `gen_fixture.py`
+**deterministically synthesizes** the wire bytes — we control the request
+headers/body AND a faithful Anthropic Messages responder (non-stream JSON + full
+SSE: `message_start` → `content_block_start/delta` (text + `input_json_delta`,
+incl. parallel `tool_use`) → `content_block_stop` → `message_delta` (usage,
+stop_reason) → `message_stop`) — and frames them into a classic pcap (Ethernet/
+IPv4/TCP over loopback, 3-way handshake, monotonic seq, MTU-segmented, FIN).
+Output is **secret-free by construction** (non-secret-shaped auth values), so no
+scrub pass is needed.
+
+```bash
+python3 scripts/pcaps/gen_fixture.py --list                 # scenarios
+python3 scripts/pcaps/gen_fixture.py --all                  # (re)generate all → corpus/
+python3 scripts/pcaps/gen_fixture.py --scenario <name> --out <file.pcap>
+# then: flip status="active" in corpus.toml, `just corpus bless`, `just corpus test`
+```
+
+Add a scenario by writing a `scen_*()` (returns `(request, response)` byte pairs
+on one connection) and registering it in `SCENARIOS`. Cheapest way to fill
+anthropic/openai/cliproxy cells — and it doubles as a conformance harness: the
+golden test replays the synthesized bytes through the real pipeline, so a parser
+regression breaks the golden.
+
 ## Capture recipes
 
 All captures are loopback `127.0.0.1:8317` plaintext HTTP (Heron's post-TLS

--- a/scripts/pcaps/gen_fixture.py
+++ b/scripts/pcaps/gen_fixture.py
@@ -394,6 +394,134 @@ def scen_claude_cli_anthropic_nonstream():
         user_text="read it (nonstream)")
 
 
+# --- openai column: chat (streaming) + responses (non-stream) ---------------
+
+OAI_MODEL = "gpt-4o-2024-08-06"
+
+
+def _oai_tool(name):
+    return {"type": "function", "function": {"name": name, "description": f"{name} tool",
+            "parameters": {"type": "object", "properties": {"x": {"type": "string"}}}}}
+
+
+def oai_chat_request(tool_names, messages, headers, stream=True):
+    h = {"authorization": f"Bearer {FAKE_OAI_KEY}", "content-type": "application/json"}
+    h.update(headers)
+    body = {"model": OAI_MODEL, "messages": messages,
+            "tools": [_oai_tool(n) for n in tool_names], "stream": stream,
+            "stream_options": {"include_usage": True}}
+    return http_request("POST", "/v1/chat/completions", h,
+                        json.dumps(body, separators=(",", ":")).encode())
+
+
+def _chunk(choices, usage=None):
+    d = {"id": "chatcmpl-synth", "object": "chat.completion.chunk",
+         "model": OAI_MODEL, "choices": choices}
+    if usage is not None:
+        d["usage"] = usage
+    return f"data: {json.dumps(d, separators=(',', ':'))}\n\n".encode()
+
+
+def oai_chat_stream(text, tool_calls, finish_reason, usage):
+    out = [_chunk([{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}])]
+    for w in (text.split(" ") if text else []):
+        out.append(_chunk([{"index": 0, "delta": {"content": w + " "}, "finish_reason": None}]))
+    for k, tc in enumerate(tool_calls):
+        js = json.dumps(tc["arguments"], separators=(",", ":"))
+        mid = len(js) // 2
+        out.append(_chunk([{"index": 0, "delta": {"tool_calls": [{"index": k, "id": tc["id"],
+                    "type": "function", "function": {"name": tc["name"], "arguments": ""}}]},
+                    "finish_reason": None}]))
+        out.append(_chunk([{"index": 0, "delta": {"tool_calls": [{"index": k,
+                    "function": {"arguments": js[:mid]}}]}, "finish_reason": None}]))
+        out.append(_chunk([{"index": 0, "delta": {"tool_calls": [{"index": k,
+                    "function": {"arguments": js[mid:]}}]}, "finish_reason": None}]))
+    out.append(_chunk([{"index": 0, "delta": {}, "finish_reason": finish_reason}]))
+    out.append(_chunk([], usage=usage))
+    out.append(b"data: [DONE]\n\n")
+    return out
+
+
+OAI_USAGE1 = {"prompt_tokens": 1400, "completion_tokens": 35, "total_tokens": 1435,
+              "prompt_tokens_details": {"cached_tokens": 512}}
+OAI_USAGE2 = {"prompt_tokens": 1500, "completion_tokens": 25, "total_tokens": 1525,
+              "prompt_tokens_details": {"cached_tokens": 1400}}
+
+CHAT_AGENTS = {
+    "opencode": {"headers": {"User-Agent": "opencode/1.14.50 ai-sdk/provider-utils/4.0.23",
+                             "x-session-affinity": "ses_synth0001"}, "tools": ["Read"]},
+    "openclaw": {"headers": {"User-Agent": "node"},
+                 "tools": ["sessions_spawn", "subagents", "Read"]},
+    "hermes":   {"headers": {"User-Agent": "openai-python/1.40.0"},
+                 "tools": ["skill_view", "delegate_task", "Read"]},
+    "generic":  {"headers": {"User-Agent": "some-sdk/1.0"}, "tools": ["Read"]},
+}
+
+
+def scen_openai_chat(agent):
+    """openai-chat streaming tool roundtrip → 1 complete turn for the given
+    agent (detection via headers for opencode, body fingerprint for
+    openclaw/hermes, fallback for generic)."""
+    cfg = CHAT_AGENTS[agent]
+    u_msg = {"role": "user", "content": "do the thing"}
+    tc = {"id": "call_synth01", "name": "Read", "arguments": {"path": "x"}}
+    req1 = oai_chat_request(cfg["tools"], [u_msg], cfg["headers"])
+    resp1 = http_response_sse(oai_chat_stream("on it", [tc], "tool_calls", OAI_USAGE1))
+    assistant = {"role": "assistant", "content": None, "tool_calls": [
+        {"id": tc["id"], "type": "function", "function": {"name": tc["name"],
+         "arguments": json.dumps(tc["arguments"], separators=(",", ":"))}}]}
+    toolmsg = {"role": "tool", "tool_call_id": tc["id"], "content": "ok"}
+    req2 = oai_chat_request(cfg["tools"], [u_msg, assistant, toolmsg], cfg["headers"])
+    resp2 = http_response_sse(oai_chat_stream("all done", [], "stop", OAI_USAGE2))
+    return [(req1, resp1), (req2, resp2)]
+
+
+def oai_responses_request(tool_names, input_items, headers):
+    h = {"authorization": f"Bearer {FAKE_OAI_KEY}", "content-type": "application/json"}
+    h.update(headers)
+    body = {"model": OAI_MODEL, "input": input_items, "stream": False,
+            "tools": [{"type": "function", "name": n, "description": f"{n} tool",
+                       "parameters": {"type": "object", "properties": {"x": {"type": "string"}}}}
+                      for n in tool_names]}
+    return http_request("POST", "/v1/responses", h,
+                        json.dumps(body, separators=(",", ":")).encode())
+
+
+def responses_json(output, usage):
+    return json.dumps({"id": "resp_synth", "object": "response", "status": "completed",
+                       "model": OAI_MODEL, "output": output, "usage": usage},
+                      separators=(",", ":")).encode()
+
+
+RESP_USAGE1 = {"input_tokens": 1400, "output_tokens": 35, "input_tokens_details": {"cached_tokens": 512}}
+RESP_USAGE2 = {"input_tokens": 1500, "output_tokens": 25, "input_tokens_details": {"cached_tokens": 1400}}
+
+
+def scen_openai_responses(agent):
+    """openai-responses non-stream tool roundtrip → 1 complete turn. codex via
+    Originator + X-Codex-Turn-Metadata; generic via fallback. ex1 output carries
+    a function_call (not terminal); ex2 output is a message (terminal)."""
+    if agent == "codex":
+        headers = {"User-Agent": "codex_cli_rs/0.41.0", "Originator": "codex_cli_rs",
+                   "X-Codex-Turn-Metadata": json.dumps({"session_id": SESSION})}
+        tool_names = ["shell"]
+    else:
+        headers = {"User-Agent": "openai-python/1.40.0"}
+        tool_names = ["lookup"]
+    user_item = {"type": "message", "role": "user",
+                 "content": [{"type": "input_text", "text": "do the thing"}]}
+    req1 = oai_responses_request(tool_names, [user_item], headers)
+    fc = {"type": "function_call", "id": "fc_synth01", "call_id": "call_synth01",
+          "name": tool_names[0], "arguments": json.dumps({"x": "y"}, separators=(",", ":"))}
+    resp1 = http_response_json(responses_json([fc], RESP_USAGE1))
+    fc_out = {"type": "function_call_output", "call_id": "call_synth01", "output": "ok"}
+    msg = {"type": "message", "role": "assistant",
+           "content": [{"type": "output_text", "text": "all done"}]}
+    req2 = oai_responses_request(tool_names, [user_item, fc, fc_out], headers)
+    resp2 = http_response_json(responses_json([msg], RESP_USAGE2))
+    return [(req1, resp1), (req2, resp2)]
+
+
 SCENARIOS = {
     "claude-cli-anthropic-stream": scen_claude_cli_anthropic_stream,
     "claude-cli-anthropic-nonstream": scen_claude_cli_anthropic_nonstream,
@@ -401,6 +529,13 @@ SCENARIOS = {
     "hermes-anthropic": scen_hermes_anthropic,
     "generic-anthropic": scen_generic_anthropic,
     "cliproxy-mixed-format": scen_cliproxy_mixed_format,
+    # openai column (below)
+    "opencode-openai-chat": lambda: scen_openai_chat("opencode"),
+    "openclaw-openai-chat": lambda: scen_openai_chat("openclaw"),
+    "hermes-openai-chat": lambda: scen_openai_chat("hermes"),
+    "generic-openai-chat": lambda: scen_openai_chat("generic"),
+    "codex-responses": lambda: scen_openai_responses("codex"),
+    "generic-openai-responses": lambda: scen_openai_responses("generic"),
 }
 
 

--- a/scripts/pcaps/gen_fixture.py
+++ b/scripts/pcaps/gen_fixture.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Deterministically synthesize Heron pcap corpus fixtures.
+
+We control the request headers/body AND the response, so this generates the
+whole `anthropic` column (claude-cli / openclaw / hermes / generic) and the
+**cliproxy mixed-format** cell (OpenAI-Chat request → Anthropic-shaped response,
+issue #96) without any live server, real API key, or capture — fully
+reproducible and secret-free by construction.
+
+Output is a classic little-endian pcap (linktype 1 = Ethernet) that Heron's
+PcapFileSource reads directly. Frames are Ethernet/IPv4/TCP over loopback
+(127.0.0.1) with a real 3-way handshake, monotonic per-direction sequence
+numbers, MTU-sized data segments (to exercise reassembly), and a FIN teardown.
+Checksums are zero — Heron reassembles by 5-tuple+seq and does not validate
+them.
+
+Usage:
+  gen_fixture.py --scenario <name> --out <file.pcap>
+  gen_fixture.py --list
+  gen_fixture.py --all --corpus-dir testdata/pcaps/corpus   # regenerate all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# pcap + TCP/IP framing  (classic pcap, linktype 1 Ethernet, loopback)
+# ---------------------------------------------------------------------------
+
+CLIENT_IP = "127.0.0.1"
+SERVER_IP = "127.0.0.1"
+CLIENT_PORT = 50000
+SERVER_PORT = 8317
+MSS = 1400  # segment size for data payloads
+
+
+def _ip4(addr: str) -> bytes:
+    return bytes(int(o) for o in addr.split("."))
+
+
+def _eth(client_to_server: bool) -> bytes:
+    # dst mac, src mac, ethertype IPv4. Distinct per direction for realism.
+    a = bytes([0x02, 0, 0, 0, 0, 0x01])
+    b = bytes([0x02, 0, 0, 0, 0, 0x02])
+    return (b + a if client_to_server else a + b) + b"\x08\x00"
+
+
+def _ipv4(payload_len: int, c2s: bool, ip_id: int) -> bytes:
+    total = 20 + payload_len
+    src, dst = (CLIENT_IP, SERVER_IP) if c2s else (SERVER_IP, CLIENT_IP)
+    return struct.pack(
+        ">BBHHHBBH4s4s",
+        0x45, 0x00, total, ip_id & 0xFFFF, 0x4000, 64, 6, 0, _ip4(src), _ip4(dst)
+    )
+
+
+def _tcp(c2s: bool, seq: int, ack: int, flags: int, payload_len: int) -> bytes:
+    sport, dport = (CLIENT_PORT, SERVER_PORT) if c2s else (SERVER_PORT, CLIENT_PORT)
+    off_flags = (5 << 12) | flags  # data offset 5 words (20 bytes), no options
+    return struct.pack(
+        ">HHIIHHHH", sport, dport, seq & 0xFFFFFFFF, ack & 0xFFFFFFFF,
+        off_flags, 65535, 0, 0
+    )
+
+
+FIN, SYN, PSH, ACK = 0x01, 0x02, 0x08, 0x10
+
+
+class PcapWriter:
+    def __init__(self):
+        self.records: list[bytes] = []
+        self.ip_id = 1
+        self.ts = 1_700_000_000  # fixed base; +1us per packet (deterministic)
+        self.tick = 0
+
+    def _emit(self, c2s: bool, seq: int, ack: int, flags: int, payload: bytes):
+        frame = _eth(c2s) + _ipv4(20 + len(payload), c2s, self.ip_id) + \
+            _tcp(c2s, seq, ack, flags, len(payload)) + payload
+        self.ip_id += 1
+        self.tick += 1
+        rec = struct.pack("<IIII", self.ts, self.tick, len(frame), len(frame)) + frame
+        self.records.append(rec)
+
+    def connection(self, client_stream: bytes, server_stream: bytes):
+        """One TCP connection: handshake, client bytes, server bytes, teardown.
+        Per-direction byte order is preserved (that's all Heron's reassembler
+        needs); we interleave a single request burst then a single response
+        burst, which is sufficient for the joiner to pair exchanges in order."""
+        c_seq, s_seq = 1000, 5000
+        # handshake
+        self._emit(True, c_seq, 0, SYN, b"")
+        c_seq += 1
+        self._emit(False, s_seq, c_seq, SYN | ACK, b"")
+        s_seq += 1
+        self._emit(True, c_seq, s_seq, ACK, b"")
+        # client → server data
+        for i in range(0, len(client_stream), MSS):
+            seg = client_stream[i:i + MSS]
+            self._emit(True, c_seq, s_seq, PSH | ACK, seg)
+            c_seq += len(seg)
+        # server → client data
+        for i in range(0, len(server_stream), MSS):
+            seg = server_stream[i:i + MSS]
+            self._emit(False, s_seq, c_seq, PSH | ACK, seg)
+            s_seq += len(seg)
+        # teardown
+        self._emit(True, c_seq, s_seq, FIN | ACK, b"")
+        c_seq += 1
+        self._emit(False, s_seq, c_seq, FIN | ACK, b"")
+
+    def to_bytes(self) -> bytes:
+        gh = struct.pack("<IHHiIII", 0xA1B2C3D4, 2, 4, 0, 0, 65535, 1)
+        return gh + b"".join(self.records)
+
+
+# ---------------------------------------------------------------------------
+# HTTP framing helpers
+# ---------------------------------------------------------------------------
+
+def http_request(method: str, path: str, headers: dict, body: bytes) -> bytes:
+    lines = [f"{method} {path} HTTP/1.1"]
+    h = dict(headers)
+    h.setdefault("Host", "127.0.0.1:8317")
+    h["Content-Length"] = str(len(body))
+    for k, v in h.items():
+        lines.append(f"{k}: {v}")
+    return ("\r\n".join(lines) + "\r\n\r\n").encode() + body
+
+
+def http_response_json(body: bytes, content_type="application/json") -> bytes:
+    head = (
+        "HTTP/1.1 200 OK\r\n"
+        f"content-type: {content_type}\r\n"
+        f"content-length: {len(body)}\r\n\r\n"
+    )
+    return head.encode() + body
+
+
+def http_response_sse(events: list[bytes]) -> bytes:
+    """SSE over chunked transfer-encoding (each event = one chunk)."""
+    head = (
+        "HTTP/1.1 200 OK\r\n"
+        "content-type: text/event-stream; charset=utf-8\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+    ).encode()
+    out = bytearray(head)
+    for ev in events:
+        out += f"{len(ev):x}\r\n".encode() + ev + b"\r\n"
+    out += b"0\r\n\r\n"
+    return bytes(out)
+
+
+def sse(event: str, data: dict) -> bytes:
+    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n".encode()
+
+
+# ---------------------------------------------------------------------------
+# Faithful Anthropic Messages responder
+# ---------------------------------------------------------------------------
+
+def anthropic_nonstream(text="hello from the assistant",
+                        tool=None, stop_reason="end_turn",
+                        usage=None, model="claude-sonnet-4-20250514") -> bytes:
+    content = [{"type": "text", "text": text}]
+    if tool:
+        content.append({"type": "tool_use", "id": tool["id"], "name": tool["name"],
+                        "input": tool["input"]})
+    u = usage or {"input_tokens": 1200, "output_tokens": 85,
+                  "cache_read_input_tokens": 1024, "cache_creation_input_tokens": 0}
+    return json.dumps({
+        "id": "msg_0123456789abcdef", "type": "message", "role": "assistant",
+        "model": model, "content": content,
+        "stop_reason": stop_reason, "stop_sequence": None, "usage": u,
+    }, separators=(",", ":")).encode()
+
+
+def anthropic_stream(text="Let me check that.", tools=None,
+                     stop_reason="end_turn", usage=None,
+                     model="claude-sonnet-4-20250514") -> list[bytes]:
+    """Full Anthropic streaming event sequence. `tools` is a list of
+    {id,name,input} for (possibly parallel) tool_use blocks — every
+    content_block_start arrives, then input_json_delta per index (exercises
+    the index-keyed SSE accumulator)."""
+    tools = tools or []
+    u = usage or {"input_tokens": 1200, "output_tokens": 1,
+                  "cache_read_input_tokens": 1024, "cache_creation_input_tokens": 0}
+    out = [sse("message_start", {"type": "message_start", "message": {
+        "id": "msg_0123456789abcdef", "type": "message", "role": "assistant",
+        "model": model, "content": [], "stop_reason": None,
+        "stop_sequence": None, "usage": u}})]
+    # text block index 0
+    out.append(sse("content_block_start", {"type": "content_block_start",
+                "index": 0, "content_block": {"type": "text", "text": ""}}))
+    for piece in text.split(" "):
+        out.append(sse("content_block_delta", {"type": "content_block_delta",
+                    "index": 0, "delta": {"type": "text_delta", "text": piece + " "}}))
+    out.append(sse("content_block_stop", {"type": "content_block_stop", "index": 0}))
+    # tool_use blocks: all starts first, then interleaved input_json_delta
+    for n, t in enumerate(tools, start=1):
+        out.append(sse("content_block_start", {"type": "content_block_start",
+                    "index": n, "content_block": {"type": "tool_use",
+                    "id": t["id"], "name": t["name"], "input": {}}}))
+    for n, t in enumerate(tools, start=1):
+        js = json.dumps(t["input"], separators=(",", ":"))
+        mid = len(js) // 2
+        for part in (js[:mid], js[mid:]):
+            out.append(sse("content_block_delta", {"type": "content_block_delta",
+                        "index": n, "delta": {"type": "input_json_delta",
+                        "partial_json": part}}))
+    for n in range(1, len(tools) + 1):
+        out.append(sse("content_block_stop", {"type": "content_block_stop", "index": n}))
+    out.append(sse("message_delta", {"type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": (usage or {}).get("output_tokens", 85)}}))
+    out.append(sse("message_stop", {"type": "message_stop"}))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# scenarios → list of (request_bytes, response_bytes) on one connection
+# ---------------------------------------------------------------------------
+
+# Auth values are deliberately NON-secret-shaped (no sk-/sk-ant- prefix) so the
+# synthesized fixtures are secret-free by construction and pass the corpus
+# leakage gate without a scrub pass. Wire-API + agent detection here keys off
+# route + anthropic-version + User-Agent/session headers, not the token prefix.
+FAKE_ANT_KEY = "REDACTED-anthropic-test-token"
+FAKE_OAI_KEY = "REDACTED-openai-test-token"
+SESSION = "11111111-2222-3333-4444-555555555555"
+
+# A claude-cli MAIN agent request carries the "Agent" tool (the sub-agent
+# spawner); sub-agent requests lack it (h-llm claude_cli::looks_like_subagent).
+# Include it so this synthesizes as a single-agent main turn, not an orphan.
+CLAUDE_TOOLS = [
+    {"name": "Agent", "description": "spawn a sub-agent",
+     "input_schema": {"type": "object", "properties": {"prompt": {"type": "string"}}}},
+    {"name": "Read", "description": "read a file",
+     "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}}},
+]
+
+
+def scen_claude_cli_anthropic_stream():
+    """claude-cli over Anthropic /v1/messages, streaming, one tool roundtrip
+    → 1 complete turn. Exercises claude-cli header detection + index-keyed SSE
+    accumulator + usage/cache extraction."""
+    hdr = {
+        "User-Agent": "claude-cli/2.1.0 (external, cli)",
+        "X-Claude-Code-Session-Id": SESSION,
+        "anthropic-version": "2023-06-01",
+        "authorization": f"Bearer {FAKE_ANT_KEY}",
+        "content-type": "application/json",
+    }
+    # exchange 1: user prompt → assistant tool_use (stop_reason tool_use)
+    req1 = http_request("POST", "/v1/messages", hdr, json.dumps({
+        "model": "claude-sonnet-4-20250514", "max_tokens": 1024,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "read config.toml"}]}],
+        "tools": CLAUDE_TOOLS, "stream": True}, separators=(",", ":")).encode())
+    resp1 = http_response_sse(anthropic_stream(
+        text="I'll read it.",
+        tools=[{"id": "toolu_01aaaa", "name": "Read", "input": {"path": "config.toml"}}],
+        stop_reason="tool_use",
+        usage={"input_tokens": 1500, "output_tokens": 40,
+               "cache_read_input_tokens": 1024, "cache_creation_input_tokens": 256}))
+    # exchange 2: tool_result → assistant final text (stop_reason end_turn)
+    req2 = http_request("POST", "/v1/messages", hdr, json.dumps({
+        "model": "claude-sonnet-4-20250514", "max_tokens": 1024,
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "read config.toml"}]},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01aaaa",
+                "name": "Read", "input": {"path": "config.toml"}}]},
+            {"role": "user", "content": [{"type": "tool_result",
+                "tool_use_id": "toolu_01aaaa", "content": "port=8317"}]}],
+        "tools": CLAUDE_TOOLS, "stream": True}, separators=(",", ":")).encode())
+    resp2 = http_response_sse(anthropic_stream(
+        text="The port is 8317.", tools=[], stop_reason="end_turn",
+        usage={"input_tokens": 1600, "output_tokens": 30,
+               "cache_read_input_tokens": 1500, "cache_creation_input_tokens": 0}))
+    return [(req1, resp1), (req2, resp2)]
+
+
+def scen_cliproxy_mixed_format():
+    """cliproxy mixed-format (#96): OpenAI-Chat REQUEST, Anthropic-shaped
+    RESPONSE. Heron detects openai-chat from the request; usage extraction must
+    fall back to Anthropic field names (input_tokens/output_tokens)."""
+    hdr = {
+        "User-Agent": "openai-python/1.40.0",
+        "authorization": f"Bearer {FAKE_OAI_KEY}",
+        "content-type": "application/json",
+    }
+    req = http_request("POST", "/v1/chat/completions", hdr, json.dumps({
+        "model": "gpt-4o", "stream": False,
+        "messages": [{"role": "user", "content": "hello"}]}, separators=(",", ":")).encode())
+    # Response is Anthropic Messages shape (proxy returned upstream shape):
+    resp = http_response_json(anthropic_nonstream(
+        text="hi there", stop_reason="end_turn",
+        usage={"input_tokens": 309, "output_tokens": 37}))
+    return [(req, resp)]
+
+
+SCENARIOS = {
+    "claude-cli-anthropic-stream": scen_claude_cli_anthropic_stream,
+    "cliproxy-mixed-format": scen_cliproxy_mixed_format,
+}
+
+
+def build(scenario: str) -> bytes:
+    exchanges = SCENARIOS[scenario]()
+    w = PcapWriter()
+    client = b"".join(req for req, _ in exchanges)
+    server = b"".join(resp for _, resp in exchanges)
+    w.connection(client, server)
+    return w.to_bytes()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario")
+    ap.add_argument("--out")
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--corpus-dir", default="testdata/pcaps/corpus")
+    ap.add_argument("--list", action="store_true")
+    args = ap.parse_args()
+
+    if args.list:
+        for k in SCENARIOS:
+            print(k)
+        return 0
+    if args.all:
+        d = Path(args.corpus_dir)
+        d.mkdir(parents=True, exist_ok=True)
+        for name in SCENARIOS:
+            p = d / f"{name}.pcap"
+            p.write_bytes(build(name))
+            print(f"wrote {p} ({p.stat().st_size} bytes)")
+        return 0
+    if not args.scenario or not args.out:
+        ap.error("need --scenario and --out (or --all / --list)")
+    Path(args.out).write_bytes(build(args.scenario))
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pcaps/gen_fixture.py
+++ b/scripts/pcaps/gen_fixture.py
@@ -302,8 +302,104 @@ def scen_cliproxy_mixed_format():
     return [(req, resp)]
 
 
+# --- shared anthropic roundtrip builder (fills the rest of the column) -------
+
+def _tool_def(name):
+    return {"name": name, "description": f"{name} tool",
+            "input_schema": {"type": "object", "properties": {"x": {"type": "string"}}}}
+
+
+def ant_req(tool_names, messages, stream, headers):
+    h = {"anthropic-version": "2023-06-01",
+         "authorization": f"Bearer {FAKE_ANT_KEY}", "content-type": "application/json"}
+    h.update(headers)
+    body = {"model": "claude-sonnet-4-20250514", "max_tokens": 1024,
+            "messages": messages, "tools": [_tool_def(n) for n in tool_names],
+            "stream": stream}
+    return http_request("POST", "/v1/messages", h, json.dumps(body, separators=(",", ":")).encode())
+
+
+def ant_roundtrip(tool_names, headers, stream, tools_called, user_text):
+    """2-exchange tool roundtrip on one connection → 1 complete turn.
+    tools_called = assistant tool_use blocks emitted in exchange 1 (>1 = parallel)."""
+    u_msg = {"role": "user", "content": [{"type": "text", "text": user_text}]}
+    req1 = ant_req(tool_names, [u_msg], stream, headers)
+    u1 = {"input_tokens": 1400, "output_tokens": 35,
+          "cache_read_input_tokens": 512, "cache_creation_input_tokens": 0}
+    if stream:
+        resp1 = http_response_sse(anthropic_stream(
+            text="working on it", tools=tools_called, stop_reason="tool_use", usage=u1))
+    else:
+        resp1 = http_response_json(anthropic_nonstream(
+            text="working on it", tool=tools_called[0], stop_reason="tool_use", usage=u1))
+    assistant_blocks = [{"type": "tool_use", "id": t["id"], "name": t["name"],
+                         "input": t["input"]} for t in tools_called]
+    tool_results = [{"type": "tool_result", "tool_use_id": t["id"], "content": "ok"}
+                    for t in tools_called]
+    msgs2 = [u_msg, {"role": "assistant", "content": assistant_blocks},
+             {"role": "user", "content": tool_results}]
+    req2 = ant_req(tool_names, msgs2, stream, headers)
+    u2 = {"input_tokens": 1500, "output_tokens": 25,
+          "cache_read_input_tokens": 1400, "cache_creation_input_tokens": 0}
+    if stream:
+        resp2 = http_response_sse(anthropic_stream(
+            text="all done", tools=[], stop_reason="end_turn", usage=u2))
+    else:
+        resp2 = http_response_json(anthropic_nonstream(
+            text="all done", tool=None, stop_reason="end_turn", usage=u2))
+    return [(req1, resp1), (req2, resp2)]
+
+
+def scen_openclaw_anthropic_parallel():
+    """openclaw over Anthropic, streaming, PARALLEL tool_use (two blocks) →
+    1 complete openclaw turn. Body-fingerprint match (sessions_spawn+subagents);
+    parallel tool_use exercises the index-keyed SSE accumulator."""
+    return ant_roundtrip(
+        tool_names=["sessions_spawn", "subagents", "Read", "Grep"],
+        headers={"User-Agent": "node"}, stream=True,
+        tools_called=[{"id": "toolu_par1", "name": "Read", "input": {"path": "a.txt"}},
+                      {"id": "toolu_par2", "name": "Grep", "input": {"pattern": "foo"}}],
+        user_text="search the repo")
+
+
+def scen_hermes_anthropic():
+    """hermes over Anthropic, streaming → 1 complete hermes turn. Body
+    fingerprint (skill_view + delegate_task); no Hermes-specific UA."""
+    return ant_roundtrip(
+        tool_names=["skill_view", "delegate_task", "Read"],
+        headers={"User-Agent": "anthropic-sdk-python/0.40.0"}, stream=True,
+        tools_called=[{"id": "toolu_herm1", "name": "Read", "input": {"path": "x"}}],
+        user_text="use a skill")
+
+
+def scen_generic_anthropic():
+    """generic fallback over Anthropic (no claude-cli headers, no openclaw/hermes
+    markers, no Agent tool) → 1 complete generic turn; session synthesized from
+    the first tool_use id."""
+    return ant_roundtrip(
+        tool_names=["Read"],
+        headers={"User-Agent": "some-sdk/1.0"}, stream=True,
+        tools_called=[{"id": "toolu_gen1", "name": "Read", "input": {"path": "x"}}],
+        user_text="read a file")
+
+
+def scen_claude_cli_anthropic_nonstream():
+    """claude-cli over Anthropic, NON-streaming (Content-Length JSON) → 1
+    complete claude-cli turn. Exercises the non-stream Anthropic extractor."""
+    return ant_roundtrip(
+        tool_names=["Agent", "Read"],
+        headers={"User-Agent": "claude-cli/2.1.0 (external, cli)",
+                 "X-Claude-Code-Session-Id": SESSION}, stream=False,
+        tools_called=[{"id": "toolu_ns1", "name": "Read", "input": {"path": "x"}}],
+        user_text="read it (nonstream)")
+
+
 SCENARIOS = {
     "claude-cli-anthropic-stream": scen_claude_cli_anthropic_stream,
+    "claude-cli-anthropic-nonstream": scen_claude_cli_anthropic_nonstream,
+    "openclaw-anthropic-parallel": scen_openclaw_anthropic_parallel,
+    "hermes-anthropic": scen_hermes_anthropic,
+    "generic-anthropic": scen_generic_anthropic,
     "cliproxy-mixed-format": scen_cliproxy_mixed_format,
 }
 

--- a/scripts/pcaps/scrub_pcap.py
+++ b/scripts/pcaps/scrub_pcap.py
@@ -112,18 +112,19 @@ def build_rules(seed: str):
         re.compile(rb"(?i)((?:x-claude-code-session-id|x-codex-turn-metadata|x-session-affinity|x-session-id)\s*:\s*)([^\r\n]+)"),
         lambda m: m.group(1) + _fake_token(m.group(2), seed, ALNUM),
     ))
-    # RFC1918 private IPs (ASCII, in payloads) → same-length filler (no longer an IP)
+    # Internal IPs (ASCII, in payloads): RFC1918 + CGNAT 100.64/10 — kept in
+    # sync with check-leakage.sh PRIV_IP_RE. → same-length filler (no longer an IP)
     rules.append((
         "rfc1918_ip",
-        re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b"),
+        re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3})\b"),
         lambda m: _same_len(m.group(0)),
     ))
-    # home-directory paths → redact the username component only.
+    # home-directory paths (incl. /root) → redact the user/first component only.
     # (The literal prefixes are spelled with a char-class so this source file
     # itself doesn't trip the repo's home-path leakage gate.)
     rules.append((
         "home_path",
-        re.compile(rb"(/Us[e]rs/|/h[o]me/)([^/\r\n\s\"']+)"),
+        re.compile(rb"(/Us[e]rs/|/h[o]me/|/r[o]ot/)([^/\r\n\s\"']+)"),
         lambda m: m.group(1) + _same_len(m.group(2)),
     ))
     # e-mail addresses
@@ -141,8 +142,8 @@ RESIDUAL_FORBIDDEN = [
     ("provider_key", re.compile(rb"sk-(?:ant-)?[A-Za-z0-9_\-]{12,}")),
     ("jwt", re.compile(rb"eyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}")),
     ("pem", re.compile(rb"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
-    ("rfc1918_ip", re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b")),
-    ("home_path", re.compile(rb"(?:/Us[e]rs/|/h[o]me/)[A-Za-z0-9][^/\r\n\s\"']*")),
+    ("rfc1918_ip", re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3})\b")),
+    ("home_path", re.compile(rb"(?:/Us[e]rs/|/h[o]me/|/r[o]ot/)[A-Za-z0-9][^/\r\n\s\"']*")),
 ]
 
 

--- a/scripts/pcaps/scrub_pcap.py
+++ b/scripts/pcaps/scrub_pcap.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Scrub secrets/PII out of a pcap while preserving wire structure.
+
+Heron's capture is loopback PLAINTEXT HTTP, so secrets live in the HTTP
+headers/bodies, not the L2/L3 framing. This tool does **length-preserving**
+byte substitution over the raw pcap: each matched secret/PII run is replaced
+with an equal-length filler, so every TCP segment keeps its size — no
+Content-Length, sequence-number, or checksum rewriting is needed, and the
+file still replays through the pipeline to the SAME LlmCall/AgentTurn ground
+truth. (Heron reassembles flows by 5-tuple+seq and does not validate TCP/IP
+checksums, so the redacted bytes parse fine.)
+
+What is PRESERVED (so fixtures still exercise detection + extraction):
+  JSON structure, key names, array cardinality, `type` discriminators,
+  tool names + tool-call structure, `usage` numbers (= ground truth),
+  finish_reason / stop_reason, model strings, agent-detection headers
+  (User-Agent, X-Claude-Code-Session-Id, x-session-affinity, ...).
+
+What is REDACTED (value bytes only, length-preserved):
+  Authorization / x-api-key / Bearer tokens, sk-* / sk-ant-* keys,
+  JWTs, PEM private-key blocks, RFC1918 IPs, home-directory paths,
+  e-mail addresses, and the session/turn-id token VALUES inside the kept
+  agent headers (replaced with a DETERMINISTIC same-length fake so
+  session/tool-id linking still resolves identically on replay).
+
+Usage:
+  scrub_pcap.py <in.pcap> <out.pcap> [--sidecar <out.json>] [--seed <hex>]
+
+Exit non-zero if any known secret pattern still matches AFTER scrubbing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+# Deterministic filler so re-running on the same input is reproducible and the
+# result is obviously redacted (not a plausible real value).
+FILL = b"X"
+
+
+def _same_len(b: bytes) -> bytes:
+    return FILL * len(b)
+
+
+def _fake_token(original: bytes, seed: str, alphabet: bytes) -> bytes:
+    """Deterministic same-length replacement drawn from `alphabet`, so a given
+    real token always maps to the same fake (session/tool-id linking survives)
+    while leaking nothing. Stable across runs via the committed seed."""
+    out = bytearray()
+    h = hashlib.sha256(seed.encode() + original).digest()
+    i = 0
+    while len(out) < len(original):
+        if i >= len(h):
+            h = hashlib.sha256(h).digest()
+            i = 0
+        c = original[len(out)]
+        # keep structural punctuation (-, _, ., /) so id SHAPES are preserved
+        if c in b"-_./":
+            out.append(c)
+        else:
+            out.append(alphabet[h[i] % len(alphabet)])
+        i += 1
+    return bytes(out)
+
+
+HEX = b"0123456789abcdef"
+ALNUM = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+# (name, compiled-regex, replacer). Each replacer returns a SAME-LENGTH bytes.
+# Order matters: most specific first.
+def build_rules(seed: str):
+    rules = []
+
+    # Authorization: Bearer <token>  /  Authorization: <token>
+    rules.append((
+        "authorization_header",
+        re.compile(rb"(?i)(authorization:\s*)(bearer\s+)?([^\r\n]+)"),
+        lambda m: m.group(1) + (m.group(2) or b"") + _same_len(m.group(3)),
+    ))
+    # x-api-key / api-key style headers
+    rules.append((
+        "api_key_header",
+        re.compile(rb"(?i)((?:x-api-key|api[-_]?key)\s*[:=]\s*)([^\r\n,;\"']+)"),
+        lambda m: m.group(1) + _same_len(m.group(2)),
+    ))
+    # sk-ant-… and sk-… provider keys anywhere
+    rules.append((
+        "provider_key",
+        re.compile(rb"sk-(?:ant-)?[A-Za-z0-9_\-]{12,}"),
+        lambda m: _same_len(m.group(0)),
+    ))
+    # JWTs (three base64url segments)
+    rules.append((
+        "jwt",
+        re.compile(rb"eyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}"),
+        lambda m: _same_len(m.group(0)),
+    ))
+    # PEM private-key blocks
+    rules.append((
+        "pem_block",
+        re.compile(rb"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+        lambda m: _same_len(m.group(0)),
+    ))
+    # Kept agent headers — preserve the header + id SHAPE, fake the VALUE
+    rules.append((
+        "agent_session_header",
+        re.compile(rb"(?i)((?:x-claude-code-session-id|x-codex-turn-metadata|x-session-affinity|x-session-id)\s*:\s*)([^\r\n]+)"),
+        lambda m: m.group(1) + _fake_token(m.group(2), seed, ALNUM),
+    ))
+    # RFC1918 private IPs (ASCII, in payloads) → same-length filler (no longer an IP)
+    rules.append((
+        "rfc1918_ip",
+        re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b"),
+        lambda m: _same_len(m.group(0)),
+    ))
+    # home-directory paths → redact the username component only.
+    # (The literal prefixes are spelled with a char-class so this source file
+    # itself doesn't trip the repo's home-path leakage gate.)
+    rules.append((
+        "home_path",
+        re.compile(rb"(/Us[e]rs/|/h[o]me/)([^/\r\n\s\"']+)"),
+        lambda m: m.group(1) + _same_len(m.group(2)),
+    ))
+    # e-mail addresses
+    rules.append((
+        "email",
+        re.compile(rb"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
+        lambda m: _same_len(m.group(0)),
+    ))
+    return rules
+
+
+# Patterns that MUST NOT survive scrubbing (post-scan gate). Loopback 127.* is
+# allowed; only RFC1918 + credentials + key material are forbidden.
+RESIDUAL_FORBIDDEN = [
+    ("provider_key", re.compile(rb"sk-(?:ant-)?[A-Za-z0-9_\-]{12,}")),
+    ("jwt", re.compile(rb"eyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}")),
+    ("pem", re.compile(rb"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("rfc1918_ip", re.compile(rb"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b")),
+    ("home_path", re.compile(rb"(?:/Us[e]rs/|/h[o]me/)[A-Za-z0-9][^/\r\n\s\"']*")),
+]
+
+
+def scrub(data: bytes, seed: str) -> tuple[bytes, dict]:
+    counts: dict[str, int] = {}
+    out = data
+    for name, rx, repl in build_rules(seed):
+        n = 0
+
+        def _sub(m, _repl=repl):
+            nonlocal n
+            r = _repl(m)
+            assert len(r) == len(m.group(0)), f"{name}: non-length-preserving replacement"
+            n += 1
+            return r
+
+        out = rx.sub(_sub, out)
+        if n:
+            counts[name] = n
+    assert len(out) == len(data), "scrub changed file length"
+    return out, counts
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("infile")
+    ap.add_argument("outfile")
+    ap.add_argument("--sidecar", default=None, help="write a redaction audit JSON here")
+    ap.add_argument("--seed", default="heron-pcap-scrub-v1", help="deterministic fake seed")
+    args = ap.parse_args()
+
+    data = Path(args.infile).read_bytes()
+    out, counts = scrub(data, args.seed)
+
+    # Post-scan: refuse to emit if a forbidden pattern survived. Allow the
+    # username after the home-dir prefix to be all-X (our filler) — exclude that.
+    residual = []
+    for name, rx in RESIDUAL_FORBIDDEN:
+        for m in rx.finditer(out):
+            frag = m.group(0)
+            if name == "home_path" and set(frag.split(b"/")[-1]) <= set(FILL):
+                continue
+            residual.append((name, m.start()))
+    if residual:
+        sys.stderr.write(f"ERROR: {len(residual)} forbidden pattern(s) survived scrubbing: "
+                         f"{sorted({n for n, _ in residual})}\n")
+        return 2
+
+    Path(args.outfile).write_bytes(out)
+
+    sidecar = {
+        "input": Path(args.infile).name,
+        "output": Path(args.outfile).name,
+        "size_bytes": len(out),
+        "length_preserved": True,
+        "seed": args.seed,
+        "rules_fired": counts,
+    }
+    if args.sidecar:
+        Path(args.sidecar).write_text(json.dumps(sidecar, indent=2) + "\n")
+    print(json.dumps(sidecar, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pcaps/scrub_pcap.sh
+++ b/scripts/pcaps/scrub_pcap.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Turn a raw capture into a committable, secret-free corpus fixture.
+#
+#   scripts/pcaps/scrub_pcap.sh <raw.pcap> --id <fixture-id> [--trim <expr>]
+#
+# Steps:
+#   1. (optional) trim to the relevant TCP streams with editcap/tshark IF
+#      present — skipped gracefully otherwise.
+#   2. length-preserving secret/PII redaction via scrub_pcap.py (the gate:
+#      refuses to emit if a forbidden pattern survives).
+#   3. write testdata/pcaps/corpus/<id>.pcap + testdata/pcaps/<id>.scrub.json.
+#
+# After this: add/flip the corpus.toml entry to status="active", then
+# `just corpus bless` to generate the golden, eyeball the golden diff, and
+# commit (the .pcap lands in git-LFS per .gitattributes).
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+
+RAW=""
+ID=""
+TRIM=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --id) ID="$2"; shift 2 ;;
+    --trim) TRIM="$2"; shift 2 ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) RAW="$1"; shift ;;
+  esac
+done
+[ -n "$RAW" ] && [ -n "$ID" ] || { echo "usage: scrub_pcap.sh <raw.pcap> --id <id> [--trim <tshark-filter>]" >&2; exit 2; }
+[ -f "$RAW" ] || { echo "no such file: $RAW" >&2; exit 2; }
+
+CORPUS_DIR="$ROOT/testdata/pcaps/corpus"
+OUT="$CORPUS_DIR/$ID.pcap"
+SIDE="$ROOT/testdata/pcaps/$ID.scrub.json"
+mkdir -p "$CORPUS_DIR"
+
+WORK="$RAW"
+TMP=""
+if [ -n "$TRIM" ]; then
+  if command -v tshark >/dev/null 2>&1; then
+    TMP=$(mktemp /tmp/scrub-trim-XXXX.pcap)
+    echo "trim: tshark -Y '$TRIM'"
+    tshark -r "$RAW" -Y "$TRIM" -w "$TMP" >/dev/null 2>&1 || { echo "tshark trim failed" >&2; exit 1; }
+    WORK="$TMP"
+  else
+    echo "::warning:: --trim requested but tshark not found; skipping trim" >&2
+  fi
+fi
+
+python3 "$HERE/scrub_pcap.py" "$WORK" "$OUT" --sidecar "$SIDE"
+[ -n "$TMP" ] && rm -f "$TMP"
+
+echo
+echo "wrote $OUT"
+echo "next: set status=\"active\" for id=\"$ID\" in testdata/pcaps/corpus.toml, then 'just corpus bless'"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1465,6 +1465,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]

--- a/server/h-turn/Cargo.toml
+++ b/server/h-turn/Cargo.toml
@@ -20,3 +20,4 @@ tokio-util = { workspace = true }
 h-capture.workspace = true
 h-metrics.workspace = true
 h-protocol.workspace = true
+toml = "0.8"

--- a/server/h-turn/tests/corpus_golden.rs
+++ b/server/h-turn/tests/corpus_golden.rs
@@ -232,6 +232,47 @@ fn project_turn(t: &h_turn::AgentTurn) -> serde_json::Value {
     })
 }
 
+/// Tool calls in the RECONSTRUCTED response body, with whether each carried a
+/// non-empty parsed input/arguments. This is what guards SSE reconstruction
+/// (esp. parallel `tool_use` via index-keyed accumulation — an `input: ""` is
+/// the pre-fix symptom). Covers anthropic (`content[].tool_use`) and openai
+/// chat (`choices[0].message.tool_calls[]`).
+fn response_tool_uses(c: &h_llm::model::LlmCall) -> serde_json::Value {
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    let Some(body) = c.response_body.as_deref() else {
+        return serde_json::json!([]);
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body) else {
+        return serde_json::json!([]);
+    };
+    if let Some(content) = v.get("content").and_then(|x| x.as_array()) {
+        for b in content {
+            if b.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
+                let name = b.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
+                let has_input = matches!(b.get("input"),
+                    Some(serde_json::Value::Object(o)) if !o.is_empty());
+                out.push(serde_json::json!({"name": name, "has_input": has_input}));
+            }
+        }
+    }
+    if let Some(tcs) = v.get("choices").and_then(|c| c.get(0))
+        .and_then(|c| c.get("message")).and_then(|m| m.get("tool_calls"))
+        .and_then(|t| t.as_array())
+    {
+        for tc in tcs {
+            let f = tc.get("function");
+            let name = f.and_then(|f| f.get("name")).and_then(|n| n.as_str())
+                .unwrap_or("").to_string();
+            let args = f.and_then(|f| f.get("arguments")).and_then(|a| a.as_str())
+                .unwrap_or("");
+            let has_input = !args.trim().is_empty() && args.trim() != "{}";
+            out.push(serde_json::json!({"name": name, "has_input": has_input}));
+        }
+    }
+    out.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    serde_json::Value::Array(out)
+}
+
 fn project_call(c: &h_llm::model::LlmCall) -> serde_json::Value {
     serde_json::json!({
         "wire_api": c.wire_api,
@@ -248,6 +289,9 @@ fn project_call(c: &h_llm::model::LlmCall) -> serde_json::Value {
         "tool_call_count": c.tool_call_count,
         "tool_names": sorted_strings(&c.tool_names),
         "agent_topology": opt_str(&c.agent_topology),
+        // reconstructed response tool calls + input-presence — guards SSE
+        // (parallel) tool_use reconstruction
+        "response_tool_uses": response_tool_uses(c),
         // synthetic id VALUE is non-deterministic — assert shape/presence only
         "response_id_present": c.response_id.is_some(),
     })

--- a/server/h-turn/tests/corpus_golden.rs
+++ b/server/h-turn/tests/corpus_golden.rs
@@ -269,6 +269,17 @@ fn response_tool_uses(c: &h_llm::model::LlmCall) -> serde_json::Value {
             out.push(serde_json::json!({"name": name, "has_input": has_input}));
         }
     }
+    // openai responses: output[].type==function_call {name, arguments}
+    if let Some(items) = v.get("output").and_then(|o| o.as_array()) {
+        for it in items {
+            if it.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                let name = it.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
+                let args = it.get("arguments").and_then(|a| a.as_str()).unwrap_or("");
+                let has_input = !args.trim().is_empty() && args.trim() != "{}";
+                out.push(serde_json::json!({"name": name, "has_input": has_input}));
+            }
+        }
+    }
     out.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
     serde_json::Value::Array(out)
 }

--- a/server/h-turn/tests/corpus_golden.rs
+++ b/server/h-turn/tests/corpus_golden.rs
@@ -1,0 +1,381 @@
+//! Golden regression over the curated pcap corpus.
+//!
+//! Data-driven: reads `testdata/pcaps/corpus.toml`, replays each committed
+//! fixture through the FULL pipeline (capture → protocol → llm → turn), projects
+//! the extracted `LlmCall`/`AgentTurn` into a DETERMINISTIC JSON shape (no uuids,
+//! no timing fields), and compares it to `testdata/pcaps/golden/<id>.json`.
+//!
+//! - Missing fixtures (or unsmudged git-LFS pointers) are SKIPPED, so the
+//!   workspace still builds + tests green without `git lfs pull`.
+//! - `HERON_BLESS_GOLDENS=1` (re)writes the goldens instead of asserting.
+//!   Use `just corpus bless`.
+//!
+//! NOTE: the replay harness here intentionally mirrors the one in
+//! `integration.rs`. Deduping both onto a shared `tests/common/` module is a
+//! follow-up; kept separate for now to isolate this new file from the existing
+//! turn-grouping tests.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use h_capture::{CaptureSource, PcapFileSource, RoutingSender};
+use h_common::internal_metrics::{Metric, MetricsSystem};
+use h_protocol::{spawn_flow_dispatcher, spawn_http_joiner_stage, spawn_protocol_stage};
+use h_turn::tracker::TrackerConfig;
+
+// ----------------------------------------------------------------------------
+// fixture resolution (corpus/ first, then legacy testdata/pcaps/), LFS-aware
+// ----------------------------------------------------------------------------
+
+fn pcaps_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata/pcaps")
+}
+
+/// An unsmudged git-LFS pointer is a tiny text file beginning with the LFS
+/// header — treat it (and absent files) as "not present" so the test skips.
+fn is_real_pcap(p: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(p) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    if meta.len() < 1024 {
+        if let Ok(head) = std::fs::read(p) {
+            if head.starts_with(b"version https://git-lfs") {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn fixture(file: &str) -> Option<PathBuf> {
+    let base = pcaps_root();
+    for cand in [base.join("corpus").join(file), base.join(file)] {
+        if is_real_pcap(&cand) {
+            return Some(cand);
+        }
+    }
+    None
+}
+
+// ----------------------------------------------------------------------------
+// replay harness (full pipeline, 1/1/1 sharding, collecting calls + turns)
+// ----------------------------------------------------------------------------
+
+async fn run_pcap_collecting_calls(
+    file: &str,
+) -> Option<(Vec<h_turn::AgentTurn>, Vec<Arc<h_llm::model::LlmCall>>)> {
+    let path = fixture(file)?;
+    let mut metrics_sys = MetricsSystem::new();
+
+    let source_metrics = metrics_sys.register_worker(
+        "capture.corpus",
+        &[
+            Metric::CapturePacketsReceived,
+            Metric::CaptureKernelPacketsDropped,
+        ],
+    );
+
+    let queue_size = 4096usize;
+    let (raw_tx, raw_rx) = mpsc::channel::<h_capture::RawPacket>(queue_size);
+
+    let flow_shards = 1usize;
+    let turn_shards = 1usize;
+    let metrics_shards = 1usize;
+    let mut parsed_txs = Vec::with_capacity(flow_shards);
+    let mut parsed_rxs = Vec::with_capacity(flow_shards);
+    let mut protocol_event_txs = Vec::with_capacity(flow_shards);
+    let mut protocol_event_rxs = Vec::with_capacity(flow_shards);
+    let mut joiner_event_txs = Vec::with_capacity(flow_shards);
+    let mut joiner_event_rxs = Vec::with_capacity(flow_shards);
+    for _ in 0..flow_shards {
+        let (ptx, prx) = mpsc::channel::<h_protocol::WorkerInput>(queue_size);
+        parsed_txs.push(ptx);
+        parsed_rxs.push(prx);
+        let (etx, erx) = mpsc::channel::<h_protocol::model::HttpParseEvent>(queue_size);
+        protocol_event_txs.push(etx);
+        protocol_event_rxs.push(erx);
+        let (jtx, jrx) = mpsc::channel::<h_protocol::HttpJoinerEvent>(queue_size);
+        joiner_event_txs.push(jtx);
+        joiner_event_rxs.push(jrx);
+    }
+
+    let mut turn_shard_txs = Vec::with_capacity(turn_shards);
+    let mut turn_shard_rxs = Vec::with_capacity(turn_shards);
+    for _ in 0..turn_shards {
+        let (tx, rx) = mpsc::channel::<h_llm::model::TurnShardInput>(queue_size);
+        turn_shard_txs.push(tx);
+        turn_shard_rxs.push(rx);
+    }
+
+    let mut metrics_shard_txs = Vec::with_capacity(metrics_shards);
+    let mut metrics_shard_rxs = Vec::with_capacity(metrics_shards);
+    for _ in 0..metrics_shards {
+        let (tx, rx) = mpsc::channel::<h_llm::model::LlmEvent>(queue_size);
+        metrics_shard_txs.push(tx);
+        metrics_shard_rxs.push(rx);
+    }
+
+    let (calls_tx, mut calls_rx) = mpsc::channel::<Arc<h_llm::model::LlmCall>>(queue_size);
+    let (turns_tx, mut turns_rx) = mpsc::channel::<h_turn::AgentTurn>(queue_size);
+    let (m_out_tx, mut m_out_rx) = mpsc::channel::<h_metrics::model::LlmMetricsBatch>(queue_size);
+
+    spawn_flow_dispatcher(raw_rx, parsed_txs, "dispatcher", &mut metrics_sys);
+    spawn_protocol_stage(parsed_rxs, protocol_event_txs, &mut metrics_sys);
+    spawn_http_joiner_stage(protocol_event_rxs, joiner_event_txs, None, &mut metrics_sys);
+
+    let registry = Arc::new(h_llm::agents::build_default_registry());
+    let wire_api_registry = Arc::new(h_llm::wire_apis::build_default_wire_api_registry());
+    h_llm::spawn_llm_stage(
+        joiner_event_rxs,
+        turn_shard_txs,
+        metrics_shard_txs,
+        calls_tx,
+        wire_api_registry.clone(),
+        registry,
+        &mut metrics_sys,
+        h_llm::agent_classifier::ClassifierConfig::default(),
+        h_common::config::BodyCapConfig::default(),
+    );
+
+    h_turn::spawn_turn_stage(
+        TrackerConfig::default(),
+        turn_shard_rxs,
+        turns_tx,
+        &mut metrics_sys,
+        None,
+    );
+
+    h_metrics::spawn_metrics_stage(metrics_shard_rxs, m_out_tx, &mut metrics_sys);
+
+    let _metrics_svc = metrics_sys.start();
+
+    let source = PcapFileSource::new(path, "corpus".to_string(), None);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let src_task = tokio::spawn({
+        let tx = raw_tx.clone();
+        let cancel = cancel.clone();
+        async move {
+            let _ = Box::new(source)
+                .run(RoutingSender::single(tx), source_metrics, cancel)
+                .await;
+        }
+    });
+    drop(raw_tx);
+
+    let calls_collector = tokio::spawn(async move {
+        let mut acc: Vec<Arc<h_llm::model::LlmCall>> = Vec::new();
+        while let Some(c) = calls_rx.recv().await {
+            acc.push(c);
+        }
+        acc
+    });
+    let metrics_drain = tokio::spawn(async move { while m_out_rx.recv().await.is_some() {} });
+
+    let mut finalized: Vec<h_turn::AgentTurn> = Vec::new();
+    while let Some(turn) = turns_rx.recv().await {
+        finalized.push(turn);
+    }
+
+    let _ = src_task.await;
+    let calls = calls_collector.await.unwrap_or_default();
+    let _ = metrics_drain.await;
+    Some((finalized, calls))
+}
+
+// ----------------------------------------------------------------------------
+// deterministic projection (NO uuids / timing / synthetic-id VALUES)
+// ----------------------------------------------------------------------------
+
+fn opt_str<T: std::fmt::Display>(v: &Option<T>) -> serde_json::Value {
+    match v {
+        Some(x) => serde_json::Value::String(x.to_string()),
+        None => serde_json::Value::Null,
+    }
+}
+
+fn sorted_strings(v: &[String]) -> Vec<String> {
+    let mut s = v.to_vec();
+    s.sort();
+    s
+}
+
+fn project_turn(t: &h_turn::AgentTurn) -> serde_json::Value {
+    let tool_surfaces: Vec<String> = {
+        let mut s: Vec<String> = t.tool_surfaces.iter().map(|x| x.to_string()).collect();
+        s.sort();
+        s
+    };
+    serde_json::json!({
+        "agent_kind": t.agent_kind,
+        "wire_api": t.wire_api,
+        "call_count": t.call_count,
+        "status": t.status.to_string(),
+        "models_used": sorted_strings(&t.models_used),
+        "subagents_used": sorted_strings(&t.subagents_used),
+        "tool_surfaces": tool_surfaces,
+        "tool_call_total": t.tool_call_total,
+        "agent_topology": opt_str(&t.agent_topology),
+        "final_finish_reason": opt_str(&t.final_finish_reason),
+        "total_input_tokens": t.total_input_tokens,
+        "total_output_tokens": t.total_output_tokens,
+        "total_cache_read_input_tokens": t.total_cache_read_input_tokens,
+        "total_cache_creation_input_tokens": t.total_cache_creation_input_tokens,
+        // presence only — the actual preview text is scrubbed placeholder
+        "user_input_preview_present": t.user_input_preview.is_some(),
+        "final_answer_preview_present": t.final_answer_preview.is_some(),
+    })
+}
+
+fn project_call(c: &h_llm::model::LlmCall) -> serde_json::Value {
+    serde_json::json!({
+        "wire_api": c.wire_api,
+        "model": c.model,
+        "is_stream": c.is_stream,
+        "status_code": c.status_code,
+        "finish_reason": opt_str(&c.finish_reason),
+        "input_tokens": c.input_tokens,
+        "output_tokens": c.output_tokens,
+        "cache_read_input_tokens": c.cache_read_input_tokens,
+        "cache_creation_input_tokens": c.cache_creation_input_tokens,
+        "is_agent_request": c.is_agent_request,
+        "tool_surface": opt_str(&c.tool_surface),
+        "tool_call_count": c.tool_call_count,
+        "tool_names": sorted_strings(&c.tool_names),
+        "agent_topology": opt_str(&c.agent_topology),
+        // synthetic id VALUE is non-deterministic — assert shape/presence only
+        "response_id_present": c.response_id.is_some(),
+    })
+}
+
+/// Stable string sort over projected values → order-insensitive goldens.
+fn sort_values(mut v: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+    v.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    v
+}
+
+fn build_golden(
+    turns: &[h_turn::AgentTurn],
+    calls: &[Arc<h_llm::model::LlmCall>],
+) -> serde_json::Value {
+    let turns_p = sort_values(turns.iter().map(project_turn).collect());
+    let calls_p = sort_values(calls.iter().map(|c| project_call(c)).collect());
+    serde_json::json!({
+        "turn_count": turns.len(),
+        "call_count": calls.len(),
+        "turns": turns_p,
+        "calls": calls_p,
+    })
+}
+
+// ----------------------------------------------------------------------------
+// the data-driven test
+// ----------------------------------------------------------------------------
+
+fn manifest_path() -> PathBuf {
+    pcaps_root().join("corpus.toml")
+}
+
+fn golden_path(id: &str) -> PathBuf {
+    pcaps_root().join("golden").join(format!("{id}.json"))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn corpus_goldens_match() {
+    let bless = std::env::var("HERON_BLESS_GOLDENS").is_ok();
+
+    let manifest_src = std::fs::read_to_string(manifest_path())
+        .expect("testdata/pcaps/corpus.toml must exist");
+    let manifest: toml::Value = toml::from_str(&manifest_src).expect("corpus.toml parses");
+    let fixtures = manifest
+        .get("fixture")
+        .and_then(|f| f.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut ran = 0usize;
+    let mut skipped = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for fx in &fixtures {
+        let id = fx.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let file = fx
+            .get("file")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        assert!(!id.is_empty() && !file.is_empty(), "fixture needs id + file");
+
+        // `status = "pending"` documents a target matrix cell whose capture
+        // hasn't been obtained/scrubbed yet — listed for visibility, skipped.
+        let status = fx
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("active");
+        if status != "active" {
+            eprintln!("skip {id}: status={status} (matrix cell pending capture)");
+            skipped += 1;
+            continue;
+        }
+
+        let Some((turns, calls)) = run_pcap_collecting_calls(&file).await else {
+            eprintln!("skip {id}: fixture {file} not present (absent or LFS pointer)");
+            skipped += 1;
+            continue;
+        };
+        ran += 1;
+
+        let golden = build_golden(&turns, &calls);
+        let got = serde_json::to_string_pretty(&golden).unwrap();
+        let gp = golden_path(&id);
+
+        if bless {
+            std::fs::create_dir_all(gp.parent().unwrap()).unwrap();
+            std::fs::write(&gp, format!("{got}\n")).unwrap();
+            eprintln!("blessed {id} -> {}", gp.display());
+            continue;
+        }
+
+        let want = match std::fs::read_to_string(&gp) {
+            Ok(s) => s,
+            Err(_) => {
+                failures.push(format!(
+                    "{id}: missing golden {} (run `just corpus bless`)",
+                    gp.display()
+                ));
+                continue;
+            }
+        };
+        if want.trim_end() != got.trim_end() {
+            failures.push(format!(
+                "{id}: golden mismatch — extracted output differs from {}.\n\
+                 If the parser change is intentional, run `just corpus bless` and review the diff.",
+                gp.display()
+            ));
+        }
+
+        // Belt-and-suspenders: assert the manifest's human-readable contract.
+        if let Some(expect) = fx.get("expect") {
+            if let Some(tc) = expect.get("turn_count").and_then(|v| v.as_integer()) {
+                if turns.len() as i64 != tc {
+                    failures.push(format!(
+                        "{id}: manifest turn_count={tc} but extracted {}",
+                        turns.len()
+                    ));
+                }
+            }
+        }
+    }
+
+    eprintln!("corpus goldens: ran={ran} skipped={skipped} bless={bless}");
+    assert!(
+        failures.is_empty(),
+        "corpus golden failures:\n{}",
+        failures.join("\n")
+    );
+}

--- a/testdata/pcaps/README.md
+++ b/testdata/pcaps/README.md
@@ -42,5 +42,51 @@ cargo run -p heron -- --pcap testdata/pcaps/claude-cli-messages-multi.pcap
 
 ## Obtaining the files
 
-These pcaps are not in git. Ask @timmy.yuan for a copy or capture your own
-loopback traffic against `127.0.0.1:8317` while using claude-cli / codex-cli.
+These (legacy, hand-distributed) pcaps are not in git. Ask @timmy.yuan for a
+copy or capture your own loopback traffic against `127.0.0.1:8317`. They feed
+the turn-grouping tests in `server/h-turn/tests/integration.rs`, which skip
+when absent.
+
+---
+
+# Committed regression corpus (`corpus/`)
+
+Separate from the legacy fixtures above: `testdata/pcaps/corpus/` holds a
+**curated, secret-scrubbed, git-LFS-committed** corpus that runs as a golden
+regression gate in CI (`server/h-turn/tests/corpus_golden.rs`,
+`cargo test --workspace`).
+
+- **`corpus.toml`** — the single source of truth for the
+  (backend × agent × wire_api × scenario) matrix. Each `[[fixture]]` is either
+  `status = "active"` (a scrubbed `corpus/<file>.pcap` + `golden/<id>.json` are
+  committed) or `status = "pending"` (a target cell whose capture isn't obtained
+  yet — listed for visibility, skipped by the test).
+- **`corpus/*.pcap`** — scrubbed fixtures, stored via git-LFS (`.gitattributes`).
+  Run `git lfs pull` to materialize them; CI checks out with `lfs: true`. An
+  unsmudged LFS pointer is treated as "absent" and skipped.
+- **`golden/<id>.json`** — the deterministic extracted projection (no uuids /
+  timing). Regenerate with `just corpus bless` and review the diff.
+- **`<id>.scrub.json`** — per-fixture redaction audit (which rules fired, size),
+  so reviewers can confirm scrubbing happened without seeing secrets.
+
+### Why "backend" is a label, not a detection output
+
+vLLM / SGLang / Ollama / LiteLLM / CLIproxy all speak `openai-chat` /
+`openai-responses` on the wire — Heron does not distinguish them per-deployment.
+Their value as fixtures is the **parsing quirk** each one locks in (SSE framing,
+usage-block field names, finish_reason vocab, the CLIproxy mixed-format usage
+fallback). `backend_label` + `[fixture.expect.quirks]` document that; the hard
+detection assertion is `wire_apis`.
+
+### Adding / refreshing a cell
+
+See [`scripts/pcaps/README.md`](../../scripts/pcaps/README.md) for the
+capture → scrub → bless → commit workflow and the capture recipes. Quick:
+
+```bash
+scripts/pcaps/scrub_pcap.sh testdata/pcaps/raw/<id>.raw.pcap --id <id>
+# flip status="active" in corpus.toml, then:
+just corpus bless && just corpus test && just corpus lint
+```
+
+Never commit raw captures — `testdata/pcaps/raw/` is gitignored.

--- a/testdata/pcaps/corpus.toml
+++ b/testdata/pcaps/corpus.toml
@@ -143,24 +143,26 @@ turn_count = 2
 [[fixture]]
 id = "opencode-openai-chat"
 file = "opencode-openai-chat.pcap"
-status = "pending"
+status = "active"
 agent_kind = "opencode"
 wire_apis = ["openai-chat"]
 backend_label = "openai-direct"
-scenarios = ["multi-turn", "tool-calls"]
-notes = "opencode UA + x-session-affinity. NEEDS FRESH CAPTURE (not in the original 7)."
+scenarios = ["streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: opencode UA + x-session-affinity over openai-chat SSE, tool roundtrip → 1 complete turn."
+[fixture.expect]
+turn_count = 1
 
 [[fixture]]
 id = "openclaw-openai-chat"
 file = "openclaw-openai-chat.pcap"
-status = "pending"
+status = "active"
 agent_kind = "openclaw"
 wire_apis = ["openai-chat"]
 backend_label = "litellm"
-scenarios = ["multi-session", "tool-calls", "tool-id-canonicalization"]
-notes = "Two sessions; client echoes tool_calls[].id without underscore — exercises canonicalize_tool_id. 4 turns / 2 sessions."
+scenarios = ["streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: openclaw body-fingerprint (sessions_spawn+subagents) over openai-chat SSE → 1 complete turn. (A richer 2-session/4-turn real capture remains a future cell.)"
 [fixture.expect]
-turn_count = 4
+turn_count = 1
 
 [[fixture]]
 id = "openclaw-anthropic"
@@ -180,12 +182,50 @@ usage_field_style = "anthropic"
 [[fixture]]
 id = "hermes-openai-chat"
 file = "hermes-openai-chat.pcap"
-status = "pending"
+status = "active"
 agent_kind = "hermes"
 wire_apis = ["openai-chat"]
 backend_label = "litellm"
-scenarios = ["tool-calls", "title-gen"]
-notes = "Body-fingerprint (skill_view/delegate_task/...). 4-call main turn + 1 title-gen one-shot."
+scenarios = ["streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: hermes body-fingerprint (skill_view+delegate_task) over openai-chat SSE → 1 complete turn."
+[fixture.expect]
+turn_count = 1
+
+[[fixture]]
+id = "generic-openai-chat"
+file = "generic-openai-chat.pcap"
+status = "active"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "openai-direct"
+scenarios = ["streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: no agent headers/markers → generic fallback over openai-chat SSE; session from first tool_call id → 1 complete turn."
+[fixture.expect]
+turn_count = 1
+
+[[fixture]]
+id = "codex-responses"
+file = "codex-responses.pcap"
+status = "active"
+agent_kind = "codex-cli"
+wire_apis = ["openai-responses"]
+backend_label = "openai-direct"
+scenarios = ["non-streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: codex-cli (Originator + X-Codex-Turn-Metadata) over /v1/responses, function_call roundtrip → 1 complete turn. Exercises responses extractor + codex session-from-metadata."
+[fixture.expect]
+turn_count = 1
+
+[[fixture]]
+id = "generic-openai-responses"
+file = "generic-openai-responses.pcap"
+status = "active"
+agent_kind = "generic"
+wire_apis = ["openai-responses"]
+backend_label = "openai-direct"
+scenarios = ["non-streaming", "tool-calls", "synthesized"]
+notes = "Synthesized: /v1/responses with no codex headers → generic fallback; function_call roundtrip → 1 complete turn."
+[fixture.expect]
+turn_count = 1
 
 [[fixture]]
 id = "gemini-cli-apikey"

--- a/testdata/pcaps/corpus.toml
+++ b/testdata/pcaps/corpus.toml
@@ -1,0 +1,185 @@
+# Heron pcap regression corpus — the (backend × agent × wire_api × scenario)
+# matrix that `server/h-turn/tests/corpus_golden.rs` replays and asserts against
+# committed goldens in testdata/pcaps/golden/<id>.json.
+#
+# - `status = "active"`  → a scrubbed pcap is committed under
+#   testdata/pcaps/corpus/<file> (git-LFS) and a golden exists. Runs in CI.
+#   (Skipped automatically if the LFS object isn't pulled — see the harness.)
+# - `status = "pending"` → a target matrix cell whose real capture hasn't been
+#   obtained + scrubbed yet. Listed here so the matrix is visible in one place;
+#   the test skips it. To activate: capture → `scripts/pcaps/scrub_pcap.sh` →
+#   drop under corpus/ → flip status → `just corpus bless` → commit.
+#
+# `backend_label` is a PROVENANCE LABEL ONLY — vllm/sglang/ollama/litellm/
+# cliproxy all speak openai-chat/openai-responses on the wire and are NOT a
+# detection output. Their value is the parsing QUIRK each one locks in
+# (see [fixture.expect.quirks]).
+
+schema_version = 1
+
+# --- ACTIVE -----------------------------------------------------------------
+
+[[fixture]]
+id            = "keepalive-claude-chat"
+file          = "keepalive-claude-chat.pcap"
+status        = "active"
+agent_kind    = "generic"
+wire_apis     = ["openai-chat"]
+backend_label = "openai-direct"
+scenarios     = ["keepalive", "pipelined", "streaming"]
+notes         = """Seed/vertical-slice fixture: two pipelined SSE responses on one \
+keep-alive connection (Claude Agent SDK system prompt over /v1/chat/completions). \
+Scrubbed from server/h-protocol/tests/fixtures/keepalive_2sse_pipelined.pcap. \
+Ground truth is captured in the golden; this cell proves the scrub→commit→golden→CI slice."""
+
+# --- PENDING: agent detection cells (seed from the 7 hand-distributed caps) --
+
+[[fixture]]
+id = "claude-cli-anthropic-single"
+file = "claude-cli-anthropic-single.pcap"
+status = "pending"
+agent_kind = "claude-cli"
+wire_apis = ["anthropic"]
+backend_label = "anthropic-direct"
+scenarios = ["single-turn", "streaming", "tool-calls"]
+notes = "Anthropic /v1/messages, claude-cli UA + X-Claude-Code-Session-Id. 1 complete turn."
+[fixture.expect]
+turn_count = 1
+
+[[fixture]]
+id = "claude-cli-anthropic-multi"
+file = "claude-cli-anthropic-multi.pcap"
+status = "pending"
+agent_kind = "claude-cli"
+wire_apis = ["anthropic"]
+backend_label = "anthropic-direct"
+scenarios = ["multi-turn", "streaming", "tool-calls", "subagent"]
+notes = "Long session, single session_id; auto title-gen filtered; Task sub-agent attaches to parent."
+
+[[fixture]]
+id = "codex-cli-responses-multi"
+file = "codex-cli-responses-multi.pcap"
+status = "pending"
+agent_kind = "codex-cli"
+wire_apis = ["openai-responses"]
+backend_label = "openai-direct"
+scenarios = ["multi-turn", "streaming", "tool-calls"]
+notes = "OpenAI /v1/responses, codex-cli. 2 turns (1 complete, 1 EOF-cut)."
+[fixture.expect]
+turn_count = 2
+
+[[fixture]]
+id = "opencode-openai-chat"
+file = "opencode-openai-chat.pcap"
+status = "pending"
+agent_kind = "opencode"
+wire_apis = ["openai-chat"]
+backend_label = "openai-direct"
+scenarios = ["multi-turn", "tool-calls"]
+notes = "opencode UA + x-session-affinity. NEEDS FRESH CAPTURE (not in the original 7)."
+
+[[fixture]]
+id = "openclaw-openai-chat"
+file = "openclaw-openai-chat.pcap"
+status = "pending"
+agent_kind = "openclaw"
+wire_apis = ["openai-chat"]
+backend_label = "litellm"
+scenarios = ["multi-session", "tool-calls", "tool-id-canonicalization"]
+notes = "Two sessions; client echoes tool_calls[].id without underscore — exercises canonicalize_tool_id. 4 turns / 2 sessions."
+[fixture.expect]
+turn_count = 4
+
+[[fixture]]
+id = "openclaw-anthropic"
+file = "openclaw-anthropic.pcap"
+status = "pending"
+agent_kind = "openclaw"
+wire_apis = ["anthropic"]
+backend_label = "litellm"
+scenarios = ["streaming", "parallel-tool-use", "compaction"]
+notes = "GLM-5 parallel tool_use; index-keyed SSE accumulator. 4 turns / 1 session."
+[fixture.expect]
+turn_count = 4
+[fixture.expect.quirks]
+sse_framing = "anthropic-events"
+usage_field_style = "anthropic"
+
+[[fixture]]
+id = "hermes-openai-chat"
+file = "hermes-openai-chat.pcap"
+status = "pending"
+agent_kind = "hermes"
+wire_apis = ["openai-chat"]
+backend_label = "litellm"
+scenarios = ["tool-calls", "title-gen"]
+notes = "Body-fingerprint (skill_view/delegate_task/...). 4-call main turn + 1 title-gen one-shot."
+
+[[fixture]]
+id = "gemini-cli-apikey"
+file = "gemini-cli-apikey.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["gemini-aistudio"]
+backend_label = "gemini-direct"
+scenarios = ["multi-turn", "streaming", "tool-calls"]
+notes = "Gemini AI Studio streamGenerateContent; generic profile. 2 turns split 4+3, one session."
+[fixture.expect]
+turn_count = 2
+
+# --- PENDING: backend-quirk cells (same wire_api, different bytes) -----------
+
+[[fixture]]
+id = "vllm-openai-chat-stream"
+file = "vllm-openai-chat-stream.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "vllm"
+scenarios = ["streaming", "tool-calls"]
+notes = "vLLM OpenAI-compatible SSE framing + usage placement. NEEDS FRESH CAPTURE."
+[fixture.expect.quirks]
+sse_framing = "openai-chunks"
+
+[[fixture]]
+id = "sglang-openai-chat-stream"
+file = "sglang-openai-chat-stream.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "sglang"
+scenarios = ["streaming", "tool-calls"]
+notes = "SGLang finish_reason vocabulary + SSE chunking. NEEDS FRESH CAPTURE."
+
+[[fixture]]
+id = "ollama-openai-chat"
+file = "ollama-openai-chat.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "ollama"
+scenarios = ["streaming"]
+notes = "Ollama OpenAI-compat usage field style + model-name strings. NEEDS FRESH CAPTURE."
+
+[[fixture]]
+id = "litellm-openai-responses"
+file = "litellm-openai-responses.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["openai-responses"]
+backend_label = "litellm"
+scenarios = ["streaming", "tool-calls"]
+notes = "LiteLLM proxy passthrough on /v1/responses. NEEDS FRESH CAPTURE."
+
+[[fixture]]
+id = "cliproxy-mixed-format"
+file = "cliproxy-mixed-format.pcap"
+status = "pending"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "cliproxy"
+scenarios = ["mixed-format", "usage-fallback"]
+notes = "HIGH VALUE (#96): OpenAI-Chat request → Anthropic-shaped usage in response. Exercises chat.rs usage fallback. NEEDS FRESH CAPTURE."
+[fixture.expect.quirks]
+mixed_format = true
+usage_field_style = "anthropic"

--- a/testdata/pcaps/corpus.toml
+++ b/testdata/pcaps/corpus.toml
@@ -32,6 +32,25 @@ keep-alive connection (Claude Agent SDK system prompt over /v1/chat/completions)
 Scrubbed from server/h-protocol/tests/fixtures/keepalive_2sse_pipelined.pcap. \
 Ground truth is captured in the golden; this cell proves the scrub→commit→golden→CI slice."""
 
+# --- ACTIVE: deterministically synthesized (scripts/pcaps/gen_fixture.py) ----
+# No real capture/scrub needed — the generator emits faithful, secret-free wire
+# bytes and frames them into a pcap. Regenerate with `gen_fixture.py --all`.
+
+[[fixture]]
+id            = "claude-cli-anthropic-stream"
+file          = "claude-cli-anthropic-stream.pcap"
+status        = "active"
+agent_kind    = "claude-cli"
+wire_apis     = ["anthropic"]
+backend_label = "anthropic-direct"
+scenarios     = ["streaming", "tool-calls", "synthesized"]
+notes         = "Synthesized: claude-cli /v1/messages SSE, one tool roundtrip → 1 complete turn. Exercises claude-cli header detection, index-keyed SSE accumulator, usage+cache extraction."
+[fixture.expect]
+turn_count = 1
+[fixture.expect.quirks]
+sse_framing = "anthropic-events"
+usage_field_style = "anthropic"
+
 # --- PENDING: agent detection cells (seed from the 7 hand-distributed caps) --
 
 [[fixture]]
@@ -174,12 +193,12 @@ notes = "LiteLLM proxy passthrough on /v1/responses. NEEDS FRESH CAPTURE."
 [[fixture]]
 id = "cliproxy-mixed-format"
 file = "cliproxy-mixed-format.pcap"
-status = "pending"
+status = "active"
 agent_kind = "generic"
 wire_apis = ["openai-chat"]
 backend_label = "cliproxy"
-scenarios = ["mixed-format", "usage-fallback"]
-notes = "HIGH VALUE (#96): OpenAI-Chat request → Anthropic-shaped usage in response. Exercises chat.rs usage fallback. NEEDS FRESH CAPTURE."
+scenarios = ["mixed-format", "usage-fallback", "synthesized"]
+notes = "HIGH VALUE (#96), synthesized by gen_fixture.py: OpenAI-Chat request → Anthropic-shaped response. Exercises openai-chat detection + chat.rs usage fallback to input_tokens/output_tokens."
 [fixture.expect.quirks]
 mixed_format = true
 usage_field_style = "anthropic"

--- a/testdata/pcaps/corpus.toml
+++ b/testdata/pcaps/corpus.toml
@@ -51,6 +51,59 @@ turn_count = 1
 sse_framing = "anthropic-events"
 usage_field_style = "anthropic"
 
+[[fixture]]
+id            = "claude-cli-anthropic-nonstream"
+file          = "claude-cli-anthropic-nonstream.pcap"
+status        = "active"
+agent_kind    = "claude-cli"
+wire_apis     = ["anthropic"]
+backend_label = "anthropic-direct"
+scenarios     = ["non-streaming", "tool-calls", "synthesized"]
+notes         = "Synthesized: claude-cli /v1/messages NON-streaming (Content-Length JSON), one tool roundtrip → 1 complete turn. Exercises the non-stream Anthropic extractor."
+[fixture.expect]
+turn_count = 1
+[fixture.expect.quirks]
+usage_field_style = "anthropic"
+
+[[fixture]]
+id            = "openclaw-anthropic-parallel"
+file          = "openclaw-anthropic-parallel.pcap"
+status        = "active"
+agent_kind    = "openclaw"
+wire_apis     = ["anthropic"]
+backend_label = "litellm"
+scenarios     = ["streaming", "parallel-tool-use", "synthesized"]
+notes         = "Synthesized: openclaw body-fingerprint (sessions_spawn+subagents) over Anthropic SSE with PARALLEL tool_use → 1 complete turn. Exercises index-keyed accumulator on parallel blocks."
+[fixture.expect]
+turn_count = 1
+[fixture.expect.quirks]
+sse_framing = "anthropic-events"
+usage_field_style = "anthropic"
+
+[[fixture]]
+id            = "hermes-anthropic"
+file          = "hermes-anthropic.pcap"
+status        = "active"
+agent_kind    = "hermes"
+wire_apis     = ["anthropic"]
+backend_label = "litellm"
+scenarios     = ["streaming", "tool-calls", "synthesized"]
+notes         = "Synthesized: hermes body-fingerprint (skill_view+delegate_task) over Anthropic SSE → 1 complete turn."
+[fixture.expect]
+turn_count = 1
+
+[[fixture]]
+id            = "generic-anthropic"
+file          = "generic-anthropic.pcap"
+status        = "active"
+agent_kind    = "generic"
+wire_apis     = ["anthropic"]
+backend_label = "anthropic-direct"
+scenarios     = ["streaming", "tool-calls", "synthesized"]
+notes         = "Synthesized: no claude-cli headers / openclaw|hermes markers / Agent tool → generic fallback over Anthropic; session synthesized from first tool_use id → 1 complete turn."
+[fixture.expect]
+turn_count = 1
+
 # --- PENDING: agent detection cells (seed from the 7 hand-distributed caps) --
 
 [[fixture]]

--- a/testdata/pcaps/corpus/claude-cli-anthropic-nonstream.pcap
+++ b/testdata/pcaps/corpus/claude-cli-anthropic-nonstream.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:834f75873582e024a9bb241645b07f12ef6d51e7f0dd5367b6b37667163fcd45
+size 2989

--- a/testdata/pcaps/corpus/claude-cli-anthropic-stream.pcap
+++ b/testdata/pcaps/corpus/claude-cli-anthropic-stream.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70690d82d4622a8cdd6647d069c3c957526386267aeb5413ac0b778a57a74733
+size 5446

--- a/testdata/pcaps/corpus/cliproxy-mixed-format.pcap
+++ b/testdata/pcaps/corpus/cliproxy-mixed-format.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:570e677f4e29e0a19ebb87778d82dcc11f15fd5e36d60dce88c663e65994afce
+size 1102

--- a/testdata/pcaps/corpus/codex-responses.pcap
+++ b/testdata/pcaps/corpus/codex-responses.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c18a2ddf758a17b6d11846c43119e0fe6a1654c2b56e2f7d826ce619c42e87b
+size 2583

--- a/testdata/pcaps/corpus/generic-anthropic.pcap
+++ b/testdata/pcaps/corpus/generic-anthropic.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20634595041aa5f7d4555b1a41d2a58c1441788b77653eac0cdeadd2f4e36508
+size 4649

--- a/testdata/pcaps/corpus/generic-openai-chat.pcap
+++ b/testdata/pcaps/corpus/generic-openai-chat.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f24ab49e70227477adc24aa57954bf8b8081c1337a51548bcdafe7c289cd563
+size 4482

--- a/testdata/pcaps/corpus/generic-openai-responses.pcap
+++ b/testdata/pcaps/corpus/generic-openai-responses.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f854d077390fc71bc6b70eecb723ac88d90f8d6fdc994da2747044874f188d
+size 2381

--- a/testdata/pcaps/corpus/hermes-anthropic.pcap
+++ b/testdata/pcaps/corpus/hermes-anthropic.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36ab7405f65e2569db3f3279fc180fe84d89404428d956503c01bbb5375c32cc
+size 5260

--- a/testdata/pcaps/corpus/hermes-openai-chat.pcap
+++ b/testdata/pcaps/corpus/hermes-openai-chat.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d402f2a269406b849463945eb863cb0913851432ffc949551ef79e82e7f5cf1
+size 5192

--- a/testdata/pcaps/corpus/keepalive-claude-chat.pcap
+++ b/testdata/pcaps/corpus/keepalive-claude-chat.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dbee80b13971507e9a455c1ac862181b9ace4508f48a3234eed6fa9be17908a
+size 367220

--- a/testdata/pcaps/corpus/openclaw-anthropic-parallel.pcap
+++ b/testdata/pcaps/corpus/openclaw-anthropic-parallel.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d393473dae541f836c70a570775e30585fc73935dcec0a2d3fdeb87a0bf75757
+size 6124

--- a/testdata/pcaps/corpus/openclaw-openai-chat.pcap
+++ b/testdata/pcaps/corpus/openclaw-openai-chat.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5e9ee43b2af58b6942f1e5fd9543bd226fe936b34ea56e49b29f3e7bf433c2b
+size 5160

--- a/testdata/pcaps/corpus/opencode-openai-chat.pcap
+++ b/testdata/pcaps/corpus/opencode-openai-chat.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c73ce29d98ef654f7cf9aa66990fac02ca88d1b6aa635ea51c8c93c20eb39f3
+size 4618

--- a/testdata/pcaps/golden/claude-cli-anthropic-nonstream.json
+++ b/testdata/pcaps/golden/claude-cli-anthropic-nonstream.json
@@ -4,13 +4,13 @@
     {
       "agent_topology": "single_agent",
       "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 1500,
+      "cache_read_input_tokens": 1400,
       "finish_reason": "end_turn",
-      "input_tokens": 1600,
+      "input_tokens": 1500,
       "is_agent_request": true,
-      "is_stream": true,
+      "is_stream": false,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 30,
+      "output_tokens": 25,
       "response_id_present": true,
       "response_tool_uses": [],
       "status_code": 200,
@@ -23,14 +23,14 @@
     },
     {
       "agent_topology": null,
-      "cache_creation_input_tokens": 256,
-      "cache_read_input_tokens": 1024,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 512,
       "finish_reason": "tool_use",
-      "input_tokens": 1500,
+      "input_tokens": 1400,
       "is_agent_request": false,
-      "is_stream": true,
+      "is_stream": false,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 40,
+      "output_tokens": 35,
       "response_id_present": true,
       "response_tool_uses": [
         {
@@ -62,10 +62,10 @@
       "tool_surfaces": [
         "function_call"
       ],
-      "total_cache_creation_input_tokens": 256,
-      "total_cache_read_input_tokens": 2524,
-      "total_input_tokens": 3100,
-      "total_output_tokens": 70,
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
       "user_input_preview_present": true,
       "wire_api": "anthropic"
     }

--- a/testdata/pcaps/golden/claude-cli-anthropic-stream.json
+++ b/testdata/pcaps/golden/claude-cli-anthropic-stream.json
@@ -1,0 +1,66 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 1500,
+      "finish_reason": "end_turn",
+      "input_tokens": 1600,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "claude-sonnet-4-20250514",
+      "output_tokens": 30,
+      "response_id_present": true,
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "Read"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "anthropic"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": 256,
+      "cache_read_input_tokens": 1024,
+      "finish_reason": "tool_use",
+      "input_tokens": 1500,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "claude-sonnet-4-20250514",
+      "output_tokens": 40,
+      "response_id_present": true,
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "anthropic"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "claude-cli",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "end_turn",
+      "models_used": [
+        "claude-sonnet-4-20250514"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 256,
+      "total_cache_read_input_tokens": 2524,
+      "total_input_tokens": 3100,
+      "total_output_tokens": 70,
+      "user_input_preview_present": true,
+      "wire_api": "anthropic"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/cliproxy-mixed-format.json
+++ b/testdata/pcaps/golden/cliproxy-mixed-format.json
@@ -12,6 +12,7 @@
       "model": "claude-sonnet-4-20250514",
       "output_tokens": 37,
       "response_id_present": true,
+      "response_tool_uses": [],
       "status_code": 200,
       "tool_call_count": 0,
       "tool_names": [],

--- a/testdata/pcaps/golden/cliproxy-mixed-format.json
+++ b/testdata/pcaps/golden/cliproxy-mixed-format.json
@@ -1,0 +1,24 @@
+{
+  "call_count": 1,
+  "calls": [
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": null,
+      "finish_reason": null,
+      "input_tokens": 309,
+      "is_agent_request": false,
+      "is_stream": false,
+      "model": "claude-sonnet-4-20250514",
+      "output_tokens": 37,
+      "response_id_present": true,
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 0,
+  "turns": []
+}

--- a/testdata/pcaps/golden/codex-responses.json
+++ b/testdata/pcaps/golden/codex-responses.json
@@ -1,0 +1,73 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "completed",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": false,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "shell"
+      ],
+      "tool_surface": "cli",
+      "wire_api": "openai-responses"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "completed",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": false,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "shell"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "openai-responses"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "codex-cli",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "completed",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "cli"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-responses"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/generic-anthropic.json
+++ b/testdata/pcaps/golden/generic-anthropic.json
@@ -4,13 +4,13 @@
     {
       "agent_topology": "single_agent",
       "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 1500,
+      "cache_read_input_tokens": 1400,
       "finish_reason": "end_turn",
-      "input_tokens": 1600,
+      "input_tokens": 1500,
       "is_agent_request": true,
       "is_stream": true,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 30,
+      "output_tokens": 25,
       "response_id_present": true,
       "response_tool_uses": [],
       "status_code": 200,
@@ -23,14 +23,14 @@
     },
     {
       "agent_topology": null,
-      "cache_creation_input_tokens": 256,
-      "cache_read_input_tokens": 1024,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 512,
       "finish_reason": "tool_use",
-      "input_tokens": 1500,
+      "input_tokens": 1400,
       "is_agent_request": false,
       "is_stream": true,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 40,
+      "output_tokens": 35,
       "response_id_present": true,
       "response_tool_uses": [
         {
@@ -48,7 +48,7 @@
   "turn_count": 1,
   "turns": [
     {
-      "agent_kind": "claude-cli",
+      "agent_kind": "generic",
       "agent_topology": "single_agent",
       "call_count": 2,
       "final_answer_preview_present": true,
@@ -62,10 +62,10 @@
       "tool_surfaces": [
         "function_call"
       ],
-      "total_cache_creation_input_tokens": 256,
-      "total_cache_read_input_tokens": 2524,
-      "total_input_tokens": 3100,
-      "total_output_tokens": 70,
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
       "user_input_preview_present": true,
       "wire_api": "anthropic"
     }

--- a/testdata/pcaps/golden/generic-openai-chat.json
+++ b/testdata/pcaps/golden/generic-openai-chat.json
@@ -1,0 +1,73 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "stop",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "Read"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-chat"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "tool_calls",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Read"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "generic",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "stop",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-chat"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/generic-openai-responses.json
+++ b/testdata/pcaps/golden/generic-openai-responses.json
@@ -1,0 +1,73 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "completed",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": false,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "lookup"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-responses"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "completed",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": false,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "lookup"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "openai-responses"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "generic",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "completed",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-responses"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/hermes-anthropic.json
+++ b/testdata/pcaps/golden/hermes-anthropic.json
@@ -2,35 +2,37 @@
   "call_count": 2,
   "calls": [
     {
-      "agent_topology": "single_agent",
-      "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 1500,
-      "finish_reason": "end_turn",
-      "input_tokens": 1600,
-      "is_agent_request": true,
-      "is_stream": true,
-      "model": "claude-sonnet-4-20250514",
-      "output_tokens": 30,
-      "response_id_present": true,
-      "response_tool_uses": [],
-      "status_code": 200,
-      "tool_call_count": 1,
-      "tool_names": [
-        "Read"
-      ],
-      "tool_surface": "function_call",
-      "wire_api": "anthropic"
-    },
-    {
       "agent_topology": null,
-      "cache_creation_input_tokens": 256,
-      "cache_read_input_tokens": 1024,
-      "finish_reason": "tool_use",
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "end_turn",
       "input_tokens": 1500,
       "is_agent_request": false,
       "is_stream": true,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 40,
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [
+        "Read",
+        "delegate_task",
+        "skill_view"
+      ],
+      "tool_surface": null,
+      "wire_api": "anthropic"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "tool_use",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "claude-sonnet-4-20250514",
+      "output_tokens": 35,
       "response_id_present": true,
       "response_tool_uses": [
         {
@@ -40,7 +42,11 @@
       ],
       "status_code": 200,
       "tool_call_count": 0,
-      "tool_names": [],
+      "tool_names": [
+        "Read",
+        "delegate_task",
+        "skill_view"
+      ],
       "tool_surface": null,
       "wire_api": "anthropic"
     }
@@ -48,8 +54,8 @@
   "turn_count": 1,
   "turns": [
     {
-      "agent_kind": "claude-cli",
-      "agent_topology": "single_agent",
+      "agent_kind": "hermes",
+      "agent_topology": null,
       "call_count": 2,
       "final_answer_preview_present": true,
       "final_finish_reason": "end_turn",
@@ -58,14 +64,12 @@
       ],
       "status": "complete",
       "subagents_used": [],
-      "tool_call_total": 1,
-      "tool_surfaces": [
-        "function_call"
-      ],
-      "total_cache_creation_input_tokens": 256,
-      "total_cache_read_input_tokens": 2524,
-      "total_input_tokens": 3100,
-      "total_output_tokens": 70,
+      "tool_call_total": 0,
+      "tool_surfaces": [],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
       "user_input_preview_present": true,
       "wire_api": "anthropic"
     }

--- a/testdata/pcaps/golden/hermes-openai-chat.json
+++ b/testdata/pcaps/golden/hermes-openai-chat.json
@@ -1,0 +1,79 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "stop",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "Read",
+        "delegate_task",
+        "skill_view"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-chat"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "tool_calls",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Read"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [
+        "Read",
+        "delegate_task",
+        "skill_view"
+      ],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "hermes",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "stop",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-chat"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/keepalive-claude-chat.json
+++ b/testdata/pcaps/golden/keepalive-claude-chat.json
@@ -1,0 +1,66 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": null,
+      "finish_reason": "tool_calls",
+      "input_tokens": 16848,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "exp_model",
+      "output_tokens": 165,
+      "response_id_present": true,
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "SlashCommand"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-chat"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": null,
+      "finish_reason": "tool_calls",
+      "input_tokens": 13165,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "exp_model",
+      "output_tokens": 98,
+      "response_id_present": true,
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "generic",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": false,
+      "final_finish_reason": null,
+      "models_used": [
+        "exp_model"
+      ],
+      "status": "incomplete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 0,
+      "total_input_tokens": 30013,
+      "total_output_tokens": 263,
+      "user_input_preview_present": true,
+      "wire_api": "openai-chat"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/keepalive-claude-chat.json
+++ b/testdata/pcaps/golden/keepalive-claude-chat.json
@@ -12,6 +12,16 @@
       "model": "exp_model",
       "output_tokens": 165,
       "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Bash"
+        },
+        {
+          "has_input": true,
+          "name": "Glob"
+        }
+      ],
       "status_code": 200,
       "tool_call_count": 1,
       "tool_names": [
@@ -31,6 +41,12 @@
       "model": "exp_model",
       "output_tokens": 98,
       "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "SlashCommand"
+        }
+      ],
       "status_code": 200,
       "tool_call_count": 0,
       "tool_names": [],

--- a/testdata/pcaps/golden/openclaw-anthropic-parallel.json
+++ b/testdata/pcaps/golden/openclaw-anthropic-parallel.json
@@ -4,35 +4,42 @@
     {
       "agent_topology": "single_agent",
       "cache_creation_input_tokens": 0,
-      "cache_read_input_tokens": 1500,
+      "cache_read_input_tokens": 1400,
       "finish_reason": "end_turn",
-      "input_tokens": 1600,
+      "input_tokens": 1500,
       "is_agent_request": true,
       "is_stream": true,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 30,
+      "output_tokens": 25,
       "response_id_present": true,
       "response_tool_uses": [],
       "status_code": 200,
-      "tool_call_count": 1,
+      "tool_call_count": 2,
       "tool_names": [
-        "Read"
+        "Grep",
+        "Read",
+        "sessions_spawn",
+        "subagents"
       ],
       "tool_surface": "function_call",
       "wire_api": "anthropic"
     },
     {
       "agent_topology": null,
-      "cache_creation_input_tokens": 256,
-      "cache_read_input_tokens": 1024,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 512,
       "finish_reason": "tool_use",
-      "input_tokens": 1500,
+      "input_tokens": 1400,
       "is_agent_request": false,
       "is_stream": true,
       "model": "claude-sonnet-4-20250514",
-      "output_tokens": 40,
+      "output_tokens": 35,
       "response_id_present": true,
       "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Grep"
+        },
         {
           "has_input": true,
           "name": "Read"
@@ -40,7 +47,12 @@
       ],
       "status_code": 200,
       "tool_call_count": 0,
-      "tool_names": [],
+      "tool_names": [
+        "Grep",
+        "Read",
+        "sessions_spawn",
+        "subagents"
+      ],
       "tool_surface": null,
       "wire_api": "anthropic"
     }
@@ -48,7 +60,7 @@
   "turn_count": 1,
   "turns": [
     {
-      "agent_kind": "claude-cli",
+      "agent_kind": "openclaw",
       "agent_topology": "single_agent",
       "call_count": 2,
       "final_answer_preview_present": true,
@@ -58,14 +70,14 @@
       ],
       "status": "complete",
       "subagents_used": [],
-      "tool_call_total": 1,
+      "tool_call_total": 2,
       "tool_surfaces": [
         "function_call"
       ],
-      "total_cache_creation_input_tokens": 256,
-      "total_cache_read_input_tokens": 2524,
-      "total_input_tokens": 3100,
-      "total_output_tokens": 70,
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
       "user_input_preview_present": true,
       "wire_api": "anthropic"
     }

--- a/testdata/pcaps/golden/openclaw-openai-chat.json
+++ b/testdata/pcaps/golden/openclaw-openai-chat.json
@@ -1,0 +1,79 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "stop",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "Read",
+        "sessions_spawn",
+        "subagents"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-chat"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "tool_calls",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Read"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [
+        "Read",
+        "sessions_spawn",
+        "subagents"
+      ],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "openclaw",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "stop",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-chat"
+    }
+  ]
+}

--- a/testdata/pcaps/golden/opencode-openai-chat.json
+++ b/testdata/pcaps/golden/opencode-openai-chat.json
@@ -1,0 +1,75 @@
+{
+  "call_count": 2,
+  "calls": [
+    {
+      "agent_topology": "single_agent",
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 1400,
+      "finish_reason": "stop",
+      "input_tokens": 1500,
+      "is_agent_request": true,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 25,
+      "response_id_present": true,
+      "response_tool_uses": [],
+      "status_code": 200,
+      "tool_call_count": 1,
+      "tool_names": [
+        "Read"
+      ],
+      "tool_surface": "function_call",
+      "wire_api": "openai-chat"
+    },
+    {
+      "agent_topology": null,
+      "cache_creation_input_tokens": null,
+      "cache_read_input_tokens": 512,
+      "finish_reason": "tool_calls",
+      "input_tokens": 1400,
+      "is_agent_request": false,
+      "is_stream": true,
+      "model": "gpt-4o-2024-08-06",
+      "output_tokens": 35,
+      "response_id_present": true,
+      "response_tool_uses": [
+        {
+          "has_input": true,
+          "name": "Read"
+        }
+      ],
+      "status_code": 200,
+      "tool_call_count": 0,
+      "tool_names": [
+        "Read"
+      ],
+      "tool_surface": null,
+      "wire_api": "openai-chat"
+    }
+  ],
+  "turn_count": 1,
+  "turns": [
+    {
+      "agent_kind": "opencode",
+      "agent_topology": "single_agent",
+      "call_count": 2,
+      "final_answer_preview_present": true,
+      "final_finish_reason": "stop",
+      "models_used": [
+        "gpt-4o-2024-08-06"
+      ],
+      "status": "complete",
+      "subagents_used": [],
+      "tool_call_total": 1,
+      "tool_surfaces": [
+        "function_call"
+      ],
+      "total_cache_creation_input_tokens": 0,
+      "total_cache_read_input_tokens": 1912,
+      "total_input_tokens": 2900,
+      "total_output_tokens": 60,
+      "user_input_preview_present": true,
+      "wire_api": "openai-chat"
+    }
+  ]
+}

--- a/testdata/pcaps/keepalive-claude-chat.scrub.json
+++ b/testdata/pcaps/keepalive-claude-chat.scrub.json
@@ -1,0 +1,13 @@
+{
+  "input": "keepalive_2sse_pipelined.pcap",
+  "output": "keepalive-claude-chat.pcap",
+  "size_bytes": 367220,
+  "length_preserved": true,
+  "seed": "heron-pcap-scrub-v1",
+  "rules_fired": {
+    "authorization_header": 4,
+    "rfc1918_ip": 4,
+    "home_path": 8,
+    "email": 8
+  }
+}


### PR DESCRIPTION
## What

Turns the hand-distributed, gitignored pcap fixtures into a curated, **secret-scrubbed, git-LFS-committed** corpus that gates parser regressions in CI — across the (LLM-backend × agent × wire_api × scenario) matrix. The replay plumbing already existed (`PcapFileSource` + the h-turn replay harness); this adds the corpus layer around it.

## Why

The replay + e2e harnesses skip when fixtures are absent, and the pcaps are gitignored, so **none of it runs in CI** — a parser change can green the build yet mangle real traffic (the #96 cliproxy mixed-format class). This makes the corpus committable and CI-gated.

## Pieces

- **`testdata/pcaps/corpus.toml`** — single source of truth for the matrix. `status="active"` cells run; `status="pending"` cells document target combinations awaiting capture. `backend_label` (vllm/sglang/ollama/litellm/cliproxy) is a **provenance label + quirk dimension, not a detection output** (they're all `openai-chat`/`openai-responses` on the wire); `[fixture.expect.quirks]` carries the assertable difference (SSE framing, usage-field style, mixed-format).
- **`scripts/pcaps/scrub_pcap.py`** (+`.sh`, README) — **length-preserving** byte redaction of secrets/PII (Authorization / `sk-*` / JWT / PEM / RFC1918 / home-paths / email) that keeps JSON structure, tool defs, `usage` numbers and SSE framing intact, so the scrubbed file replays to the **same** ground truth (Heron doesn't validate TCP/IP checksums, so same-length substitution needs no checksum rewrite). Refuses to emit on residual secrets.
- **`server/h-turn/tests/corpus_golden.rs`** — data-driven golden test over the manifest, reusing the full-pipeline replay; projects `LlmCall`/`AgentTurn` to a deterministic shape (no uuids/timing) and compares to `testdata/pcaps/golden/<id>.json`. **Skips absent fixtures AND unsmudged git-LFS pointers**, so the workspace builds without `git lfs pull`. Bless via `HERON_BLESS_GOLDENS=1` / `just corpus bless`.
- **`scripts/lint/check-pcap-corpus.sh`** — manifest↔file↔golden consistency + a **binary-payload leakage scan** (`check-leakage.sh` skips binaries, so this is the secret gate for committed pcaps). Wired into `ci.yml`.
- **git-LFS**: `.gitattributes` tracks `testdata/pcaps/corpus/*.pcap`; `.gitignore` keeps a `raw/` scratch dir ignored; `ci.yml` checks out with `lfs: true`.
- **`just corpus {test,bless,lint}`**; docs in `testdata/pcaps/README.md`.

## Validation

Seeded one **active** cell end-to-end (`keepalive-claude-chat`, scrubbed from the committed protocol fixture) to prove scrub → commit (LFS) → golden → CI. The scrubbed pcap still replays into a real turn (generic / openai-chat, function_call surface, 30,013 input tokens) — confirming redaction preserved structure. Locally: `cargo build --workspace` ✓, `cargo test -p h-turn --test corpus_golden` ✓, `check-leakage.sh` ✓ (566 files), `check-pcap-corpus.sh` ✓.

## ⚠️ CI prerequisite

**git-lfs must be installed on the `ci-pool` runner** for `actions/checkout lfs:true` to materialize the corpus (otherwise the harness sees pointer files and skips them — degraded but not broken).

## Scope / follow-ups

The framework + full matrix are defined; the remaining cells fill in as captures are scrubbed (each = one manifest entry + LFS pcap + golden, no code change — many need fresh captures against live backends). Follow-ups: dedupe the replay harness shared with `integration.rs`; add a tara `--corpus-dir` soak feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)