### PR TITLE
feat(export): SFT trajectory export from agent turns/sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This covers OpenAI direct, Azure OpenAI, Anthropic direct, AWS Bedrock / GCP Ver
 
 **Per-call drill-down when you need it** — every LLM call is also captured with structured request/response *and* the raw body. Stalled tool calls, malformed prompts, unexpected token counts: the evidence is on the page, not behind a re-run.
 
+**Export turns as training data.** Any reconstructed turn — or a whole session — exports as an **SFT trajectory**: OpenAI-style `messages` JSONL with tool calls, tool results, and assistant reasoning preserved, and tool-call arguments rehydrated to objects. Download a single turn or session straight from its detail view, or batch-export from the Agent Turns list — the current filter (time window · agent kind · model · wire API) becomes a one-line-per-turn JSONL, so a slice of real captured agent traffic turns into a fine-tuning set with one click. Anthropic and OpenAI-chat wire formats today; unsupported formats are reported and skipped rather than failing the batch.
+
 **Metrics** are framed first at the **agent layer** — turn count and duration distribution per agent kind, call count per turn, tool-call success rate — and then at the **call layer**: TTFT · E2E latency · TPOT · token throughput · call rate · active calls · call error rate · prompt-cache hit ratio. The Overview page is built around both. See [glossary](docs/glossary.md) for what each means and why.
 
 ![Overview — agent activity timeseries + per-kind distribution at the top, call-rate / latency / error rate / per-model panels below](docs/images/overview.png)
@@ -105,6 +107,7 @@ This covers OpenAI direct, Azure OpenAI, Anthropic direct, AWS Bedrock / GCP Ver
 - **AI platform / inference ops** — see the real service-to-service topology your traffic flows through (clients → litellm → vLLM / SGLang), measure each hop independently, and catch silent model substitutions
 - **FinOps & engineering managers** — attribute spend across teams/repos/projects from real turns, not periodic SDK exports that can drift
 - **Compliance & security** — capture-once evidence chain of what crossed the wire, scoped per agent kind and per session
+- **Model trainers / fine-tuners** — turn real captured agent runs into SFT datasets, per turn or whole session, without hand-labeling or re-running the agent
 
 ## Quickstart
 

--- a/console/src/components/trajectory-actions.tsx
+++ b/console/src/components/trajectory-actions.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react"
+import { Download, Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { downloadFile, type DownloadResult } from "@/lib/api"
+
+/** Icon-only "download this trajectory" button (turn / session detail views). */
+export function DownloadTrajectoryButton({
+  url,
+  fallbackName,
+  title = "Download as an SFT trajectory (.jsonl)",
+  className,
+}: {
+  url: string
+  fallbackName: string
+  title?: string
+  className?: string
+}) {
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={async (e) => {
+        e.stopPropagation()
+        e.preventDefault()
+        setBusy(true)
+        setErr(null)
+        try {
+          await downloadFile(url, fallbackName)
+        } catch (e2) {
+          setErr(e2 instanceof Error ? e2.message : String(e2))
+        } finally {
+          setBusy(false)
+        }
+      }}
+      title={err ?? title}
+      aria-label={title}
+      className={cn(
+        "rounded p-1 transition-colors hover:bg-muted hover:text-foreground",
+        err ? "text-destructive" : "text-muted-foreground",
+        className,
+      )}
+    >
+      {busy ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
+    </button>
+  )
+}
+
+/** Labeled batch-export button with inline written/skipped feedback
+ * (Agent Turns list — exports every turn matching the current filters). */
+export function BatchExportButton({
+  url,
+  fallbackName = "trajectories.jsonl",
+  label = "Export trajectories",
+  className,
+}: {
+  url: string
+  fallbackName?: string
+  label?: string
+  className?: string
+}) {
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<DownloadResult | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true)
+          setErr(null)
+          setResult(null)
+          try {
+            setResult(await downloadFile(url, fallbackName))
+          } catch (e) {
+            setErr(e instanceof Error ? e.message : String(e))
+          } finally {
+            setBusy(false)
+          }
+        }}
+        title="Export every turn matching the current filters as SFT trajectories (.jsonl)"
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50",
+          className,
+        )}
+      >
+        {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
+        {label}
+      </button>
+      {result && (
+        <span className="text-xs text-muted-foreground">
+          {result.written}/{result.total}
+          {result.skipped > 0 && <span className="text-amber-500"> · {result.skipped} skipped</span>}
+        </span>
+      )}
+      {err && <span className="text-xs text-destructive">{err}</span>}
+    </div>
+  )
+}

--- a/console/src/components/turn-detail/top-bar.tsx
+++ b/console/src/components/turn-detail/top-bar.tsx
@@ -3,6 +3,8 @@ import { Info, X } from "lucide-react"
 import { MetadataPopover } from "./metadata-popover"
 import type { AgentTurnDetail } from "@/types/api"
 import { ExtractPacketsButton } from "@/features/pcap-extract/ExtractPacketsButton"
+import { DownloadTrajectoryButton } from "@/components/trajectory-actions"
+import { turnTrajectoryUrl } from "@/lib/trajectory-export"
 
 interface Props {
   turn: AgentTurnDetail
@@ -22,6 +24,11 @@ export function TopBar({ turn, onClose }: Props) {
         <span>{turn.agent_kind}</span>
         <span>·</span>
         <span className="font-mono" title={turn.turn_id}>{truncateMid(turn.turn_id)}</span>
+        <DownloadTrajectoryButton
+          url={turnTrajectoryUrl(turn.turn_id)}
+          fallbackName={`trajectory-${turn.turn_id}.jsonl`}
+          title="Download this turn as an SFT trajectory (.jsonl)"
+        />
         <ExtractPacketsButton anchor={{ type: "agent_turn", row: turn }} />
         <button
           onClick={() => setMetaOpen((o) => !o)}

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -37,3 +37,48 @@ export async function apiFetch<T>(
   }
   return json.data
 }
+
+export interface DownloadResult {
+  /** Items skipped during a batch export (unsupported wire / unavailable body). */
+  skipped: number
+  total: number
+  written: number
+}
+
+/**
+ * Download a raw (non-`ApiResponse`) endpoint as a file via a blob + anchor
+ * click — used for the trajectory export endpoints, which serve NDJSON with a
+ * `Content-Disposition` attachment rather than the JSON envelope. Returns the
+ * `X-Export-*` counters when present (batch export) so callers can surface how
+ * many turns were skipped.
+ */
+export async function downloadFile(path: string, fallbackName: string): Promise<DownloadResult> {
+  const res = await fetch(path)
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ code: res.status, message: res.statusText }))
+    throw new ApiError(body.code ?? res.status, body.message ?? res.statusText)
+  }
+
+  const num = (h: string) => Number(res.headers.get(h) ?? "0") || 0
+  const result: DownloadResult = {
+    skipped: num("x-export-skipped"),
+    total: num("x-export-total"),
+    written: num("x-export-written"),
+  }
+
+  const disposition = res.headers.get("content-disposition") ?? ""
+  const match = disposition.match(/filename="?([^"]+)"?/)
+  const filename = match?.[1] ?? fallbackName
+
+  const blob = await res.blob()
+  const objectUrl = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = objectUrl
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(objectUrl)
+
+  return result
+}

--- a/console/src/lib/trajectory-export.ts
+++ b/console/src/lib/trajectory-export.ts
@@ -1,0 +1,48 @@
+/** URL builders for the trajectory-export endpoints. */
+
+export interface BatchExportFilters {
+  /** Seconds since epoch (toolbar window). */
+  start: number
+  end: number
+  wire_api?: string
+  model?: string
+  server_ip?: string
+  status?: string
+  agent_kind?: string
+  client_ip?: string
+  server_port?: string
+  include_proxy_hops?: boolean
+}
+
+/** Single turn → one trajectory. */
+export function turnTrajectoryUrl(turnId: string): string {
+  const p = new URLSearchParams({ scope: "turn", turn_id: turnId })
+  return `/api/export/trajectory?${p.toString()}`
+}
+
+/** Single session → one (multi-turn) trajectory. */
+export function sessionTrajectoryUrl(sourceId: string, sessionId: string): string {
+  const p = new URLSearchParams({ scope: "session", source_id: sourceId, session_id: sessionId })
+  return `/api/export/trajectory?${p.toString()}`
+}
+
+/** Batch → one trajectory per turn matching the agent-turns filters. */
+export function batchTrajectoriesUrl(f: BatchExportFilters): string {
+  const p = new URLSearchParams()
+  p.set("start", String(f.start))
+  p.set("end", String(f.end))
+  const optional: Record<string, string | undefined> = {
+    wire_api: f.wire_api,
+    model: f.model,
+    server_ip: f.server_ip,
+    status: f.status,
+    agent_kind: f.agent_kind,
+    client_ip: f.client_ip,
+    server_port: f.server_port,
+  }
+  for (const [k, v] of Object.entries(optional)) {
+    if (v) p.set(k, v)
+  }
+  if (f.include_proxy_hops) p.set("include_proxy_hops", "true")
+  return `/api/export/trajectories?${p.toString()}`
+}

--- a/console/src/pages/agent-session-detail.tsx
+++ b/console/src/pages/agent-session-detail.tsx
@@ -4,6 +4,8 @@ import { ArrowLeft, Loader2 } from "lucide-react"
 import { useAgentSessionDetail, useSessionTurns } from "@/hooks/use-agent-sessions"
 import { SessionHeader, TurnBlock } from "@/components/session-detail"
 import { AgentTurnDetailPanel } from "@/pages/agent-turn-detail-panel"
+import { DownloadTrajectoryButton } from "@/components/trajectory-actions"
+import { sessionTrajectoryUrl } from "@/lib/trajectory-export"
 
 export function AgentSessionDetailPage() {
   const { source_id = "", session_id = "" } = useParams()
@@ -46,12 +48,19 @@ export function AgentSessionDetailPage() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border px-4 py-3">
-        <Link
-          to="/agent-sessions"
-          className="mb-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-        >
-          <ArrowLeft className="size-3" /> Agent Sessions
-        </Link>
+        <div className="mb-2 flex items-center justify-between">
+          <Link
+            to="/agent-sessions"
+            className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+          >
+            <ArrowLeft className="size-3" /> Agent Sessions
+          </Link>
+          <DownloadTrajectoryButton
+            url={sessionTrajectoryUrl(source_id, session_id)}
+            fallbackName={`trajectory-${session_id}.jsonl`}
+            title="Download this session as one multi-turn SFT trajectory (.jsonl)"
+          />
+        </div>
         <SessionHeader detail={detail} />
       </div>
 

--- a/console/src/pages/agent-turns.tsx
+++ b/console/src/pages/agent-turns.tsx
@@ -10,6 +10,10 @@ import { FilterDropdown } from "@/components/ui/filter-dropdown"
 import { ProxyBadge } from "@/components/ui/proxy-badge"
 import { AgentTurnDetailPanel } from "./agent-turn-detail-panel"
 import { ToolSurfacePill, TopologyPill, SuspiciousMarker } from "@/components/agent-pills"
+import { BatchExportButton } from "@/components/trajectory-actions"
+import { batchTrajectoriesUrl } from "@/lib/trajectory-export"
+import { useToolbarStore } from "@/stores/toolbar"
+import { useSupportedFilterParams } from "@/hooks/use-supported-filters"
 import type { AgentTurnListItem, ToolSurface, AgentTopology } from "@/types/api"
 
 const STATUS_OPTIONS = ["in_progress", "complete", "incomplete"]
@@ -136,6 +140,24 @@ export function AgentTurnsPage() {
   const topologyFilter = topologyStr ? (topologyStr.split(",") as AgentTopology[]) : []
   const surfaceFilter = surfaceStr ? (surfaceStr.split(",") as ToolSurface[]) : []
   const { data: agentKindsData } = useAgentKinds()
+
+  // Inputs for the batch trajectory export — mirror exactly what the list
+  // query sends to the server (toolbar window + supported filters + the
+  // page's server-side filters). The client-only topology/surface/suspicious
+  // narrowing is not part of the export set.
+  const start = useToolbarStore((s) => s.start)
+  const end = useToolbarStore((s) => s.end)
+  const { params: fp } = useSupportedFilterParams()
+  const exportUrl = batchTrajectoriesUrl({
+    start,
+    end,
+    ...fp,
+    status: statusStr || undefined,
+    agent_kind: agentKindStr || undefined,
+    client_ip: clientIpStr || undefined,
+    server_port: serverPortStr || undefined,
+    include_proxy_hops: includeProxyHops,
+  })
 
   const [selectedId, setSelectedId] = useSearchParamState("selected", "")
   // Anchor (unix seconds) shared alongside `?selected` so a recipient who
@@ -290,6 +312,9 @@ export function AgentTurnsPage() {
           />
           Show proxy hops
         </label>
+        <div className="ml-auto">
+          <BatchExportButton url={exportUrl} fallbackName="trajectories.jsonl" />
+        </div>
       </div>
 
       {/* Table */}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "chrono",
  "h-capture",
  "h-common",
+ "h-export",
  "h-llm",
  "h-metrics",
  "h-pcap-extract",
@@ -1326,6 +1327,16 @@ dependencies = [
  "tokio",
  "toml_edit 0.22.27",
  "tracing",
+]
+
+[[package]]
+name = "h-export"
+version = "0.5.0"
+dependencies = [
+ "h-llm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -63,6 +63,7 @@ h-common = { path = "h-common" }
 h-capture = { path = "h-capture" }
 h-protocol = { path = "h-protocol" }
 h-llm = { path = "h-llm" }
+h-export = { path = "h-export" }
 h-turn = { path = "h-turn" }
 h-metrics = { path = "h-metrics" }
 h-storage = { path = "h-storage" }

--- a/server/h-api/Cargo.toml
+++ b/server/h-api/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 h-capture.workspace = true
 h-common.workspace = true
 h-llm.workspace = true
+h-export.workspace = true
 h-storage.workspace = true
 h-turn.workspace = true
 h-pcap-extract = { workspace = true }

--- a/server/h-api/src/lib.rs
+++ b/server/h-api/src/lib.rs
@@ -209,6 +209,10 @@ pub fn router(
             "/api/agent-sessions/{source_id}/{session_id}/turns",
             get(routes::agent_sessions::turns),
         )
+        // Trajectory export — reconstruct a turn/session (single) or every turn
+        // matching the agent-turns filters (batch) into OpenAI-style SFT JSONL.
+        .route("/api/export/trajectory", get(routes::export::single))
+        .route("/api/export/trajectories", get(routes::export::batch))
         .with_state(storage)
         .merge(internal_metrics_routes)
         .merge(runtime_config_routes)

--- a/server/h-api/src/routes/export.rs
+++ b/server/h-api/src/routes/export.rs
@@ -1,0 +1,350 @@
+//! `/api/export/trajectory{,ies}` — reconstruct captured agent turns/sessions
+//! into OpenAI-style SFT JSONL for fine-tuning.
+//!
+//! * `GET /api/export/trajectory` — one turn (`scope=turn&turn_id=…`) or one session
+//!   (`scope=session&source_id=…&session_id=…`, the whole multi-turn conversation as a single
+//!   trajectory).
+//! * `GET /api/export/trajectories` — **batch**: every turn matching the same filters as
+//!   `/api/agent-turns` (time range + wire_api/model/status/…), one trajectory line per turn. This
+//!   is how a training set is built from a slice of captured traffic.
+//!
+//! Reconstruction uses the turn's terminal call, whose bodies already carry the
+//! full cumulative history (`h_export::reconstruct_trajectory`). Responses are
+//! raw NDJSON with a `Content-Disposition` attachment (NOT the `ApiResponse`
+//! envelope). The batch endpoint pre-resolves every turn so it can report
+//! `X-Export-Skipped` in a header, and skips (rather than fails) turns whose
+//! wire format is unsupported or whose body is unavailable.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Response, StatusCode};
+use h_storage::query::{TurnDetail, TurnsQuery};
+use h_storage::StorageBackend;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::extractors::Query;
+use crate::params::{parse_csv, to_dimension_filter, to_time_range};
+use crate::response::ApiError;
+
+/// Hard cap on a single batch export, to bound the N+1 terminal-call lookups.
+const MAX_BATCH_TURNS: u32 = 2000;
+
+#[derive(Debug, Deserialize)]
+pub struct ExportTrajectoryParams {
+    /// `"turn"` | `"session"`.
+    pub scope: String,
+    /// Required when `scope == "turn"`.
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    /// Required when `scope == "session"`.
+    #[serde(default)]
+    pub source_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// Mirrors `agent_turns::TurnsParams` (the list filters) so a batch export
+/// covers exactly the turns the user is looking at.
+#[derive(Debug, Deserialize)]
+pub struct ExportBatchParams {
+    pub start: i64,
+    pub end: i64,
+    #[serde(default)]
+    pub wire_api: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub server_ip: Option<String>,
+    #[serde(default)]
+    pub client_ip: Option<String>,
+    #[serde(default)]
+    pub server_port: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub agent_kind: Option<String>,
+    #[serde(default)]
+    pub include_proxy_hops: bool,
+    /// Max turns to export (default 1000, capped at `MAX_BATCH_TURNS`).
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// Export a single turn or session as one JSONL line.
+pub async fn single(
+    State(storage): State<Arc<dyn StorageBackend>>,
+    Query(p): Query<ExportTrajectoryParams>,
+) -> Result<Response<Body>, ApiError> {
+    let (detail, scope_label, filename) = match p.scope.as_str() {
+        "turn" => {
+            let turn_id = p
+                .turn_id
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| ApiError::InvalidParam("turn scope requires turn_id".into()))?;
+            let detail = storage
+                .query_turn_by_id(turn_id)
+                .await?
+                .ok_or_else(|| ApiError::NotFound(format!("turn not found: {turn_id}")))?;
+            (detail, "turn", format!("trajectory-{turn_id}.jsonl"))
+        }
+        "session" => {
+            let source_id = p.source_id.as_deref().unwrap_or_default();
+            let session_id = p
+                .session_id
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    ApiError::InvalidParam("session scope requires session_id".into())
+                })?;
+            let detail = resolve_session_last_turn(&storage, source_id, session_id)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::NotFound(format!("session has no turns: {source_id}/{session_id}"))
+                })?;
+            (detail, "session", format!("trajectory-{session_id}.jsonl"))
+        }
+        other => return Err(ApiError::InvalidParam(format!("invalid scope: {other}"))),
+    };
+
+    match line_from_turn_detail(&storage, &detail, scope_label).await? {
+        Ok(line) => ndjson_response(line, &filename, None),
+        Err(reason) => Err(ApiError::InvalidParam(reason)),
+    }
+}
+
+/// Batch-export every turn matching the agent-turns filters, one line per turn.
+pub async fn batch(
+    State(storage): State<Arc<dyn StorageBackend>>,
+    Query(p): Query<ExportBatchParams>,
+) -> Result<Response<Body>, ApiError> {
+    let server_ports = parse_csv(&p.server_port)
+        .iter()
+        .map(|s| {
+            s.parse::<u16>()
+                .map_err(|_| ApiError::InvalidParam(format!("invalid server_port: {s}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let page_size = p.limit.unwrap_or(1000).clamp(1, MAX_BATCH_TURNS);
+    let query = TurnsQuery {
+        time_range: to_time_range(p.start, p.end)?,
+        filter: to_dimension_filter(&p.wire_api, &p.model, &p.server_ip, &None),
+        client_ips: parse_csv(&p.client_ip),
+        server_ports,
+        statuses: parse_csv(&p.status),
+        agent_kinds: parse_csv(&p.agent_kind),
+        sort_by: "start_time".to_string(),
+        sort_order: "desc".to_string(),
+        page: 1,
+        page_size,
+        include_proxy_hops: p.include_proxy_hops,
+    };
+
+    let page = storage.query_turns(&query).await?;
+    let total = page.items.len();
+    let mut lines: Vec<String> = Vec::new();
+    for item in &page.items {
+        // TurnListItem lacks final_call_id; resolve the full detail per turn.
+        let Some(detail) = storage.query_turn_by_id(&item.turn_id).await? else {
+            continue;
+        };
+        match line_from_turn_detail(&storage, &detail, "turn").await {
+            Ok(Ok(line)) => lines.push(line),
+            // skip unsupported wire / unavailable body — don't fail the batch
+            Ok(Err(_reason)) => {}
+            Err(_api) => {}
+        }
+    }
+    let written = lines.len();
+    let skipped = total - written;
+    ndjson_response(
+        lines.join(""),
+        "trajectories.jsonl",
+        Some((total, written, skipped)),
+    )
+}
+
+/// The session's most-recent turn — its terminal call's request body holds the
+/// whole multi-turn session history.
+async fn resolve_session_last_turn(
+    storage: &Arc<dyn StorageBackend>,
+    source_id: &str,
+    session_id: &str,
+) -> Result<Option<TurnDetail>, ApiError> {
+    let page = storage
+        .query_session_turns(&h_storage::query::SessionTurnsQuery {
+            source_id: source_id.to_string(),
+            session_id: session_id.to_string(),
+            cursor: None,
+            page_size: 1,
+        })
+        .await?;
+    let Some(last) = page.items.first() else {
+        return Ok(None);
+    };
+    Ok(storage.query_turn_by_id(&last.turn_id).await?)
+}
+
+/// Reconstruct one trajectory line from a resolved `TurnDetail`.
+///
+/// Outer `Result` = a genuine storage/internal failure (500 on the single path;
+/// counted as skipped on the batch path). Inner `Result` = `Ok(line)` or
+/// `Err(reason)` for export-level issues (no terminal call, unsupported wire,
+/// truncated/missing body) the caller turns into a 400 (single) or a skip (batch).
+async fn line_from_turn_detail(
+    storage: &Arc<dyn StorageBackend>,
+    detail: &TurnDetail,
+    scope_label: &str,
+) -> Result<Result<String, String>, ApiError> {
+    let Some(final_call_id) = detail.final_call_id.clone() else {
+        return Ok(Err("turn has no terminal call".to_string()));
+    };
+    let calls = storage
+        .query_calls_by_ids(&[final_call_id.clone()], true)
+        .await?;
+    let Some(call) = calls.into_iter().next() else {
+        return Ok(Err("terminal call body unavailable".to_string()));
+    };
+
+    // A truncated body manifests as a JSON parse failure.
+    let req: Value = match call.request_body.as_deref().map(serde_json::from_str) {
+        Some(Ok(v)) => v,
+        Some(Err(_)) => return Ok(Err("malformed/truncated request body".to_string())),
+        None => return Ok(Err("missing request body".to_string())),
+    };
+    let resp: Value = match call.response_body.as_deref().map(serde_json::from_str) {
+        Some(Ok(v)) => v,
+        Some(Err(_)) => return Ok(Err("malformed/truncated response body".to_string())),
+        None => return Ok(Err("missing response body".to_string())),
+    };
+
+    let traj = match h_export::reconstruct_trajectory(&detail.wire_api, &req, &resp) {
+        Ok(t) => t,
+        Err(e) => return Ok(Err(e.to_string())),
+    };
+
+    let meta = json!({
+        "source": "heron",
+        "scope": scope_label,
+        "source_id": detail.source_id,
+        "session_id": detail.session_id,
+        "turn_id": detail.turn_id,
+        "terminal_call_id": final_call_id,
+        "wire_api": detail.wire_api,
+        "agent_kind": detail.agent_kind,
+        "model": detail.models_used.first().cloned(),
+        "final_finish_reason": detail.final_finish_reason,
+        "total_input_tokens": detail.total_input_tokens,
+        "total_output_tokens": detail.total_output_tokens,
+        "captured_at_ms": detail.end_time,
+    });
+
+    let line = serde_json::to_string(&traj.with_meta(meta))
+        .map_err(|e| ApiError::Internal(format!("serialize trajectory: {e}")))?;
+    Ok(Ok(format!("{line}\n")))
+}
+
+/// Build a raw NDJSON attachment response. `counts = (total, written, skipped)`
+/// adds the `X-Export-*` headers (batch only).
+fn ndjson_response(
+    body: String,
+    filename: &str,
+    counts: Option<(usize, usize, usize)>,
+) -> Result<Response<Body>, ApiError> {
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/x-ndjson")
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{filename}\""),
+        );
+    if let Some((total, written, skipped)) = counts {
+        builder = builder
+            .header("x-export-total", total.to_string())
+            .header("x-export-written", written.to_string())
+            .header("x-export-skipped", skipped.to_string());
+    }
+    builder
+        .body(Body::from(body))
+        .map_err(|e| ApiError::Internal(format!("build response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use h_storage::StorageBackend;
+    use h_storage_duckdb::DuckDbBackend;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::routes;
+
+    async fn app() -> Router {
+        let backend = DuckDbBackend::open(":memory:").unwrap();
+        backend.init().await.unwrap();
+        let storage: Arc<dyn StorageBackend> = Arc::new(backend);
+        Router::new()
+            .route("/api/export/trajectory", get(routes::export::single))
+            .route("/api/export/trajectories", get(routes::export::batch))
+            .with_state(storage)
+    }
+
+    #[tokio::test]
+    async fn single_turn_missing_returns_404() {
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/export/trajectory?scope=turn&turn_id=ghost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn single_turn_without_id_is_400() {
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/export/trajectory?scope=turn")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn batch_over_empty_db_is_empty_ok() {
+        let resp = app()
+            .await
+            .oneshot(
+                Request::builder()
+                    .uri("/api/export/trajectories?start=0&end=4000000000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get("x-export-total").unwrap(), "0");
+        assert_eq!(resp.headers().get("x-export-written").unwrap(), "0");
+        assert_eq!(resp.headers().get("x-export-skipped").unwrap(), "0");
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(bytes.is_empty());
+    }
+}

--- a/server/h-api/src/routes/mod.rs
+++ b/server/h-api/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_sessions;
 pub mod agent_turns;
 pub mod capture_interfaces;
 pub mod capture_sources;
+pub mod export;
 pub mod filters;
 pub mod health;
 pub mod http_exchanges;

--- a/server/h-export/Cargo.toml
+++ b/server/h-export/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "h-export"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+h-llm.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/server/h-export/src/anthropic.rs
+++ b/server/h-export/src/anthropic.rs
@@ -1,0 +1,299 @@
+//! `anthropic` (Claude Messages API) → OpenAI-style SFT.
+//!
+//! Shape differences handled here:
+//! - `system` (string | `[{type:text,text}]`) → a leading `system` message.
+//! - assistant content blocks: `text` → content, `thinking` → `reasoning_content`, `tool_use` →
+//!   `tool_calls` (its `input` is already a dict).
+//! - a user message's `tool_result` blocks → one `role:"tool"` message **each** (Anthropic packs
+//!   results into a user turn; OpenAI puts them in tool turns).
+//! - tools `{name,description,input_schema}` →
+//!   `{type:function,function:{name,description,parameters}}`.
+//!
+//! The response body is the reassembled assistant message and is appended as the
+//! final assistant turn.
+
+use serde_json::{json, Map, Value};
+
+use crate::{
+    arguments_to_dict, ExportError, Message, ToolCall, ToolCallFunction, TrainingTrajectory,
+};
+
+pub(crate) fn reconstruct(req: &Value, resp: &Value) -> Result<TrainingTrajectory, ExportError> {
+    let mut messages: Vec<Message> = Vec::new();
+
+    if let Some(text) = req.get("system").and_then(system_to_string) {
+        if !text.is_empty() {
+            messages.push(Message {
+                role: "system".to_string(),
+                content: Some(text),
+                ..Default::default()
+            });
+        }
+    }
+
+    let req_msgs = req
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ExportError::Malformed("anthropic", "request has no messages[]".into()))?;
+    for m in req_msgs {
+        convert_request_message_into(m, &mut messages);
+    }
+
+    // The response is the reassembled final assistant message.
+    if let Some(asst) = assistant_from_content(resp.get("content"), resp.get("role")) {
+        messages.push(asst);
+    }
+
+    let tools = req
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().map(convert_tool_schema).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    Ok(TrainingTrajectory {
+        messages,
+        tools,
+        meta: json!({}),
+    })
+}
+
+/// `system` is a string or an array of `{type:"text", text}` blocks.
+fn system_to_string(sys: &Value) -> Option<String> {
+    match sys {
+        Value::String(s) => Some(s.clone()),
+        Value::Array(blocks) => Some(
+            blocks
+                .iter()
+                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(""),
+        ),
+        _ => None,
+    }
+}
+
+fn convert_request_message_into(m: &Value, out: &mut Vec<Message>) {
+    let role = m.get("role").and_then(Value::as_str).unwrap_or_default();
+    match role {
+        "assistant" => {
+            if let Some(asst) = assistant_from_content(m.get("content"), m.get("role")) {
+                out.push(asst);
+            }
+        }
+        _ => {
+            // user (or anything else): plain text → user message; tool_result
+            // blocks → one tool message each. Tool messages are emitted in block
+            // order, with any free-standing user text appended after.
+            match m.get("content") {
+                Some(Value::String(s)) => out.push(Message {
+                    role: "user".to_string(),
+                    content: Some(s.clone()),
+                    ..Default::default()
+                }),
+                Some(Value::Array(blocks)) => {
+                    let mut user_text = String::new();
+                    for b in blocks {
+                        match b.get("type").and_then(Value::as_str) {
+                            Some("tool_result") => out.push(Message {
+                                role: "tool".to_string(),
+                                content: Some(tool_result_content_to_string(b.get("content"))),
+                                tool_call_id: b
+                                    .get("tool_use_id")
+                                    .and_then(Value::as_str)
+                                    .map(String::from),
+                                ..Default::default()
+                            }),
+                            Some("text") => {
+                                if let Some(t) = b.get("text").and_then(Value::as_str) {
+                                    user_text.push_str(t);
+                                }
+                            }
+                            _ => {} // image / other blocks: not part of the text trajectory
+                        }
+                    }
+                    if !user_text.is_empty() {
+                        out.push(Message {
+                            role: "user".to_string(),
+                            content: Some(user_text),
+                            ..Default::default()
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Convert an assistant content value (blocks array or string) into one
+/// assistant `Message`. Returns `None` if there's nothing to emit.
+fn assistant_from_content(content: Option<&Value>, role: Option<&Value>) -> Option<Message> {
+    let role = role
+        .and_then(Value::as_str)
+        .unwrap_or("assistant")
+        .to_string();
+    match content {
+        Some(Value::String(s)) => (!s.is_empty()).then(|| Message {
+            role,
+            content: Some(s.clone()),
+            ..Default::default()
+        }),
+        Some(Value::Array(blocks)) => {
+            let mut text = String::new();
+            let mut thinking = String::new();
+            let mut tool_calls: Vec<ToolCall> = Vec::new();
+            for b in blocks {
+                match b.get("type").and_then(Value::as_str) {
+                    Some("text") => {
+                        if let Some(t) = b.get("text").and_then(Value::as_str) {
+                            text.push_str(t);
+                        }
+                    }
+                    Some("thinking") => {
+                        if let Some(t) = b.get("thinking").and_then(Value::as_str) {
+                            thinking.push_str(t);
+                        }
+                    }
+                    Some("tool_use") => tool_calls.push(ToolCall {
+                        id: b
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        kind: "function".to_string(),
+                        function: ToolCallFunction {
+                            name: b
+                                .get("name")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                            arguments: arguments_to_dict(b.get("input")),
+                        },
+                    }),
+                    _ => {}
+                }
+            }
+            if text.is_empty() && thinking.is_empty() && tool_calls.is_empty() {
+                return None;
+            }
+            Some(Message {
+                role,
+                content: (!text.is_empty()).then_some(text),
+                reasoning_content: (!thinking.is_empty()).then_some(thinking),
+                tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),
+                ..Default::default()
+            })
+        }
+        _ => None,
+    }
+}
+
+/// A `tool_result.content` is a string or an array of `{type:text,text}` blocks.
+fn tool_result_content_to_string(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str).or_else(|| b.as_str()))
+            .collect(),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
+}
+
+fn convert_tool_schema(t: &Value) -> Value {
+    let mut func = Map::new();
+    func.insert(
+        "name".to_string(),
+        t.get("name").cloned().unwrap_or_else(|| json!("")),
+    );
+    if let Some(desc) = t.get("description") {
+        func.insert("description".to_string(), desc.clone());
+    }
+    func.insert(
+        "parameters".to_string(),
+        t.get("input_schema").cloned().unwrap_or_else(|| json!({})),
+    );
+    json!({ "type": "function", "function": Value::Object(func) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_turn_with_thinking_tooluse_and_toolresult() {
+        let req = json!({
+            "system": [{"type": "text", "text": "diagnose pcaps"}],
+            "messages": [
+                {"role": "user", "content": "what broke?"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "let me look"},
+                    {"type": "text", "text": "checking"},
+                    {"type": "tool_use", "id": "tu_1", "name": "tshark", "input": {"filter": "tcp"}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "100 packets"}
+                ]}
+            ],
+            "tools": [
+                {"name": "tshark", "description": "run tshark",
+                 "input_schema": {"type": "object", "properties": {"filter": {"type": "string"}}}}
+            ]
+        });
+        let resp = json!({
+            "role": "assistant",
+            "content": [{"type": "text", "text": "RST flood from .5"}],
+            "stop_reason": "end_turn"
+        });
+
+        let t = reconstruct(&req, &resp).unwrap();
+        // system, user, assistant(think+text+toolcall), tool, final assistant
+        assert_eq!(t.messages.len(), 5);
+
+        assert_eq!(t.messages[0].role, "system");
+        assert_eq!(t.messages[0].content.as_deref(), Some("diagnose pcaps"));
+
+        assert_eq!(t.messages[1].role, "user");
+
+        let asst = &t.messages[2];
+        assert_eq!(asst.role, "assistant");
+        assert_eq!(asst.content.as_deref(), Some("checking"));
+        assert_eq!(asst.reasoning_content.as_deref(), Some("let me look"));
+        let tc = &asst.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(tc.id, "tu_1");
+        assert_eq!(tc.function.name, "tshark");
+        assert!(tc.function.arguments.is_object());
+        assert_eq!(tc.function.arguments["filter"], json!("tcp"));
+
+        // tool_result → role:"tool" with matching id
+        let tool = &t.messages[3];
+        assert_eq!(tool.role, "tool");
+        assert_eq!(tool.tool_call_id.as_deref(), Some("tu_1"));
+        assert_eq!(tool.content.as_deref(), Some("100 packets"));
+
+        // final assistant from response
+        assert_eq!(t.messages[4].role, "assistant");
+        assert_eq!(t.messages[4].content.as_deref(), Some("RST flood from .5"));
+
+        // tool schema converted: input_schema → parameters
+        assert_eq!(t.tools.len(), 1);
+        let f = &t.tools[0]["function"];
+        assert_eq!(f["name"], json!("tshark"));
+        assert_eq!(f["description"], json!("run tshark"));
+        assert!(f["parameters"]["properties"]["filter"].is_object());
+    }
+
+    #[test]
+    fn string_system_and_string_user() {
+        let req = json!({
+            "system": "be terse",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let resp = json!({"content": [{"type": "text", "text": "hello"}]});
+        let t = reconstruct(&req, &resp).unwrap();
+        assert_eq!(t.messages[0].content.as_deref(), Some("be terse"));
+        assert_eq!(t.messages[1].content.as_deref(), Some("hi"));
+        assert_eq!(t.messages[2].content.as_deref(), Some("hello"));
+    }
+}

--- a/server/h-export/src/lib.rs
+++ b/server/h-export/src/lib.rs
@@ -1,0 +1,142 @@
+//! Reconstruct a captured agent turn/session into a **training trajectory**
+//! shaped for SFT fine-tuning (OpenAI `messages` format).
+//!
+//! The agent CLI re-sends the full cumulative message history on every call, so
+//! a turn's terminal call already carries the whole turn in its `request_body`,
+//! and a session's last turn's terminal call carries the whole session. We
+//! therefore reconstruct from a single (request_body, response_body) pair:
+//! `messages = normalize(request_body) ++ final-assistant(response_body)`.
+//!
+//! Output invariants (OpenAI-style SFT): `messages[]` each have a `role`;
+//! `tool_calls[].function.arguments` is always a **dict, never a JSON string**;
+//! assistant `reasoning_content` (Anthropic `thinking` / OpenAI `reasoning`) is
+//! preserved. `tools` and `_meta` are tolerated extras.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+mod anthropic;
+mod openai_chat;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExportError {
+    /// Wire formats not yet supported by the normalizer (codex
+    /// `openai-responses`, `gemini-aistudio`). Adding one is a new dispatch arm.
+    #[error("unsupported wire_api: {0}")]
+    UnsupportedWireApi(String),
+    /// The terminal call's body was sampled away by the capture body cap
+    /// (`body_bytes_dropped > 0`) — reconstructing would silently drop turns.
+    #[error("captured body was truncated (body_bytes_dropped > 0); trajectory would be lossy")]
+    BodyTruncated,
+    /// No terminal call / no body to reconstruct from.
+    #[error("no terminal call body to reconstruct from")]
+    MissingTerminalBody,
+    #[error("malformed {0} body: {1}")]
+    Malformed(&'static str, String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolCallFunction {
+    pub name: String,
+    /// Always a JSON object. OpenAI stores this as a string on the wire; the
+    /// normalizer parses it so the exported tool call is the expected dict shape.
+    pub arguments: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: ToolCallFunction,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Message {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrainingTrajectory {
+    pub messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<Value>,
+    /// Provenance, set by the caller via [`TrainingTrajectory::with_meta`].
+    #[serde(rename = "_meta")]
+    pub meta: Value,
+}
+
+impl TrainingTrajectory {
+    /// Attach a provenance `_meta` object (the normalizer leaves it `{}`).
+    pub fn with_meta(mut self, meta: Value) -> Self {
+        self.meta = meta;
+        self
+    }
+}
+
+/// Reconstruct a trajectory from one captured (request, response) body pair.
+/// Bodies must already be parsed JSON (heron stores reassembled JSON even for
+/// streaming). `_meta` is left empty — attach it with [`TrainingTrajectory::with_meta`].
+pub fn reconstruct_trajectory(
+    wire_api: &str,
+    request_body: &Value,
+    response_body: &Value,
+) -> Result<TrainingTrajectory, ExportError> {
+    match wire_api {
+        h_llm::wire_apis::OPENAI_CHAT => openai_chat::reconstruct(request_body, response_body),
+        h_llm::wire_apis::ANTHROPIC => anthropic::reconstruct(request_body, response_body),
+        other => Err(ExportError::UnsupportedWireApi(other.to_string())),
+    }
+}
+
+// ---- shared helpers used by both wire normalizers --------------------------
+
+/// Parse a tool-call `arguments` field into a dict. OpenAI sends a JSON
+/// **string**; Anthropic `tool_use.input` is already an object. Unparseable
+/// strings degrade to `{}` (valid, lossy) rather than failing the export.
+pub(crate) fn arguments_to_dict(args: Option<&Value>) -> Value {
+    match args {
+        Some(Value::String(s)) => serde_json::from_str::<Value>(s).unwrap_or_else(|_| json!({})),
+        Some(other) => other.clone(),
+        None => json!({}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_wire_returns_typed_error() {
+        let v = json!({});
+        for wire in ["openai-responses", "gemini-aistudio", "totally-unknown"] {
+            match reconstruct_trajectory(wire, &v, &v) {
+                Err(ExportError::UnsupportedWireApi(w)) => assert_eq!(w, wire),
+                other => panic!("expected UnsupportedWireApi for {wire}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn arguments_string_becomes_dict() {
+        let parsed = arguments_to_dict(Some(&json!("{\"k\":\"v\",\"n\":3}")));
+        assert!(parsed.is_object());
+        assert_eq!(parsed["k"], json!("v"));
+        assert_eq!(parsed["n"], json!(3));
+        // already-dict passes through
+        assert_eq!(arguments_to_dict(Some(&json!({"a":1}))), json!({"a":1}));
+        // garbage / absent → empty dict
+        assert_eq!(arguments_to_dict(Some(&json!("not json"))), json!({}));
+        assert_eq!(arguments_to_dict(None), json!({}));
+    }
+}

--- a/server/h-export/src/openai_chat.rs
+++ b/server/h-export/src/openai_chat.rs
@@ -1,0 +1,173 @@
+//! `openai-chat` → OpenAI-style SFT. The request is already OpenAI-shaped, so this
+//! is mostly pass-through; the one transform is parsing each assistant
+//! `tool_calls[].function.arguments` from its JSON-string form into a dict.
+
+use serde_json::{json, Value};
+
+use crate::{
+    arguments_to_dict, ExportError, Message, ToolCall, ToolCallFunction, TrainingTrajectory,
+};
+
+pub(crate) fn reconstruct(req: &Value, resp: &Value) -> Result<TrainingTrajectory, ExportError> {
+    let req_msgs = req
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ExportError::Malformed("openai-chat", "request has no messages[]".into()))?;
+
+    let mut messages: Vec<Message> = req_msgs.iter().map(convert_message).collect();
+
+    // Append the final assistant turn from the response.
+    if let Some(msg) = resp
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .and_then(|c| c.get("message"))
+    {
+        messages.push(convert_message(msg));
+    }
+
+    let tools = req
+        .get("tools")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(TrainingTrajectory {
+        messages,
+        tools,
+        meta: json!({}),
+    })
+}
+
+fn convert_message(m: &Value) -> Message {
+    let role = m
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    let reasoning_content = m
+        .get("reasoning_content")
+        .or_else(|| m.get("reasoning"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let tool_calls = m
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(convert_tool_call).collect::<Vec<_>>())
+        .filter(|v| !v.is_empty());
+
+    Message {
+        role,
+        content: content_to_string(m.get("content")),
+        reasoning_content,
+        tool_calls,
+        tool_call_id: m
+            .get("tool_call_id")
+            .and_then(Value::as_str)
+            .map(String::from),
+        name: m.get("name").and_then(Value::as_str).map(String::from),
+    }
+}
+
+fn convert_tool_call(tc: &Value) -> Option<ToolCall> {
+    let function = tc.get("function")?;
+    Some(ToolCall {
+        id: tc
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        kind: "function".to_string(),
+        function: ToolCallFunction {
+            name: function
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            arguments: arguments_to_dict(function.get("arguments")),
+        },
+    })
+}
+
+/// OpenAI `content` is a string or an array of parts (`{type:"text",text}`).
+/// Join text parts; `None` when absent/empty (e.g. an assistant turn that is
+/// only `tool_calls`).
+fn content_to_string(content: Option<&Value>) -> Option<String> {
+    match content {
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        Some(Value::Array(parts)) => {
+            let joined: String = parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(Value::as_str).or_else(|| p.as_str()))
+                .collect();
+            (!joined.is_empty()).then_some(joined)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn arguments_string_to_dict_and_reasoning_mapped() {
+        let req = json!({
+            "messages": [
+                {"role": "system", "content": "be helpful"},
+                {"role": "user", "content": "trace this"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"id": "call_1", "type": "function",
+                     "function": {"name": "shell", "arguments": "{\"cmd\":\"ls\"}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "name": "shell", "content": "a.txt"}
+            ],
+            "tools": [{"type": "function", "function": {"name": "shell", "parameters": {}}}]
+        });
+        let resp = json!({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "done",
+                "reasoning": "I listed the dir"
+            }}]
+        });
+
+        let t = reconstruct(&req, &resp).unwrap();
+        assert_eq!(t.messages.len(), 5);
+
+        // assistant tool call: arguments parsed to a dict
+        let asst = &t.messages[2];
+        let tc = &asst.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(tc.id, "call_1");
+        assert!(tc.function.arguments.is_object());
+        assert_eq!(tc.function.arguments["cmd"], json!("ls"));
+
+        // tool result message
+        let tool = &t.messages[3];
+        assert_eq!(tool.role, "tool");
+        assert_eq!(tool.tool_call_id.as_deref(), Some("call_1"));
+
+        // final assistant from response, bare `reasoning` → reasoning_content
+        let final_asst = t.messages.last().unwrap();
+        assert_eq!(final_asst.role, "assistant");
+        assert_eq!(final_asst.content.as_deref(), Some("done"));
+        assert_eq!(
+            final_asst.reasoning_content.as_deref(),
+            Some("I listed the dir")
+        );
+
+        // tools passed through
+        assert_eq!(t.tools.len(), 1);
+    }
+
+    #[test]
+    fn missing_messages_is_malformed() {
+        let err = reconstruct(&json!({}), &json!({})).unwrap_err();
+        assert!(matches!(err, ExportError::Malformed("openai-chat", _)));
+    }
+}


### PR DESCRIPTION
## What

A flagship capability for heron: turn captured agent **turns** and **sessions** into **SFT training trajectories** — single or batch — so real captured agent traffic becomes reusable fine-tuning supervision without hand-labeling or replaying the agent.

## How it works

The agent CLI re-sends the full cumulative message history on every call, so a turn's terminal call already carries the whole turn (and a session's last turn carries the whole session). A new `h-export` crate reconstructs one OpenAI-style `messages` trajectory from a single (request, response) wire-body pair:

- **anthropic** + **openai-chat** wire formats (codex / gemini return a typed `Unsupported` error)
- content blocks → `tool_calls` / `tool`-role messages; `thinking` → `reasoning_content`
- `tool_calls[].function.arguments` rehydrated from a JSON-string to a dict
- streaming bodies are already reassembled to clean JSON upstream, so the normalizer is a pure transform

## API

| Endpoint | Result |
|---|---|
| `GET /api/export/trajectory?scope=turn&turn_id=…` | one turn |
| `GET /api/export/trajectory?scope=session&source_id&session_id` | whole session as one multi-turn trajectory |
| `GET /api/export/trajectories?<agent-turns filters>` | **batch**: one trajectory per turn matching the current filters |

Raw NDJSON attachment downloads; the batch endpoint reports `X-Export-Skipped` and skips (rather than fails) turns whose wire format is unsupported or whose body is unavailable.

## Console

- **Download trajectory** button on turn detail (TopBar) and session detail header
- **Export trajectories** on the Agent Turns list — exports every turn matching the current filter (time window · agent kind · model · wire API · status), with a written / skipped count

## Tests

- `h-export`: 6 unit tests (anthropic with thinking + tool_use + tool_result; openai-chat arguments-string→dict + reasoning mapping; unsupported-wire error)
- `h-api`: 3 export route tests (single missing → 404, single without id → 400, empty batch → 200 with `X-Export-*` headers)
- console `tsc` + `vite build` clean

## Not in this PR

Live end-to-end on a running capture (export a real turn → import into a trainer) — covered by unit tests + the documented format; a live run is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)