### PR TITLE
docs: quality/release pipeline + v0.5.0 refresh (ClickHouse, perf gates)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,11 @@ class of past failure has a deterministic gate before it can ship.
 **Before a release** — push a `v*` tag → `release.yml`:
 - A `gate` job refuses to build/publish unless the tagged commit carries a
   passing `staging-soaked` status, so the multi-arch binaries are never cut from
-  un-soaked code. `VERSION` is the SSOT (`just bump`); the GitHub Release notes
-  come from the matching `CHANGELOG.md` section.
+  un-soaked code. Cutting a release: `just bump` (the `VERSION` file is the SSOT
+  for the binary's embedded version) → tag `v<version>` on the soaked commit →
+  `release.yml` builds the binaries and creates the Release, keyed by the tag,
+  with notes from the matching `CHANGELOG.md` section. (Tag/`VERSION` agreement
+  is by the `just bump` → tag convention, not yet enforced in the workflow.)
 
 **Out of band** — a **nightly longevity soak** (a timer on the staging VM) runs
 the load soak for hours, tracking RSS + on-disk DB size to catch slow leaks /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ heron/
 │   ├── h-metrics/               # Sliding-window aggregation → LlmMetric
 │   ├── h-storage/               # StorageBackend trait + DuckDB/PG/ClickHouse + write buffer
 │   ├── h-storage-duckdb/        # DuckDB implementation of StorageBackend
+│   ├── h-storage-clickhouse/    # ClickHouse implementation of StorageBackend
 │   ├── h-api/                   # Axum REST API
 │   ├── app/
 │   │   └── heron/               # Binary entry crate
@@ -92,3 +93,49 @@ Three entities: `agent_turns` (agent turn), `llm_calls` (per-call detail + full 
 | ClickHouse | Large-scale, high-throughput columnar analytics |
 
 See [docs/design/07-schema.md](docs/design/07-schema.md) for full schema design.
+
+## Quality & release pipeline
+
+Code reaches production — and a release — through a layered, gated chain. Each
+class of past failure has a deterministic gate before it can ship.
+
+**Per-PR (CI, before merge)** — on a dedicated CI runner pool:
+- `cargo test --workspace`, plus a `--features fault-injection` run whose
+  `concurrent_tests` drive **fault injection under sustained concurrent write
+  load** (DuckDB FATAL/invalidate + ENOSPC/`DiskFull`): a write either commits
+  or returns `Err` — never silently lost, never partial — and
+  `reopen_all_connections` recovers with no lost rows.
+- Schema-migration tests over synthesized legacy DB shapes.
+- Lint gates: referenced-secret provisioning, secret-value sanity,
+  validated-constructor scoping, and an internal-infra **leakage** gate (no
+  private IP / key material / machine path in any tracked file).
+- `cargo bench -p h-protocol --no-run` — criterion hot-path benches compiled so
+  they can't bitrot (timings are too noisy on shared runners to gate on).
+- Stdlib unit tests for the staging-soak and longevity judges.
+- An automated PR-review agent reviews the diff.
+
+**On merge to `main`** — `ci → deploy-staging → staging-soak`:
+- **staging-soak** replays a known pcap corpus through the freshly deployed
+  binary on the staging VM and asserts parse/pairing/turn/persistence
+  invariants, then runs a **rate-controlled sustained-load soak** (bounded
+  queues, stable RSS, zero drops/flush-errors). Both compare against a rolling
+  dual-binary known-good — a too-tight environment surfaces as `harness_broken`,
+  not a false candidate-reject. On pass it stamps a `staging-soaked` commit
+  status.
+
+**Before production** — `staging-soak → [manual approval] → deploy-prod`:
+- deploy-prod builds on the prod host, restarts the service, gates on a health
+  check with **automatic rollback**, and supersedes older waiting approvals so
+  the queue can't wedge. The load soak is **enforcing** here — a regression vs
+  known-good blocks the deploy.
+
+**Before a release** — push a `v*` tag → `release.yml`:
+- A `gate` job refuses to build/publish unless the tagged commit carries a
+  passing `staging-soaked` status, so the multi-arch binaries are never cut from
+  un-soaked code. `VERSION` is the SSOT (`just bump`); the GitHub Release notes
+  come from the matching `CHANGELOG.md` section.
+
+**Out of band** — a **nightly longevity soak** (a timer on the staging VM) runs
+the load soak for hours, tracking RSS + on-disk DB size to catch slow leaks /
+unbounded growth (the checkpoint-bloat class), and files a scrubbed, deduplicated
+issue on regression.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This covers OpenAI direct, Azure OpenAI, Anthropic direct, AWS Bedrock / GCP Ver
 
 ![Overview — agent activity timeseries + per-kind distribution at the top, call-rate / latency / error rate / per-model panels below](docs/images/overview.png)
 
-**Storage** in DuckDB (default, embedded, single-file) with per-table retention enabled out of the box, or **ClickHouse** for high-volume columnar analytics — select it with `storage.backend`. Pluggable backend trait; PostgreSQL is designed but not yet wired.
+**Storage** in DuckDB (default, embedded, single-file) with per-table retention enabled out of the box, or **ClickHouse** for high-volume columnar analytics — select it with `storage.backend = "clickhouse"` in the config. Pluggable backend trait; PostgreSQL is designed but not yet wired.
 
 **Console** at `http://localhost:3000`: overview · performance · usage · errors · services (table / path / model views) · agent turns · agent sessions · LLM calls (with full request/response body drill-down) · raw HTTP exchanges · pipeline-health debug views.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This covers OpenAI direct, Azure OpenAI, Anthropic direct, AWS Bedrock / GCP Ver
 
 ![Overview — agent activity timeseries + per-kind distribution at the top, call-rate / latency / error rate / per-model panels below](docs/images/overview.png)
 
-**Storage** in DuckDB (default, embedded, single-file) with per-table retention enabled out of the box. Pluggable backend trait — PostgreSQL and ClickHouse are designed but not yet wired.
+**Storage** in DuckDB (default, embedded, single-file) with per-table retention enabled out of the box, or **ClickHouse** for high-volume columnar analytics — select it with `storage.backend`. Pluggable backend trait; PostgreSQL is designed but not yet wired.
 
 **Console** at `http://localhost:3000`: overview · performance · usage · errors · services (table / path / model views) · agent turns · agent sessions · LLM calls (with full request/response body drill-down) · raw HTTP exchanges · pipeline-health debug views.
 
@@ -174,7 +174,7 @@ out of anything you push back.
 
 The current surface is the foundation layer (Ops use cases). On the way:
 
-- **Storage** — PostgreSQL and ClickHouse backends (schemas already designed)
+- **Storage** — PostgreSQL backend (ClickHouse shipped in v0.5.0; PG schema already designed)
 - **Wire APIs** — more provider-specific extensions (Bedrock variants, Vertex non-Anthropic, etc.)
 
 See [docs/mission.md](docs/mission.md) for the full ladder.

--- a/docs/promo/launch-posts.md
+++ b/docs/promo/launch-posts.md
@@ -1,6 +1,6 @@
 # Launch posts — Heron
 
-Ready-to-paste copy for the v0.4.0 launch. Tune the personal/“why I built
+Ready-to-paste copy for the v0.5.0 launch. Tune the personal/“why I built
 this” lines to your own voice before posting. **Do not** paste any internal
 host/IP/credential anywhere — keep it to the public repo + public demo only.
 
@@ -38,7 +38,8 @@ OpenAI/Azure/Anthropic/Bedrock/Vertex/Gemini and any OpenAI-compatible local
 server (vLLM, SGLang, Ollama, llama.cpp).
 
 Single statically-linked binary with the web console embedded; Linux (musl)
-+ macOS. Apache-2.0, no telemetry.
++ macOS. Apache-2.0, no telemetry. Stores to an embedded DuckDB out of the
+box, or ClickHouse when you need columnar analytics at high volume.
 
 You can try it with zero privileges by replaying a pcap:
   heron --pcap-file capture.pcap --no-retention


### PR DESCRIPTION
Brings the docs in line with this run's work (perf suite + gates + ClickHouse +
v0.5.0).

- **CLAUDE.md / AGENTS.md** — new **"Quality & release pipeline"** section. The
  repo had no doc of how code reaches prod/release; this documents the gated
  chain end to end: per-PR CI (incl. **fault-injection under sustained load** +
  leakage/secret/constructor lints + bench compile), merge → staging-soak with
  the **enforcing** rate-controlled load soak, manual-approval deploy-prod
  (health gate + rollback + supersede), `v*` tag → release **gated on
  `staging-soaked`**, and the **nightly longevity soak**. Hosts/runners are
  referred to generically per the PR-hygiene rule; also lists the new
  `h-storage-clickhouse` crate.
- **README** — ClickHouse is now a working backend (was "designed but not yet
  wired"): corrected the storage paragraph + the roadmap entry.
- **docs/promo/launch-posts.md** — the promotion copy: v0.4.0 → v0.5.0, plus the
  DuckDB-or-ClickHouse storage line in the Show HN pitch.

Docs-only; leakage lint green; pipeline section carries no internal host/IP/
runner/user identifiers.