### PR TITLE
feat(staging): nightly longevity soak — the 102 GB endurance catcher (PR4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
         # Dependency-free (stdlib only) so it needs no pip install on the runner.
         run: python3 scripts/staging/tests/test_tara_invariants.py
 
+      - name: longevity-soak checker tests
+        # Guards the nightly endurance judgement logic
+        # (scripts/staging/longevity_check.py). Stdlib-only.
+        run: python3 scripts/staging/tests/test_longevity_check.py
+
       # --- staging artifact ---------------------------------------------
       # On a push to main (post-merge), build the deployable binary and
       # publish it so deploy-staging.yml can roll it onto the heron-stage VM.

--- a/scripts/staging/longevity-soak.service
+++ b/scripts/staging/longevity-soak.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=longevity-soak — heron endurance run (one pass)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Dedicated service user (operator-created), matching mara's pattern. No NIC /
+# capture capabilities are needed — the soak replays a pcap FILE, not a device.
+User=longevity
+# Required config lives here (chmod 600, NOT in the repo). At minimum:
+#   LONGEVITY_BINARY=/opt/heron/heron
+#   LONGEVITY_CORPUS=/opt/heron/corpus.pcap
+# Optional: LONGEVITY_DURATION (default 14400=4h), LONGEVITY_RATE_PPS (500),
+#   LONGEVITY_REPO, GH_TOKEN (to file a regression issue via the REST API).
+EnvironmentFile=/etc/longevity/env
+ExecStart=/usr/local/bin/longevity-soak.sh --json-out /var/log/longevity/last.json
+# The run is hours long — never let systemd time it out. A regression exits 1
+# (it files an issue); SuccessExitStatus keeps that from wedging the timer.
+TimeoutStartSec=infinity
+SuccessExitStatus=0 1
+# Keep memory honest even here — a runaway soak must not threaten the VM.
+MemoryMax=4G
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/staging/longevity-soak.sh
+++ b/scripts/staging/longevity-soak.sh
@@ -172,12 +172,15 @@ if [ "${LONGEVITY_NO_FILE:-0}" = 1 ] || [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-# Mask any internal infra identity before the body leaves the host (same rule
-# as mara's scrub()).
+# Mask any internal infra identity before the body leaves the host. Keep the
+# rule set IN SYNC with mara.sh's scrub() (the canonical copy): IPv4, home
+# paths, URL authorities, and ssh-style user@host — a fatal log line pulled into
+# the issue can carry any of them.
 scrub() {
   sed -E -e 's/\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b/<ip>/g' \
          -e 's#(/home|/Users)/[A-Za-z0-9._-]+#\1/<user>#g' \
-         -e 's#(https?://)[^/[:space:]]+#\1<host>#g'
+         -e 's#(https?://)[^/[:space:]]+#\1<host>#g' \
+         -e 's/\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+/<user>@<host>/g'
 }
 SIG="longevity-regression"
 FAILED="$(printf '%s' "$VERDICT" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin).get("failed",[])))' 2>/dev/null)"

--- a/scripts/staging/longevity-soak.sh
+++ b/scripts/staging/longevity-soak.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# longevity-soak — the nightly endurance run (quality-infra L7, PR4).
+#
+# Drives heron under a steady rate-controlled pcap-file replay for HOURS and
+# tracks RSS + on-disk DuckDB size + pipeline metrics over the whole window,
+# then asserts the run stayed healthy (no memory leak, no super-linear DB
+# bloat, no checkpoint/"broken index" FATAL, no flush errors). This is the test
+# that would have caught the 2026-06-02 prod outage — a 102 GB DuckDB whose
+# checkpoint hit a "broken index" FATAL → SIGSEGV. Not a per-PR gate; runs from
+# a systemd timer (longevity-soak.timer) on the staging VM.
+#
+# Reuses the same throwaway-workdir + private-port + isolated-DuckDB model as
+# tara.sh, plus the rate_pps load primitive (PR1) so the load is steady and
+# prod-like instead of an as-fast-as-possible firehose.
+#
+# Usage:
+#   longevity-soak.sh --binary <heron> --corpus <pcap>
+#       [--duration 14400] [--rate-pps 500] [--sample-secs 30]
+#       [--max-rss-growth-pct 30] [--max-bytes-per-call-growth-pct 50]
+#       [--min-pkts N] [--json-out <file>] [--workdir <dir>] [--keep]
+#
+# Issue filing on regression (best-effort, only when configured):
+#   LONGEVITY_REPO   GitHub repo            (default Netis/heron)
+#   GH_TOKEN         token for the REST API (no `gh` — the runner has only curl)
+#   LONGEVITY_NO_FILE=1   never file an issue (report only)
+#
+# Exit: 0 healthy · 1 regression · 2 usage/setup error.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$HERE/longevity_check.py"
+
+# Main knobs fall back to env (so the systemd unit configures them purely via
+# its EnvironmentFile) and are overridable by the flags below.
+BINARY="${LONGEVITY_BINARY:-}" CORPUS="${LONGEVITY_CORPUS:-}"
+DURATION="${LONGEVITY_DURATION:-14400}" RATE_PPS="${LONGEVITY_RATE_PPS:-500}"
+SAMPLE_SECS="${LONGEVITY_SAMPLE_SECS:-30}"
+MAX_RSS_GROWTH_PCT=30 MAX_BPC_GROWTH_PCT=50 MIN_PKTS=0
+JSON_OUT="" WORKROOT="" KEEP=0 PORT="${LONGEVITY_PORT:-4601}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --binary)    BINARY="$2"; shift 2;;
+    --corpus)    CORPUS="$2"; shift 2;;
+    --duration)  DURATION="$2"; shift 2;;
+    --rate-pps)  RATE_PPS="$2"; shift 2;;
+    --sample-secs) SAMPLE_SECS="$2"; shift 2;;
+    --max-rss-growth-pct) MAX_RSS_GROWTH_PCT="$2"; shift 2;;
+    --max-bytes-per-call-growth-pct) MAX_BPC_GROWTH_PCT="$2"; shift 2;;
+    --min-pkts)  MIN_PKTS="$2"; shift 2;;
+    --json-out)  JSON_OUT="$2"; shift 2;;
+    --workdir)   WORKROOT="$2"; shift 2;;
+    --port)      PORT="$2"; shift 2;;
+    --keep)      KEEP=1; shift;;
+    *) echo "longevity-soak: unknown arg '$1'" >&2; exit 2;;
+  esac
+done
+
+[ -x "$BINARY" ] || { echo "longevity-soak: --binary '$BINARY' missing/not executable" >&2; exit 2; }
+[ -f "$CORPUS" ] || { echo "longevity-soak: --corpus '$CORPUS' not found" >&2; exit 2; }
+[ -f "$CHECKER" ] || { echo "longevity-soak: checker '$CHECKER' not found" >&2; exit 2; }
+# Default the throughput floor to half the nominal rate × duration, so a stalled
+# run (no traffic for the window) fails `load_sustained`.
+[ "$MIN_PKTS" -gt 0 ] 2>/dev/null || MIN_PKTS=$(( RATE_PPS * DURATION / 2 ))
+
+WORKROOT="${WORKROOT:-$(mktemp -d /tmp/longevity.XXXXXX)}"
+mkdir -p "$WORKROOT/data"
+cleanup() { [ "$KEEP" = 1 ] || rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+CORPUS_ABS="$(cd "$(dirname "$CORPUS")" && pwd)/$(basename "$CORPUS")"
+CFG="$WORKROOT/config.toml" LOG="$WORKROOT/heron.log"
+DB="$WORKROOT/data/heron.duckdb" SAMPLES="$WORKROOT/samples.jsonl"
+
+cat > "$CFG" <<TOML
+[[pipeline]]
+name = "longevity"
+dispatcher_count = 1
+flow_shard_count = 4
+[pipeline.turn]
+idle_timeout_secs = 4
+sweep_interval_secs = 2
+grace_ms = 500
+shard_count = 1
+[pipeline.metrics]
+shard_count = 1
+[[pipeline.sources]]
+type = "pcap-file"
+path = "$CORPUS_ABS"
+realtime = false
+source_id = "longevity"
+loop_secs = $DURATION
+rate_pps = $RATE_PPS
+[storage]
+backend = "duckdb"
+[storage.duckdb]
+path = "$DB"
+[storage.sink]
+batch_size = 200
+flush_interval_ms = 500
+# Retention enabled with a short sweep interval so the pruning + checkpoint
+# paths are exercised across the run (the surfaces that bloated prod).
+[storage.retention]
+enabled = true
+check_interval_secs = 60
+calls = 1
+turns = 1
+http_exchanges = 1
+[internal_metrics]
+enabled = true
+interval_secs = 2
+[api]
+listen = "127.0.0.1"
+port = $PORT
+TOML
+
+echo "longevity-soak: starting $BINARY on :$PORT — ${DURATION}s @ ${RATE_PPS}pps, sampling every ${SAMPLE_SECS}s" >&2
+"$BINARY" -v -c "$CFG" > "$LOG" 2>&1 &
+PID=$!
+
+# Wait for the API.
+up=0
+for _ in $(seq 1 30); do
+  curl -fsS -m 2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && { up=1; break; }
+  kill -0 "$PID" 2>/dev/null || break
+  sleep 1
+done
+if [ "$up" != 1 ]; then
+  echo "longevity-soak: heron API never came up" >&2
+  kill -9 "$PID" 2>/dev/null || true
+  exit 2
+fi
+
+# Sample RSS + on-disk DB size + metrics over the window.
+: > "$SAMPLES"
+t_end=$(( $(date +%s) + DURATION ))
+while [ "$(date +%s)" -lt "$t_end" ]; do
+  kill -0 "$PID" 2>/dev/null || { echo "longevity-soak: heron died mid-run" >&2; break; }
+  rss_kb="$(awk '/^VmRSS:/{print $2}' "/proc/$PID/status" 2>/dev/null || echo 0)"
+  db_bytes="$(stat -c %s "$DB" 2>/dev/null || stat -f %z "$DB" 2>/dev/null || echo 0)"
+  m="$(curl -fsS -m 5 "http://127.0.0.1:$PORT/api/internal-metrics" 2>/dev/null || echo '{}')"
+  printf '{"ts":%s,"rss_kb":%s,"db_bytes":%s,"metrics":%s}\n' \
+    "$(date +%s)" "${rss_kb:-0}" "${db_bytes:-0}" "$m" >> "$SAMPLES"
+  sleep "$SAMPLE_SECS"
+done
+
+# Let the sink drain, then graceful stop.
+sleep 4
+kill -TERM "$PID" 2>/dev/null || true
+for _ in $(seq 1 8); do kill -0 "$PID" 2>/dev/null || break; sleep 1; done
+kill -9 "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+
+VERDICT="$(python3 "$CHECKER" --samples "$SAMPLES" --logfile "$LOG" \
+  --max-rss-growth-pct "$MAX_RSS_GROWTH_PCT" \
+  --max-bytes-per-call-growth-pct "$MAX_BPC_GROWTH_PCT" \
+  --min-pkts "$MIN_PKTS")"
+rc=$?
+printf '%s\n' "$VERDICT"
+[ -z "$JSON_OUT" ] || printf '%s\n' "$VERDICT" > "$JSON_OUT"
+
+if [ "$rc" = 0 ]; then
+  echo "longevity-soak: PASS — endured ${DURATION}s with no leak / bloat / FATAL" >&2
+  exit 0
+fi
+
+echo "longevity-soak: REGRESSION — $(printf '%s' "$VERDICT" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin).get("failed",[])))' 2>/dev/null)" >&2
+
+# Best-effort: file a scrubbed, de-duplicated issue (only when configured).
+REPO="${LONGEVITY_REPO:-Netis/heron}"
+if [ "${LONGEVITY_NO_FILE:-0}" = 1 ] || [ -z "${GH_TOKEN:-}" ]; then
+  echo "longevity-soak: issue filing skipped (LONGEVITY_NO_FILE or no GH_TOKEN)" >&2
+  exit 1
+fi
+
+# Mask any internal infra identity before the body leaves the host (same rule
+# as mara's scrub()).
+scrub() {
+  sed -E -e 's/\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b/<ip>/g' \
+         -e 's#(/home|/Users)/[A-Za-z0-9._-]+#\1/<user>#g' \
+         -e 's#(https?://)[^/[:space:]]+#\1<host>#g'
+}
+SIG="longevity-regression"
+FAILED="$(printf '%s' "$VERDICT" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin).get("failed",[])))' 2>/dev/null)"
+# Dedup: skip if an open issue already tracks this signature.
+EXIST="$(curl -fsS -m 10 -H "Authorization: Bearer $GH_TOKEN" \
+  "${GITHUB_API_URL:-https://api.github.com}/search/issues?q=$(printf 'repo:%s+is:issue+is:open+in:title+%s' "$REPO" "$SIG")" \
+  2>/dev/null | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("total_count",0))
+except Exception: print(0)' 2>/dev/null || echo 0)"
+if [ "${EXIST:-0}" != "0" ]; then
+  echo "longevity-soak: open '$SIG' issue already exists — not refiling" >&2
+  exit 1
+fi
+
+BODY="$(printf '🤖 **longevity-soak** detected an endurance regression.\n\n- **Failed invariants**: `%s`\n- **Duration**: %ss @ %spps\n\n```json\n%s\n```\n\nThis is the leak / DB-bloat / checkpoint-FATAL class (the 102 GB prod-outage family). Add `agent:assess` to route into triage.' \
+  "$FAILED" "$DURATION" "$RATE_PPS" "$VERDICT" | scrub)"
+TITLE="[longevity] endurance regression: $SIG"
+PAYLOAD="$(python3 -c 'import json,sys; print(json.dumps({"title":sys.argv[1],"body":sys.argv[2],"labels":["longevity","incident"]}))' "$TITLE" "$BODY")"
+code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+  "${GITHUB_API_URL:-https://api.github.com}/repos/${REPO}/issues" -d "$PAYLOAD" 2>/dev/null || echo 000)
+[ "$code" = "201" ] && echo "longevity-soak: filed regression issue" >&2 \
+  || echo "::warning::longevity-soak: failed to file issue (HTTP $code)" >&2
+exit 1

--- a/scripts/staging/longevity-soak.timer
+++ b/scripts/staging/longevity-soak.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=longevity-soak — nightly heron endurance run
+
+[Timer]
+# Nightly, off-hours. Randomize a little so multiple hosts don't all start at
+# the same instant.
+OnCalendar=*-*-* 02:00:00
+RandomizedDelaySec=20min
+# Fire on resume if a window was missed (host asleep / restarted).
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/staging/longevity_check.py
+++ b/scripts/staging/longevity_check.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""longevity_check — the judgement half of the nightly longevity soak.
+
+Reads a `samples.jsonl` time series (one line per sample: ts, rss_kb,
+db_bytes, and a flattened `/api/internal-metrics` snapshot) plus the heron
+log, and asserts that a multi-hour sustained-load run stays HEALTHY over time —
+the regression class behind the 2026-06-02 prod outage (a 102 GB DuckDB whose
+checkpoint hit a "broken index" FATAL → SIGSEGV):
+
+  - no_fatal_logs       : no panic / "broken index" / checkpoint FATAL ever.
+  - no_flush_errors     : storage never reported a flush error.
+  - rss_stable          : post-warmup RSS growth < threshold (memory leak).
+  - db_growth_sane      : on-disk DuckDB bytes-PER-stored-call stays bounded —
+                          the DB may grow with ingestion, but it must grow
+                          ~linearly with data, not super-linearly (the index /
+                          checkpoint bloat that ran prod to 102 GB).
+  - load_sustained      : the run actually ingested a meaningful packet volume
+                          for its whole window (didn't silently stall).
+
+Pure input→verdict (stdlib only, no pytest) so it is unit-testable by feeding a
+synthesized series; mirrors tara_invariants.py. Exit 0 = pass, 1 = regression.
+"""
+import argparse
+import json
+import re
+import sys
+
+FATAL_PATTERNS = [
+    r"panicked at",
+    r"\bFATAL\b",
+    r"broken index",            # the #50/#52 DuckDB checkpoint class (the 102 GB FATAL)
+    r"exited abnormally",
+    r"JoinHandle polled after completion",
+]
+
+
+def scan_log(path):
+    fatals = []
+    if not path:
+        return fatals
+    try:
+        with open(path, "r", errors="replace") as fh:
+            for line in fh:
+                for pat in FATAL_PATTERNS:
+                    if re.search(pat, line):
+                        fatals.append(line.rstrip()[:300])
+                        break
+    except FileNotFoundError:
+        pass
+    return fatals
+
+
+def flatten(metrics_json):
+    out = {}
+    data = metrics_json.get("data", metrics_json) if isinstance(metrics_json, dict) else {}
+    for pipe in data.get("pipelines", []):
+        for m in pipe.get("metrics", []):
+            out[m["name"]] = m.get("value", 0)
+    return out
+
+
+def load_samples(path):
+    rows = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return rows
+
+
+def _metric(sample, name, default=0):
+    m = sample.get("metrics")
+    if isinstance(m, dict):
+        flat = flatten(m)
+        return flat.get(name, default)
+    return default
+
+
+def evaluate(samples, fatals, *, max_rss_growth_pct, max_bytes_per_call_growth_pct,
+             min_pkts, warmup_frac, min_calls_for_db_check):
+    """Return a list of {name, ok, detail} invariant results."""
+    inv = []
+    inv.append(("no_fatal_logs", len(fatals) == 0,
+                "clean" if not fatals else f"{len(fatals)} fatal line(s): {fatals[0]}"))
+
+    if len(samples) < 4:
+        inv.append(("enough_samples", False,
+                    f"only {len(samples)} samples — run too short / sampler stalled"))
+        return [{"name": n, "ok": bool(ok), "detail": d} for n, ok, d in inv]
+    inv.append(("enough_samples", True, f"{len(samples)} samples"))
+
+    warm = max(1, int(len(samples) * warmup_frac))
+    post = samples[warm:]
+
+    # --- memory leak: post-warmup RSS growth ---
+    rss = [s.get("rss_kb", 0) for s in post if s.get("rss_kb", 0) > 0]
+    if len(rss) >= 2 and rss[0] > 0:
+        growth = (rss[-1] - rss[0]) / rss[0] * 100.0
+        inv.append(("rss_stable", growth <= max_rss_growth_pct,
+                    f"RSS {rss[0]}→{rss[-1]} KB = {growth:+.1f}% post-warmup (limit {max_rss_growth_pct}%)"))
+    else:
+        # RSS sampling is Linux-/proc-only; absent on macOS dry-runs.
+        inv.append(("rss_stable", True, "no RSS samples (non-Linux?) — skipped"))
+
+    # --- no flush errors across the whole run ---
+    max_flush_err = max((_metric(s, "flush_errors") for s in samples), default=0)
+    inv.append(("no_flush_errors", max_flush_err == 0, f"max flush_errors={max_flush_err}"))
+
+    # --- DB growth sanity: bytes per stored call must not balloon ---
+    # The DB grows with ingestion; what catches the 102 GB class is *bytes per
+    # row* exploding (index/checkpoint bloat) rather than tracking the data.
+    def bytes_per_call(s):
+        calls = _metric(s, "calls_ingested")
+        db = s.get("db_bytes", 0)
+        return (db / calls) if calls > 0 and db > 0 else None
+
+    # Per-call DB cost is dominated by fixed schema / page / checkpoint overhead
+    # until enough rows land, so the ratio is only meaningful at scale — gate it
+    # on a minimum call volume (a few-minute smoke would false-fail otherwise; a
+    # real nightly run is far past this floor).
+    calls_last = _metric(samples[-1], "calls_ingested")
+    early = next((bytes_per_call(s) for s in post if bytes_per_call(s)), None)
+    late = next((bytes_per_call(s) for s in reversed(post) if bytes_per_call(s)), None)
+    if calls_last < min_calls_for_db_check:
+        inv.append(("db_growth_sane", True,
+                    f"skipped — only {calls_last} calls (< {min_calls_for_db_check} "
+                    "needed for a meaningful bytes/call ratio)"))
+    elif early and late:
+        growth = (late - early) / early * 100.0
+        inv.append(("db_growth_sane", growth <= max_bytes_per_call_growth_pct,
+                    f"bytes/call {early:.0f}→{late:.0f} = {growth:+.1f}% "
+                    f"(limit {max_bytes_per_call_growth_pct}%)"))
+    else:
+        inv.append(("db_growth_sane", False,
+                    "no db_bytes / calls_ingested samples to size the DB growth"))
+
+    # --- load actually sustained for the window ---
+    last_pkts = _metric(samples[-1], "pkts_received")
+    inv.append(("load_sustained", last_pkts >= min_pkts,
+                f"pkts_received={last_pkts} (min {min_pkts})"))
+
+    return [{"name": n, "ok": bool(ok), "detail": d} for n, ok, d in inv]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--samples", required=True)
+    ap.add_argument("--logfile", default="")
+    ap.add_argument("--label", default="longevity")
+    ap.add_argument("--max-rss-growth-pct", type=float, default=30.0)
+    ap.add_argument("--max-bytes-per-call-growth-pct", type=float, default=50.0)
+    ap.add_argument("--min-pkts", type=int, default=100000)
+    ap.add_argument("--warmup-frac", type=float, default=0.25)
+    ap.add_argument("--min-calls-for-db-check", type=int, default=1000)
+    args = ap.parse_args()
+
+    samples = load_samples(args.samples)
+    fatals = scan_log(args.logfile)
+    inv = evaluate(samples, fatals,
+                   max_rss_growth_pct=args.max_rss_growth_pct,
+                   max_bytes_per_call_growth_pct=args.max_bytes_per_call_growth_pct,
+                   min_pkts=args.min_pkts, warmup_frac=args.warmup_frac,
+                   min_calls_for_db_check=args.min_calls_for_db_check)
+    passed = all(i["ok"] for i in inv)
+
+    def g(s, k):
+        return s.get(k, 0) if s else 0
+    first, last = (samples[0] if samples else {}), (samples[-1] if samples else {})
+    verdict = {
+        "label": args.label,
+        "pass": passed,
+        "invariants": inv,
+        "failed": [i["name"] for i in inv if not i["ok"]],
+        "summary": {
+            "samples": len(samples),
+            "rss_kb": {"first": g(first, "rss_kb"), "last": g(last, "rss_kb")},
+            "db_bytes": {"first": g(first, "db_bytes"), "last": g(last, "db_bytes")},
+            "calls_ingested_last": _metric(last, "calls_ingested") if last else 0,
+            "pkts_received_last": _metric(last, "pkts_received") if last else 0,
+        },
+        "fatal_lines": fatals,
+    }
+    print(json.dumps(verdict, indent=2))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/staging/tests/test_longevity_check.py
+++ b/scripts/staging/tests/test_longevity_check.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Unit tests for longevity_check — dependency-free (stdlib only), so CI runs it
+without pytest:
+
+    python3 scripts/staging/tests/test_longevity_check.py
+
+Synthesizes a `samples` time series (the shape longevity-soak.sh writes) and
+asserts each endurance invariant trips on the matching perturbation.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import longevity_check as L  # noqa: E402
+
+
+def sample(ts, rss_kb, db_bytes, calls, pkts, flush_errors=0):
+    """One samples.jsonl row in the /api/internal-metrics nested shape."""
+    return {
+        "ts": ts,
+        "rss_kb": rss_kb,
+        "db_bytes": db_bytes,
+        "metrics": {
+            "data": {
+                "pipelines": [
+                    {
+                        "metrics": [
+                            {"name": "calls_ingested", "value": calls},
+                            {"name": "pkts_received", "value": pkts},
+                            {"name": "flush_errors", "value": flush_errors},
+                        ]
+                    }
+                ]
+            }
+        },
+    }
+
+
+def healthy(n=12, calls0=2000, leak=0, bloat=1.0):
+    """n samples at scale: RSS flat (+`leak` KB/step), DB ~linear with calls
+    (× `bloat` on the per-call cost at the end)."""
+    out = []
+    for i in range(n):
+        calls = calls0 + i * 500
+        # ~2 KB/call baseline; bloat ramps the per-call cost over the run.
+        per_call = 2000 * (1 + (bloat - 1) * (i / (n - 1)))
+        out.append(sample(1_700_000_000 + i * 30, 500_000 + i * leak,
+                          int(calls * per_call), calls, 50_000 + i * 20_000))
+    return out
+
+
+def ev(samples, fatals=(), **kw):
+    args = dict(max_rss_growth_pct=30.0, max_bytes_per_call_growth_pct=50.0,
+                min_pkts=100_000, warmup_frac=0.25, min_calls_for_db_check=1000)
+    args.update(kw)
+    return L.evaluate(samples, list(fatals), **args)
+
+
+def failed(invs):
+    return [i["name"] for i in invs if not i["ok"]]
+
+
+def test_healthy_passes():
+    assert failed(ev(healthy())) == [], failed(ev(healthy()))
+
+
+def test_fatal_log_fails():
+    assert "no_fatal_logs" in failed(ev(healthy(), fatals=["thread panicked at lib.rs:1"]))
+
+
+def test_broken_index_fatal_fails():
+    assert "no_fatal_logs" in failed(ev(healthy(), fatals=["ERROR broken index while merging"]))
+
+
+def test_rss_leak_fails():
+    # +40 KB every step over 12 samples → well past the 30% post-warmup limit.
+    assert "rss_stable" in failed(ev(healthy(leak=40_000)))
+
+
+def test_flush_errors_fail():
+    s = healthy()
+    s[-1]["metrics"]["data"]["pipelines"][0]["metrics"][2]["value"] = 3  # flush_errors
+    assert "no_flush_errors" in failed(ev(s))
+
+
+def test_db_bloat_fails_at_scale():
+    # Per-call DB cost triples over the run with calls well past the floor.
+    assert "db_growth_sane" in failed(ev(healthy(bloat=3.0)))
+
+
+def test_db_check_skipped_below_min_calls():
+    # Tiny call volume throughout (last sample still < 1000) → the bytes/call
+    # ratio is noise → skipped (not failed) even though the DB cost balloons.
+    s = [sample(1_700_000_000 + i * 30, 500_000, 100_000 * (i + 1) ** 2, 5 * (i + 1),
+                100_000 + i * 20_000) for i in range(12)]
+    assert max(_calls(x) for x in s) < 1000  # precondition: stays under the floor
+    assert "db_growth_sane" not in failed(ev(s))
+
+
+def _calls(samp):
+    return samp["metrics"]["data"]["pipelines"][0]["metrics"][0]["value"]
+
+
+def test_low_throughput_fails_load_sustained():
+    assert "load_sustained" in failed(ev(healthy(), min_pkts=10**9))
+
+
+def test_too_few_samples_fails():
+    assert "enough_samples" in failed(ev(healthy(n=3)))
+
+
+def test_rss_skipped_when_no_proc():
+    # rss_kb=0 (macOS / no /proc) → rss_stable is skipped, not failed.
+    s = [sample(1_700_000_000 + i * 30, 0, 4_000_000 + i, 2000 + i * 500, 100_000 + i * 20_000)
+         for i in range(12)]
+    assert "rss_stable" not in failed(ev(s))
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except AssertionError as e:
+            fails += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            fails += 1
+            print(f"ERR  {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - fails}/{len(tests)} passed")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
PR4 (final) of the perf suite (PR1 #106, PR2 #110, PR3 #121). A **scheduled
endurance run** that drives heron under a steady rate-controlled pcap-file
replay for **hours** and tracks **RSS + on-disk DuckDB size** + pipeline metrics
over the whole window — the test that would have caught the 2026-06-02 prod
outage (a 102 GB DuckDB whose checkpoint hit a "broken index" FATAL → SIGSEGV).

## What
- **`longevity-soak.sh`** — reuses tara's throwaway-workdir + isolated-DuckDB
  model and the `rate_pps` load primitive (PR1); enables retention with a short
  sweep so the prune/checkpoint paths run; samples RSS + DB bytes + metrics every
  interval. On regression it files a **scrubbed, de-duplicated** GitHub issue via
  the REST API (the staging runner has no `gh` — same lesson as #115). Main knobs
  fall back to env so the systemd unit configures them via its EnvironmentFile.
- **`longevity_check.py`** — pure input→verdict (stdlib): `no_fatal_logs` (the
  "broken index"/panic/FATAL class), `no_flush_errors`, `rss_stable` (post-warmup
  leak), `load_sustained`, and `db_growth_sane` (bytes-per-stored-call must not
  balloon — the index/checkpoint bloat that ran prod to 102 GB). `db_growth_sane`
  is gated on a minimum call volume so a short run doesn't false-fail on
  fixed-overhead noise; the threshold targets the at-scale nightly and may want
  one calibration pass.
- **`longevity-soak.{service,timer}`** — nightly 02:00 oneshot, `MemoryMax=4G`,
  `TimeoutStartSec=infinity`, no NIC/caps (pcap-file). Mirrors mara's pattern.
- **`test_longevity_check.py`** — stdlib unit tests (10/10), wired into `ci.yml`
  beside the tara checker tests.

## Deliberately out of scope (documented in-code)
Real ENOSPC via tmpfs + a 102 GB checkpoint repro need a mounted fs / privileges
a soak can't assume; PR3's chaos tests cover the injected DiskFull/invalidate
*handling*.

## Verified
End-to-end 18s smoke passes (no FATAL, load sustained, db check correctly skipped
below the call floor, issue-filing skipped without a token); checker unit tests
**10/10**; `bash -n` + `yaml.safe_load` clean; leakage lint green.