### PR TITLE
dogfood: delegate leakage guard + bump triage/implement to agent-ops@v0.2.0

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,0 +1,38 @@
+name: guard
+
+# Hygiene gate — DELEGATES the generic, LLM-free leakage check to the shared
+# agent-ops mechanism (Netis/agent-ops). agent-ops's check-leakage.sh was
+# extracted FROM this repo; the reusable workflow runs it on GitHub-hosted
+# ubuntu against THIS repo's tracked files + THIS repo's
+# scripts/lint/leakage-allowlist.txt, so the gate is single-sourced and any
+# future hardening in agent-ops applies here automatically.
+#
+# Scope note (intentional): only the LEAKAGE gate is delegated.
+#   - secret-EXISTENCE / secret-VALUE checks stay in ci.yml — they validate
+#     THIS repo's specific secrets (AGENT_GH_TOKEN / LITELLM_*) with the values
+#     passed in as env, which is inherently consumer-specific. (agent-ops
+#     guard.yml's run_secret_checks also mis-invokes check-secret-values.sh —
+#     tracked as an agent-ops follow-up — so we pass run_secret_checks: false.)
+#   - heron-specific lints (pcap-corpus, validated-constructors,
+#     test-check-leakage self-test) stay in ci.yml — not part of the framework.
+#
+# During the migration this runs in PARALLEL with ci.yml's leakage step; that
+# redundant ci.yml step is removed in the final cleanup. The in-tree
+# scripts/lint/check-leakage.sh is retained (heron's test-check-leakage.sh
+# self-test + the pcap-corpus gate still reference it).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    uses: Netis/agent-ops/.github/workflows/guard.yml@v0.2.0
+    with:
+      agent_ops_ref: v0.2.0
+      run_secret_checks: false
+    secrets: inherit

--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -37,8 +37,8 @@ permissions:
 jobs:
   implement:
     if: ${{ github.event.label.name == 'agent:try' }}
-    uses: Netis/agent-ops/.github/workflows/implement.yml@v0.1.0
+    uses: Netis/agent-ops/.github/workflows/implement.yml@v0.2.0
     with:
-      agent_ops_ref: v0.1.0
+      agent_ops_ref: v0.2.0
       runner_labels: '["self-hosted","heron"]'
     secrets: inherit          # LITELLM_BASE_URL / API_KEY / NO_PROXY + AGENT_GH_TOKEN + AUTO_MERGE_TEAM

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   triage:
-    uses: Netis/agent-ops/.github/workflows/triage.yml@v0.1.0
+    uses: Netis/agent-ops/.github/workflows/triage.yml@v0.2.0
     with:
-      agent_ops_ref: v0.1.0
+      agent_ops_ref: v0.2.0
       runner_labels: '["self-hosted","heron"]'
     secrets: inherit          # LITELLM_BASE_URL / API_KEY / NO_PROXY + AGENT_GH_TOKEN


### PR DESCRIPTION
## What
Finishes heron's adoption of **agent-ops v0.2.0**:

1. **New `guard.yml`** — delegates the generic LLM-free **leakage gate** to `agent-ops guard.yml@v0.2.0` (runs agent-ops's `check-leakage.sh` — extracted from this repo — against this repo's tracked files + `leakage-allowlist.txt`, on GitHub-hosted ubuntu). Single-sources the leakage check.
   - **Scope (intentional):** only leakage is delegated. `run_secret_checks: false` — secret existence/value checks stay in `ci.yml` (they validate THIS repo's specific secrets with values in env; also agent-ops guard.yml's value-check is mis-invoked — an agent-ops follow-up). heron-specific lints (pcap-corpus, validated-constructors, the leakage self-test) stay in `ci.yml`.
2. **Bump** `issue-triage.yml` + `issue-implement.yml` pins `v0.1.0 → v0.2.0` so all delegated surfaces track one release.

## Proof
This PR's own **CI → pr-review is the first run of the now-delegated `review.yml@v0.2.0`** (merged in #131) — so merging it *is* the proof that the review migration fires + reviews correctly.

The redundant `ci.yml` leakage step + the in-tree fallback scripts are removed in the final cleanup PR once every surface is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)