### PR TITLE
fix(deploy-prod): rebuild console bundle before cargo build (stale embedded UI)

### DIFF
--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -23,6 +23,7 @@
 #   HERON_PROD_PORT      heron API port           (default: 4500)
 #   HEALTH_TIMEOUT_SECS  health-gate budget secs  (default: 120)
 #   CARGO_BIN            cargo path               (default: ~/.cargo/bin/cargo)
+#   BUN_BIN              bun path                 (default: bun on PATH)
 #
 # Exit: 0 = deployed + healthy; non-zero = failed (rolled back if possible).
 set -euo pipefail
@@ -33,9 +34,11 @@ SERVICE="${HERON_PROD_SERVICE:-heron.service}"
 PORT="${HERON_PROD_PORT:-4500}"
 HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-120}"
 CARGO="${CARGO_BIN:-$HOME/.cargo/bin/cargo}"
+BUN="${BUN_BIN:-bun}"
 
 [ -d "$REPO/.git" ] || { echo "::error::HERON_PROD_REPO_DIR not a git checkout: $REPO" >&2; exit 1; }
 [ -x "$CARGO" ] || { echo "::error::cargo not executable at $CARGO" >&2; exit 1; }
+command -v "$BUN" >/dev/null 2>&1 || { echo "::error::bun not found ($BUN) — cannot rebuild the console bundle; refusing to ship a stale embedded UI" >&2; exit 1; }
 cd "$REPO"
 
 BIN="$REPO/server/target/release/heron"
@@ -55,6 +58,23 @@ else
   echo "    (no existing binary to back up — first deploy)"
   HAVE_BAK=0
 fi
+
+# Rebuild the console bundle FIRST. `--features console` embeds console/dist at
+# COMPILE TIME via rust-embed (main.rs `#[folder = "../../../console/dist/"]`),
+# and console/dist is gitignored — so `git checkout` never updates it. Without
+# this step the cargo build below re-embeds whatever stale dist happened to be
+# on the prod host from a prior manual build, and front-end changes (themes,
+# pages) silently never reach prod even though the deploy reports success and
+# the health gate (process-up + capture-running, not a UI check) stays green.
+# Mirrors `just build all` (scripts/routers/shared/build.sh run_console).
+echo "==> build console bundle (bun) — embedded into the binary via --features console"
+( cd console && "$BUN" install && "$BUN" run build )
+[ -n "$(ls -A "$REPO/console/dist" 2>/dev/null)" ] \
+  || { echo "::error::console build produced no console/dist — refusing to embed an empty UI" >&2; exit 1; }
+# rust-embed snapshots the folder at compile time and only re-embeds when the
+# embedding crate recompiles; touch its source so an incremental cargo build
+# actually picks up the freshly-built bundle instead of cached embedded bytes.
+touch server/app/heron/src/main.rs
 
 echo "==> build (release + console, incremental — MUST pass --features console)"
 ( cd server && "$CARGO" build --release --bin heron --features console )


### PR DESCRIPTION
## Problem

Production deploys reported success but never showed front-end changes — the three-theme redesign (#134) and the trajectory-export buttons (#135) were both invisible on prod despite a green `deploy-prod` run + health gate.

**Root cause:** `scripts/prod/deploy-prod.sh` builds the binary with `--features console` but never rebuilds the front-end first. `--features console` embeds `console/dist` at **compile time** via rust-embed (`main.rs` `#[folder = "../../../console/dist/"]`), and `console/dist` is **gitignored** — so the script's `git checkout <sha>` updates the Rust/TS source but not the built bundle. The cargo build then re-embeds whatever stale `dist` a prior manual build left on the host.

The health gate checks process-up + capture-running, **not** the UI, so it stays green over a stale console. Staging didn't catch it either: `deploy-staging` consumes the CI-built artifact (which *does* run the console build), and `staging-soak` replays pcaps to exercise the capture pipeline, never the console. Prod is the only path that builds locally from source — and it was the one skipping the bundle.

## Fix

Build the console bundle before the cargo build, mirroring `just build all` (`scripts/routers/shared/build.sh` `run_console`):

- `bun install && bun run build` to regenerate `console/dist`
- **fail closed** if `bun` is missing or `dist` comes out empty (refuse to embed a stale/empty UI rather than silently shipping one)
- `touch server/app/heron/src/main.rs` so an incremental cargo build re-embeds the freshly-built bundle instead of cached embedded bytes

New optional `BUN_BIN` env override (default `bun` on PATH), documented in the header.

## Verification
- `bash -n scripts/prod/deploy-prod.sh` clean.
- Build order now matches the canonical `run_all()` in `build.sh` (console → cargo `--features console`).
- After merge, the next `deploy-prod` rebuilds the console and the new themes/UI reach prod on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)