### PR TITLE
fix(deploy-prod): resolve bun via ~/.bun/bin fallback (non-login deploy shell)

### DIFF
--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -34,11 +34,16 @@ SERVICE="${HERON_PROD_SERVICE:-heron.service}"
 PORT="${HERON_PROD_PORT:-4500}"
 HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-120}"
 CARGO="${CARGO_BIN:-$HOME/.cargo/bin/cargo}"
-BUN="${BUN_BIN:-bun}"
+# bun: explicit override → PATH → bun's canonical install dir. A non-login
+# deploy shell often lacks ~/.bun/bin on PATH (same reason CARGO defaults to
+# ~/.cargo/bin above), so fall back to the official-installer location rather
+# than failing on a host where bun is installed but just not on PATH.
+BUN="${BUN_BIN:-$(command -v bun 2>/dev/null || true)}"
+[ -n "$BUN" ] || BUN="$HOME/.bun/bin/bun"
 
 [ -d "$REPO/.git" ] || { echo "::error::HERON_PROD_REPO_DIR not a git checkout: $REPO" >&2; exit 1; }
 [ -x "$CARGO" ] || { echo "::error::cargo not executable at $CARGO" >&2; exit 1; }
-command -v "$BUN" >/dev/null 2>&1 || { echo "::error::bun not found ($BUN) — cannot rebuild the console bundle; refusing to ship a stale embedded UI" >&2; exit 1; }
+[ -x "$BUN" ] || { echo "::error::bun not executable at '$BUN' — cannot rebuild the console bundle; set BUN_BIN or install bun; refusing to ship a stale embedded UI" >&2; exit 1; }
 cd "$REPO"
 
 BIN="$REPO/server/target/release/heron"


### PR DESCRIPTION
## Follow-up to #138

#138 made `deploy-prod.sh` rebuild the console bundle before the cargo build, but the first real run failed:

```
##[error]bun not found (bun) — cannot rebuild the console bundle; refusing to ship a stale embedded UI
```

The fail-closed guard worked exactly as intended — it aborted **before** touching the running service, so prod stayed up on its previous binary. But it blocked the deploy instead of finding bun, which *is* installed on the host (`~/.bun/bin/bun`, the official installer's location). The self-hosted runner runs the deploy in a **non-login shell**, so `~/.bun/bin` isn't on `PATH` — the same reason `CARGO` already defaults to `~/.cargo/bin/cargo` rather than bare `cargo`.

## Fix

Resolve `BUN` the same way as `CARGO`:

- `BUN_BIN` explicit override → `command -v bun` on PATH → `$HOME/.bun/bin/bun` canonical fallback
- validate with `[ -x "$BUN" ]` (works for an absolute path directly)

No host-specific path is committed: `$HOME/.bun/bin` is bun's standard install directory — a generic default mirroring the existing cargo default.

## Verification
- `bash -n` clean.
- Simulated non-login resolution: bun absent from PATH but present at `$HOME/.bun/bin/bun` → resolves to the fallback and passes the `-x` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)