### PR TITLE
feat(test): cliproxy mixed-format (#96) — precise OpenAI-shape + Anthropic-usage cells

### DIFF
--- a/scripts/pcaps/gen_fixture.py
+++ b/scripts/pcaps/gen_fixture.py
@@ -283,22 +283,48 @@ def scen_claude_cli_anthropic_stream():
     return [(req1, resp1), (req2, resp2)]
 
 
+# The exact #96 shape: the proxy speaks the OpenAI Chat API (response is
+# chat.completion-SHAPED — choices[].message, finish_reason) but the usage block
+# carries ANTHROPIC field names (input_tokens / output_tokens /
+# cache_read_input_tokens) because it forwarded the upstream Anthropic usage
+# without remapping. Heron detects openai-chat from the request; the chat
+# extractor must fall back to the Anthropic usage names.
+CLIPROXY_USAGE = {"input_tokens": 309, "output_tokens": 37, "cache_read_input_tokens": 256}
+
+
+def _oai_chat_nonstream_body(text, finish_reason, usage):
+    return json.dumps({
+        "id": "chatcmpl-proxy", "object": "chat.completion", "model": OAI_MODEL,
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text},
+                     "finish_reason": finish_reason}],
+        "usage": usage,
+    }, separators=(",", ":")).encode()
+
+
 def scen_cliproxy_mixed_format():
-    """cliproxy mixed-format (#96): OpenAI-Chat REQUEST, Anthropic-shaped
-    RESPONSE. Heron detects openai-chat from the request; usage extraction must
-    fall back to Anthropic field names (input_tokens/output_tokens)."""
-    hdr = {
-        "User-Agent": "openai-python/1.40.0",
-        "authorization": f"Bearer {FAKE_OAI_KEY}",
-        "content-type": "application/json",
-    }
+    """cliproxy mixed-format (#96), NON-streaming: OpenAI-Chat request + an
+    OpenAI chat.completion-SHAPED response whose `usage` uses ANTHROPIC field
+    names. Detected openai-chat; usage falls back to input_tokens / output_tokens
+    / cache_read_input_tokens."""
+    hdr = {"User-Agent": "openai-python/1.40.0",
+           "authorization": f"Bearer {FAKE_OAI_KEY}", "content-type": "application/json"}
     req = http_request("POST", "/v1/chat/completions", hdr, json.dumps({
-        "model": "gpt-4o", "stream": False,
+        "model": OAI_MODEL, "stream": False,
         "messages": [{"role": "user", "content": "hello"}]}, separators=(",", ":")).encode())
-    # Response is Anthropic Messages shape (proxy returned upstream shape):
-    resp = http_response_json(anthropic_nonstream(
-        text="hi there", stop_reason="end_turn",
-        usage={"input_tokens": 309, "output_tokens": 37}))
+    resp = http_response_json(_oai_chat_nonstream_body("hi there", "stop", CLIPROXY_USAGE))
+    return [(req, resp)]
+
+
+def scen_cliproxy_mixed_stream():
+    """cliproxy mixed-format (#96), STREAMING: OpenAI-Chat request + OpenAI SSE
+    chunks whose final usage chunk uses ANTHROPIC field names. Exercises the
+    SSE-path usage fallback (a separate code path from the non-stream one)."""
+    hdr = {"User-Agent": "openai-python/1.40.0",
+           "authorization": f"Bearer {FAKE_OAI_KEY}", "content-type": "application/json"}
+    req = http_request("POST", "/v1/chat/completions", hdr, json.dumps({
+        "model": OAI_MODEL, "stream": True, "stream_options": {"include_usage": True},
+        "messages": [{"role": "user", "content": "hello"}]}, separators=(",", ":")).encode())
+    resp = http_response_sse(oai_chat_stream("hi there", [], "stop", CLIPROXY_USAGE))
     return [(req, resp)]
 
 
@@ -529,6 +555,7 @@ SCENARIOS = {
     "hermes-anthropic": scen_hermes_anthropic,
     "generic-anthropic": scen_generic_anthropic,
     "cliproxy-mixed-format": scen_cliproxy_mixed_format,
+    "cliproxy-mixed-format-stream": scen_cliproxy_mixed_stream,
     # openai column (below)
     "opencode-openai-chat": lambda: scen_openai_chat("opencode"),
     "openclaw-openai-chat": lambda: scen_openai_chat("openclaw"),

--- a/testdata/pcaps/corpus.toml
+++ b/testdata/pcaps/corpus.toml
@@ -290,8 +290,21 @@ status = "active"
 agent_kind = "generic"
 wire_apis = ["openai-chat"]
 backend_label = "cliproxy"
-scenarios = ["mixed-format", "usage-fallback", "synthesized"]
-notes = "HIGH VALUE (#96), synthesized by gen_fixture.py: OpenAI-Chat request → Anthropic-shaped response. Exercises openai-chat detection + chat.rs usage fallback to input_tokens/output_tokens."
+scenarios = ["mixed-format", "usage-fallback", "non-streaming", "synthesized"]
+notes = "HIGH VALUE (#96), synthesized: proxy speaks the OpenAI Chat API (chat.completion-shaped response, finish_reason=stop) but the usage block uses ANTHROPIC field names. openai-chat detection + non-stream usage fallback to input_tokens/output_tokens/cache_read_input_tokens."
+[fixture.expect.quirks]
+mixed_format = true
+usage_field_style = "anthropic"
+
+[[fixture]]
+id = "cliproxy-mixed-format-stream"
+file = "cliproxy-mixed-format-stream.pcap"
+status = "active"
+agent_kind = "generic"
+wire_apis = ["openai-chat"]
+backend_label = "cliproxy"
+scenarios = ["mixed-format", "usage-fallback", "streaming", "synthesized"]
+notes = "HIGH VALUE (#96), synthesized: STREAMING variant — OpenAI SSE chunks whose final usage chunk uses ANTHROPIC field names. Exercises the SSE-path usage fallback (separate from the non-stream path)."
 [fixture.expect.quirks]
 mixed_format = true
 usage_field_style = "anthropic"

--- a/testdata/pcaps/corpus/cliproxy-mixed-format-stream.pcap
+++ b/testdata/pcaps/corpus/cliproxy-mixed-format-stream.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1001339bdc886eab58bd740eab4b5a0e20e0a6716b34114ae1544768b6e9766c
+size 1818

--- a/testdata/pcaps/corpus/cliproxy-mixed-format.pcap
+++ b/testdata/pcaps/corpus/cliproxy-mixed-format.pcap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:570e677f4e29e0a19ebb87778d82dcc11f15fd5e36d60dce88c663e65994afce
-size 1102
+oid sha256:4ee42640119197d3e1fe1e5894fe41fc167294c6d05160ef2426c747fccc218c
+size 1128

--- a/testdata/pcaps/golden/cliproxy-mixed-format-stream.json
+++ b/testdata/pcaps/golden/cliproxy-mixed-format-stream.json
@@ -8,7 +8,7 @@
       "finish_reason": "stop",
       "input_tokens": 309,
       "is_agent_request": false,
-      "is_stream": false,
+      "is_stream": true,
       "model": "gpt-4o-2024-08-06",
       "output_tokens": 37,
       "response_id_present": true,


### PR DESCRIPTION
## What

Tightens the cliproxy mixed-format corpus cell to the **precise #96 shape** and adds a streaming variant.

The original cell returned a fully Anthropic-shaped response. The real #96 — *a proxy that speaks the OpenAI Chat API but forwards the upstream Anthropic `usage` block verbatim* — is an **OpenAI `chat.completion`-shaped response** (`choices[].message`, `finish_reason`) whose **`usage` block uses Anthropic field names**. That's exactly what `chat.rs` added a fallback for in #107.

## Cells (both verified through the real pipeline → golden)

| cell | shape | extracted |
|---|---|---|
| `cliproxy-mixed-format` (non-stream) | OpenAI chat.completion response, `finish_reason=stop`, usage in Anthropic names | openai-chat · in **309** / out **37** / cache_read **256** |
| `cliproxy-mixed-format-stream` | OpenAI SSE, final usage chunk in Anthropic names | openai-chat · stream · same fallback on the **SSE path** |

This guards the `chat.rs` usage fallback (`input_tokens` / `output_tokens` / `cache_read_input_tokens`) on **both** the non-stream and SSE extract paths — the regression class behind issue #96 (proxy serving the OpenAI API while providing Anthropic-structured usage).

Local: `cargo test -p h-turn --test corpus_golden` ✓ (ran=14), corpus lint ✓, leakage ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)