### PR TITLE
ci(perf-gates): enforce load soak before prod + require staging-soaked before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,34 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # Pre-release GATE: a release may only be cut from a commit that PASSED
+  # staging-soak (the correctness + sustained-load gate). staging-soak.yml
+  # stamps a `staging-soaked` commit status on each soaked main commit; this
+  # asserts the tagged commit carries a passing one, so the multi-arch binaries
+  # are never published from un-soaked code. Enforced on `v*` tag pushes only;
+  # workflow_dispatch (artifacts-only, for verifying the build matrix) skips it.
+  gate:
+    name: Require staging-soaked
+    runs-on: ubuntu-latest
+    steps:
+      - name: assert the tagged commit passed staging-soak
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha="${{ github.sha }}"
+          state="$(gh api "repos/${{ github.repository }}/commits/$sha/status" \
+            --jq '[.statuses[] | select(.context=="staging-soaked")] | sort_by(.updated_at) | last | .state // "none"')"
+          if [ "$state" != "success" ]; then
+            echo "::error::commit $sha has no passing 'staging-soaked' status (got '$state'). A release must be cut from a commit that passed staging-soak — merge to main, let ci → deploy-staging → staging-soak run, then tag that commit."
+            exit 1
+          fi
+          echo "✓ staging-soaked=success on $sha — clear to release"
+
   console:
     name: Build console
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/staging-soak.yml
+++ b/.github/workflows/staging-soak.yml
@@ -43,6 +43,13 @@ jobs:
         env:
           HERON_STAGE_VM: ${{ vars.HERON_STAGE_VM }}
           HERON_STAGE_USER: ${{ vars.HERON_STAGE_USER }}
+          # Make the sustained-load soak a real pre-prod GATE: a load regression
+          # now fails the deploy (was informational). Safe because tara's
+          # dual-binary baseline reports a too-tight-threshold environment as
+          # `harness_broken` (non-blocking) — only a candidate that regresses
+          # against the rolling known-good blocks. Operators can set the repo
+          # Variable HERON_STAGE_LOAD_ENFORCE=0 to fall back to informational.
+          HERON_STAGE_LOAD_ENFORCE: ${{ vars.HERON_STAGE_LOAD_ENFORCE || '1' }}
         run: bash scripts/staging/soak-staging.sh
 
       # Authoritative go/no-go signal for the prod-approval gate. Only the


### PR DESCRIPTION
The perf suite (PR1–PR4) *ran* but didn't actually **gate** the two decision
points it should: cutting a release, and promoting to production. This wires
both.

## 1. Before production — load soak becomes a hard gate
`staging-soak.yml` sets `HERON_STAGE_LOAD_ENFORCE=1`, so a sustained-load-soak
regression now **fails the deploy** (was informational). The staging-soak step
already gates `deploy-prod`, so this makes the load soak a real pre-prod gate.

**Why it's safe to flip un-calibrated:** tara runs the candidate *and* the
rolling known-good through the identical load. If the absolute thresholds are
too tight for the VM, the **known-good fails too** → `harness_broken` (rc=3,
non-blocking). Only a candidate that regresses **relative to** the known-good
(rc=1) blocks. Escape hatch: set repo Variable `HERON_STAGE_LOAD_ENFORCE=0`.

## 2. Before release — require `staging-soaked`
`release.yml` gains a `gate` job that asserts the **tagged commit** carries a
passing `staging-soaked` commit status (stamped by staging-soak.yml). The
multi-arch binaries are never published from un-soaked code. `console → linux /
macos → release` all chain off `gate`. Enforced on `v*` tag pushes only;
`workflow_dispatch` (artifacts-only matrix verification) skips the assertion.

## Verified
Both workflows parse. The release-gate `gh api … /status` + jq query was run
against the last 5 `main` commits — all `staging-soaked=success` (including the
v0.5.0 commit 726f07c) — and returns `none` for an unstamped commit (→ the gate
exits 1). Leakage lint green.

> Net effect: `ci(per-PR: chaos/bench/checker) → deploy-staging → staging-soak
> (correctness + **load, enforcing**) → [approval] → deploy-prod`, and a release
> tag is refused unless its commit passed that staging-soak. PR4's nightly
> longevity soak stays the out-of-band slow-regression catcher.