### PR TITLE
chore(pr-review): bump agent-ops pin to v0.3.1 (diff-injection review fix)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,9 +39,9 @@ permissions:
 
 jobs:
   review:
-    uses: Netis/agent-ops/.github/workflows/review.yml@v0.2.0
+    uses: Netis/agent-ops/.github/workflows/review.yml@v0.3.1
     with:
-      agent_ops_ref: v0.2.0
+      agent_ops_ref: v0.3.1
       runner_labels: '["self-hosted","heron"]'
       # Empty on the workflow_run path (resolved from the run event); the PR
       # number typed on a manual workflow_dispatch re-review.


### PR DESCRIPTION
Bumps the PR-review reusable-workflow pin `@v0.2.0 → @v0.3.1` (both `uses:` and `agent_ops_ref`).

`agent-ops` v0.3.1 pre-fetches the PR diff into the review prompt, so **vivi no longer depends on the model backend doing native tool-calling**. Until now the agent emitted `gh pr diff` as plain text, never received the diff, produced no `### Summary`, and `post_review` fell back to **COMMENTED** on every PR (#134, #135) — blocking merges on a review that never really ran.

After this lands, PR reviews on heron produce a real verdict again (and the always-blocking leakage check works from the inline diff even on a non-tool-calling backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)