### PR TITLE
feat(capture): native eBPF SSL-uprobe capture (process attribution + static-binary targets)

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+console/.tmp/

--- a/console/src/components/llm-call-detail/metadata-grid.tsx
+++ b/console/src/components/llm-call-detail/metadata-grid.tsx
@@ -11,6 +11,16 @@ export function MetadataGrid({ detail }: Props) {
     ["Response ID", detail.response_id ?? "—"],
     ["Path", detail.request_path],
     ["Client", `${detail.client_ip}:${detail.client_port}`],
+    // Process attribution (eBPF sources only); omitted entirely for passive
+    // taps where `process` is null.
+    ...(detail.process
+      ? ([
+          ["Process", `${detail.process.comm} (pid ${detail.process.pid})`],
+          ...(detail.process.exe
+            ? [["Executable", detail.process.exe] as [string, string]]
+            : []),
+        ] as [string, string][])
+      : []),
     ["Server", `${detail.server_ip}:${detail.server_port}`],
     ["Stream", detail.is_stream ? "Yes" : "No"],
     ["API Type", detail.api_type],

--- a/console/src/pages/llm-calls.tsx
+++ b/console/src/pages/llm-calls.tsx
@@ -21,6 +21,7 @@ const columns = [
   { key: "wire_api", label: "Wire API", width: "w-[110px]", sortable: false },
   { key: "model", label: "Model", width: "w-[140px]", sortable: false },
   { key: "client_ip", label: "Client", width: "w-[130px]", sortable: false },
+  { key: "process", label: "Process", width: "w-[130px]", sortable: false },
   { key: "server", label: "Server", width: "w-[180px]", sortable: false },
   { key: "request_path", label: "Path", width: "", sortable: false },
   { key: "status_code", label: "Status", width: "w-[52px]", sortable: true },
@@ -57,6 +58,21 @@ function CellValue({ item, column }: { item: LlmCallListItem; column: SortKey })
       )
     case "client_ip":
       return <span className="truncate font-mono text-xs">{item.client_ip}</span>
+    case "process": {
+      // Process attribution is only present on eBPF-sourced calls; passive
+      // taps leave it null. Show comm + pid, with the executable path on hover.
+      const p = item.process
+      if (!p) return <span className="text-muted-foreground">—</span>
+      return (
+        <span
+          className="truncate font-mono text-xs"
+          title={`pid ${p.pid}${p.exe ? ` · ${p.exe}` : ""}`}
+        >
+          {p.comm}
+          <span className="text-muted-foreground"> ({p.pid})</span>
+        </span>
+      )
+    }
     case "server":
       return (
         <span className="truncate font-mono text-xs">

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -68,7 +68,7 @@ export interface LlmCallListItem {
   tool_call_count: number
   tool_names: string[]
   /** Owning process (eBPF attribution); null for passive-tap sources. */
-  process?: ProcessInfo | null
+  process: ProcessInfo | null
 }
 
 // Metrics types
@@ -422,7 +422,7 @@ export interface LlmCallDetail {
   tool_call_count: number
   tool_names: string[]
   /** Owning process (eBPF attribution); null for passive-tap sources. */
-  process?: ProcessInfo | null
+  process: ProcessInfo | null
 }
 
 // HTTP exchange types — /api/http-exchanges

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -25,6 +25,19 @@ export interface LlmCallsPage {
   items: LlmCallListItem[]
 }
 
+/**
+ * Owning process of a captured connection. Only present on calls from an
+ * attribution-capable source (eBPF); `null` for passive-tap sources (pcap /
+ * cloud-probe), which see only the wire.
+ */
+export interface ProcessInfo {
+  pid: number
+  /** Kernel `comm` (≤15 chars), e.g. `python3`, `node`, `claude`. */
+  comm: string
+  /** Absolute executable path (`/proc/<pid>/exe`), or null when unresolved. */
+  exe: string | null
+}
+
 export interface LlmCallListItem {
   id: string
   request_time: number
@@ -54,6 +67,8 @@ export interface LlmCallListItem {
   agent_topology: AgentTopology | null
   tool_call_count: number
   tool_names: string[]
+  /** Owning process (eBPF attribution); null for passive-tap sources. */
+  process?: ProcessInfo | null
 }
 
 // Metrics types
@@ -406,6 +421,8 @@ export interface LlmCallDetail {
   agent_topology: AgentTopology | null
   tool_call_count: number
   tool_names: string[]
+  /** Owning process (eBPF attribution); null for passive-tap sources. */
+  process?: ProcessInfo | null
 }
 
 // HTTP exchange types — /api/http-exchanges

--- a/docs/design/03-ebpf-static-targets.md
+++ b/docs/design/03-ebpf-static-targets.md
@@ -80,37 +80,85 @@ libssl (which has symbols, giving ground truth):
 
 ## Deriving a signature for a Bun / Claude Code release
 
-Because the signature is build-specific, deriving it is a per-release step:
+Because the signature is build-specific, deriving it is a per-release step. Two
+config paths exist:
 
-1. Find a symbolized reference of the **same BoringSSL** (or disassemble the
-   target around the function located by xref to a vendored source-path string),
-   and read the first ~48 bytes of the `SSL_write` / `SSL_read` prologue.
-2. Wildcard (`??`) the 4-byte RIP-relative displacements (e.g. the `e8 ?? ?? ??
-   ??` call near the end) so the signature survives PIE/ASLR-independent relocs
-   across rebuilds of the same source.
-3. Validate uniqueness against the actual target binary:
+- `write_offset` / `read_offset` — explicit file offsets, bypass scanning. The
+  fast path once the offset is known (and the validation path while deriving a
+  signature). The loader attaches directly.
+- `write_sig` / `read_sig` — byte-signature patterns, resolved to a unique
+  offset at attach time. The resilient path: a signature survives ASLR and
+  matches any process mapping the binary.
+
+To derive either, you must first **locate `SSL_write` / `SSL_read` in the
+stripped binary**. What we learned probing Bun 1.3.13 (see below) makes the
+recipe concrete:
+
+1. Find the TLS write call chain dynamically — `bpftrace` ustack on the write
+   syscall from the runtime:
    ```
-   cargo run -p h-capture --example sigscan_probe -- /path/to/bun "55 41 57 ?? …"
+   bpftrace -e 'tracepoint:syscalls:sys_enter_write /comm=="bun"/ { @[ustack(perf,12)] = count(); }'
    ```
-   A good signature reports exactly **one** match (`OK: unique offset`).
-4. Put the validated patterns in config:
+   For a non-PIE EXEC (Bun is `ET_EXEC`), the frame addresses are link-time
+   vaddrs; convert to file offsets via the executable `PT_LOAD` delta
+   (`file_off = vaddr - (p_vaddr - p_offset)`; 0x318000 for this Bun).
+2. The plaintext-bearing functions (`SSL_write` / `ssl_write_internal`, arg1 =
+   `buf` in RSI) are the **outer** frames; the inner cluster is the record /
+   encryption layer (ciphertext). Validate a candidate **function entry** by
+   attaching there and checking RSI:
+   ```
+   HERON_EBPF_TARGET_BIN=/path/to/bun HERON_EBPF_WRITE_OFFSET=0x… \
+     ./target/debug/examples/ebpf_smoke   # prints captured HTTP/1.1 if RSI is plaintext
+   ```
+3. Read the first ~48 bytes at the validated entry, wildcard (`??`) the 4-byte
+   RIP-relative displacements (e.g. the `e8 ?? ?? ?? ??` call operands), and
+   confirm uniqueness:
+   ```
+   cargo run -p h-capture --example sigscan_probe -- /path/to/bun "55 48 89 e5 …"
+   ```
+4. Put the validated offset (or signature) in config:
    ```toml
    [[sources.targets]]
    binary = "/path/to/claude/bun"
    flavor = "boringssl"
-   write_sig = "…"   # validated SSL_write prologue
-   read_sig  = "…"   # validated SSL_read prologue
+   write_sig = "…"   # or write_offset = 0x…
+   read_sig  = "…"   # or read_offset  = 0x…
    ```
 
 No built-in BoringSSL signature ships (`flavor_signatures` returns none): a
 guessed-wrong signature is worse than none (it could attach to the wrong
 function), so the unique-match requirement plus operator-supplied, validated
-patterns is the safe default.
+patterns/offsets is the safe default.
+
+## What we measured on Bun 1.3.13 (the hard part: entry identification)
+
+The mechanism is proven; the open work is **reliably finding the function
+entry** in this specific binary shape. Recorded so a follow-up doesn't re-walk it:
+
+- Bun's BoringSSL is compiled **without CET** — functions do **not** start with
+  `endbr64`, so the easy entry marker the system libssl has is absent here.
+  Prologues are plain (`55 48 89 e5 …` push-rbp, or frame-pointer-omitted).
+- `bpftrace` located the exact write call chain: an inner cluster (`~0x3c2xxxx`,
+  the record/encrypt layer that calls `write@plt`) and outer frames
+  (`~0x42xxxxx`) on the plaintext side.
+- Offset-attach **registers correctly** against the EXEC binary
+  (`bpftool link list` shows `uprobe /…/bun+0x…` at the computed file offset;
+  the r-xp mapping `…r-xp 02808000 …/bun` confirms the delta), so aya + the
+  loader are sound on a non-PIE target.
+- The remaining blocker: int3-padding / prologue heuristics yield **basic-block
+  boundaries**, not guaranteed function entries on the executed path, in this
+  jump-dense optimized code. Pinning the true entry needs proper
+  disassembly-based function-boundary analysis (or a symbol-matched BoringSSL
+  build — out of reach without the matching toolchain). `bpftrace`'s numeric
+  uprobe (`uprobe:bin:0xADDR`) can't help validate here: it resolves addresses
+  via the symbol table, which is empty for BoringSSL, so use the
+  `HERON_EBPF_WRITE_OFFSET` path above instead.
 
 ## Status
 
-- Mechanism (sigscan + offset-attach + config + discovery tool): **done,
-  verified end-to-end** on a real SSL function.
-- A validated Bun/Claude Code signature: **per-release data**, derived with the
-  procedure above. Wildcarding the displacement bytes (step 2) is what makes a
-  signature resilient across patch rebuilds of one Bun line.
+- Mechanism (sigscan + offset/sig attach + config + `sigscan_probe`): **done,
+  verified end-to-end** on a real SSL function (system libssl).
+- De-risking: **done** — Bun fetch is HTTP/1.1; Bun is stripped static BoringSSL,
+  non-CET.
+- A validated Bun/Claude Code offset or signature: **open** — needs
+  disassembly-based entry identification (above), then it is per-release data.

--- a/docs/design/03-ebpf-static-targets.md
+++ b/docs/design/03-ebpf-static-targets.md
@@ -1,0 +1,116 @@
+# eBPF capture for static-binary TLS (Bun / Claude Code) — Phase 3
+
+The dynamic-libssl eBPF source (Phase 1) attaches uprobes to `SSL_read` /
+`SSL_write` **by exported symbol**. That covers Python, curl, and anything that
+dynamically links OpenSSL/BoringSSL. It does **not** cover runtimes that
+statically link and strip their TLS stack — most importantly **Claude Code**,
+distributed as a single ~100 MB **Bun** binary with a vendored BoringSSL.
+
+This note records what we verified about that target and the mechanism that
+handles it.
+
+## De-risking findings (measured, not assumed)
+
+Two questions gate the whole approach. Both were verified empirically on a
+Linux 6.8 host with Bun 1.3.13.
+
+### 1. Does Bun's `fetch()` use HTTP/2? → **No, it offers only HTTP/1.1.**
+
+Heron's parser is HTTP/1.x only; an h2 client would decrypt to HPACK/binary
+frames we can't reconstruct. So this is existential for Phase 3.
+
+A dual-protocol Node server (`http2.createSecureServer({ allowHTTP1: true })`)
+logging each client's offered ALPN via `ALPNCallback`:
+
+| client | offered ALPN | negotiated |
+|---|---|---|
+| **Bun `fetch()`** | `[http/1.1]` | **HTTP/1.1** |
+| Node `fetch()` | `[http/1.1]` | HTTP/1.1 |
+| curl `--http1.1` (control) | `[http/1.1]` | HTTP/1.1 |
+| curl (default, control) | `[h2, http/1.1]` | HTTP/2 |
+
+Bun's fetch offers **only** `http/1.1` — it never proposes h2, so the server
+(however h2-capable, e.g. `api.anthropic.com`) can only pick HTTP/1.1. The
+captured plaintext is therefore parseable by Heron unchanged. (Note this is a
+property of the *client's* ALPN offer; a direct `node:tls` probe that explicitly
+offers `['h2','http/1.1']` does negotiate h2 with anthropic — but Bun's fetch
+doesn't make that offer.)
+
+### 2. Can we attach by symbol? → **No, Bun strips all `SSL_*` symbols.**
+
+```
+$ nm -D bun | grep -c SSL_      # dynamic symbols
+0
+$ nm  bun | grep -c SSL_        # .symtab (985 syms total, none SSL_*)
+0
+$ ldd bun | grep -i ssl         # dynamic libssl?
+(none — statically linked)
+```
+
+The binary embeds BoringSSL from `vendor/boringssl/ssl/*.cc` (the source paths
+survive as assert strings), but every TLS symbol is stripped. The only handle
+left is the **machine code** of `SSL_read` / `SSL_write` — located by byte
+signature, attached by **file offset**.
+
+## Mechanism: byte-signature → file offset → offset uprobe
+
+- `h-capture/src/ebpf/sigscan.rs` — pure, cross-platform, unit-tested. Parses an
+  ELF, scans its executable `PT_LOAD` segments for a masked byte signature
+  (`??` = wildcard, for build-varying displacements/immediates), and returns the
+  **file offsets** of matches — exactly the value the kernel uprobe API takes.
+- The loader (`source.rs`) reads the target binary, resolves a **unique** offset
+  per function (`resolve_single_offset` — zero matches = wrong/stale signature,
+  many = too-loose signature; both are refused rather than mis-attached), and
+  attaches the already-loaded BPF programs by offset (`attach_offset`).
+- `[[sources.targets]]` config carries `binary`, `flavor`, and optional
+  `write_sig` / `read_sig` patterns. **Signatures are version-specific data, not
+  code**: a BoringSSL prologue pins one Bun/Claude Code build, so it lives in
+  config and an operator can update it for a new release without a rebuild.
+
+The mechanism is verified end-to-end against real SSL functions in the system
+libssl (which has symbols, giving ground truth):
+
+- The scanner maps a 48-byte signature of `SSL_write` / `SSL_read` to exactly
+  the symbol's file offset (16-byte prologue → 5 matches, 32 → 3, 48 → **1**;
+  the shared CET+frame+canary preamble is why short signatures are ambiguous).
+- Running the smoke in **offset-attach mode** (sentinel `ssl_libs` so only the
+  byte-offset path is active) captured real HTTP/1.1 plaintext — `curl … GET /
+  HTTP/1.1`, attributed to its process — proving signature → scan → offset →
+  attach → capture → attribution end-to-end.
+
+## Deriving a signature for a Bun / Claude Code release
+
+Because the signature is build-specific, deriving it is a per-release step:
+
+1. Find a symbolized reference of the **same BoringSSL** (or disassemble the
+   target around the function located by xref to a vendored source-path string),
+   and read the first ~48 bytes of the `SSL_write` / `SSL_read` prologue.
+2. Wildcard (`??`) the 4-byte RIP-relative displacements (e.g. the `e8 ?? ?? ??
+   ??` call near the end) so the signature survives PIE/ASLR-independent relocs
+   across rebuilds of the same source.
+3. Validate uniqueness against the actual target binary:
+   ```
+   cargo run -p h-capture --example sigscan_probe -- /path/to/bun "55 41 57 ?? …"
+   ```
+   A good signature reports exactly **one** match (`OK: unique offset`).
+4. Put the validated patterns in config:
+   ```toml
+   [[sources.targets]]
+   binary = "/path/to/claude/bun"
+   flavor = "boringssl"
+   write_sig = "…"   # validated SSL_write prologue
+   read_sig  = "…"   # validated SSL_read prologue
+   ```
+
+No built-in BoringSSL signature ships (`flavor_signatures` returns none): a
+guessed-wrong signature is worse than none (it could attach to the wrong
+function), so the unique-match requirement plus operator-supplied, validated
+patterns is the safe default.
+
+## Status
+
+- Mechanism (sigscan + offset-attach + config + discovery tool): **done,
+  verified end-to-end** on a real SSL function.
+- A validated Bun/Claude Code signature: **per-release data**, derived with the
+  procedure above. Wildcarding the displacement bytes (step 2) is what makes a
+  signature resilient across patch rebuilds of one Bun line.

--- a/docs/design/03-ebpf-static-targets.md
+++ b/docs/design/03-ebpf-static-targets.md
@@ -95,6 +95,11 @@ config paths exist:
   offset at attach time. The resilient path: a signature survives ASLR and
   matches any process mapping the binary.
 
+> **Stock Bun / Claude Code needs none of this.** Set `flavor = "bun"` and the
+> built-in signatures resolve both functions automatically (see [Status](#status)).
+> The recipe below is for deriving signatures for a *new* Bun line — or another
+> stripped static BoringSSL build — that the built-ins don't yet cover.
+
 To derive either, you must first **locate `SSL_write` / `SSL_read` in the
 stripped binary**. What we learned probing Bun 1.3.13 (see below) makes the
 recipe concrete:
@@ -130,10 +135,13 @@ recipe concrete:
    read_sig  = "…"   # or read_offset  = 0x…
    ```
 
-No built-in BoringSSL signature ships (`flavor_signatures` returns none): a
-guessed-wrong signature is worse than none (it could attach to the wrong
-function), so the unique-match requirement plus operator-supplied, validated
-patterns/offsets is the safe default.
+Built-in signatures ship **only** for the `bun` flavor (`flavor = "bun"` /
+`"boringssl-bun"` / `"claude-code"`); the generic `boringssl` flavor ships
+**none** (`flavor_signatures` returns `None`). A prologue is specific to one
+statically-linked build, and a guessed-wrong signature is worse than none (it
+could attach to the wrong function) — so a non-Bun static target (or a generic
+`boringssl` flavor) must supply validated `write_sig`/`read_sig`/`*_offset` in
+config, with the unique-match requirement guarding the rest.
 
 ## Why the signature is read-anchored (Bun 1.3.x findings)
 

--- a/docs/design/03-ebpf-static-targets.md
+++ b/docs/design/03-ebpf-static-targets.md
@@ -80,7 +80,12 @@ libssl (which has symbols, giving ground truth):
 
 ## Deriving a signature for a Bun / Claude Code release
 
-Because the signature is build-specific, deriving it is a per-release step. Two
+**Bun / Claude Code works out of the box** — set `flavor = "bun"` (aliases:
+`boringssl-bun`, `claude-code`) and the loader uses built-in BoringSSL
+signatures; no offset or signature config is needed for Bun v1.3.x. The sections
+below are only needed to (re)derive signatures for a different/newer build.
+
+Because a signature is build-specific, deriving one is a per-release step. Two
 config paths exist:
 
 - `write_offset` / `read_offset` — explicit file offsets, bypass scanning. The
@@ -130,35 +135,45 @@ guessed-wrong signature is worse than none (it could attach to the wrong
 function), so the unique-match requirement plus operator-supplied, validated
 patterns/offsets is the safe default.
 
-## What we measured on Bun 1.3.13 (the hard part: entry identification)
+## Why the signature is read-anchored (Bun 1.3.x findings)
 
-The mechanism is proven; the open work is **reliably finding the function
-entry** in this specific binary shape. Recorded so a follow-up doesn't re-walk it:
+Two properties of Bun's BoringSSL shaped the built-in signatures:
 
-- Bun's BoringSSL is compiled **without CET** — functions do **not** start with
-  `endbr64`, so the easy entry marker the system libssl has is absent here.
-  Prologues are plain (`55 48 89 e5 …` push-rbp, or frame-pointer-omitted).
-- `bpftrace` located the exact write call chain: an inner cluster (`~0x3c2xxxx`,
-  the record/encrypt layer that calls `write@plt`) and outer frames
-  (`~0x42xxxxx`) on the plaintext side.
-- Offset-attach **registers correctly** against the EXEC binary
-  (`bpftool link list` shows `uprobe /…/bun+0x…` at the computed file offset;
-  the r-xp mapping `…r-xp 02808000 …/bun` confirms the delta), so aya + the
-  loader are sound on a non-PIE target.
-- The remaining blocker: int3-padding / prologue heuristics yield **basic-block
-  boundaries**, not guaranteed function entries on the executed path, in this
-  jump-dense optimized code. Pinning the true entry needs proper
-  disassembly-based function-boundary analysis (or a symbol-matched BoringSSL
-  build — out of reach without the matching toolchain). `bpftrace`'s numeric
-  uprobe (`uprobe:bin:0xADDR`) can't help validate here: it resolves addresses
-  via the symbol table, which is empty for BoringSSL, so use the
-  `HERON_EBPF_WRITE_OFFSET` path above instead.
+- It is compiled **without CET** — functions do **not** start with `endbr64`, so
+  the entry marker the system libssl has is absent. Prologues are plain push-rbp
+  (`55 48 89 e5 …`). int3-padding / prologue heuristics alone yield basic-block
+  boundaries, not reliable entries, in this jump-dense optimized code — which is
+  why a *known-good prologue signature* is the right tool, not a generic scan.
+- `SSL_read`'s prologue is distinctive and matches **uniquely**; `SSL_write`'s
+  prologue is a common register-save sequence that matches **many** times. So
+  the loader anchors on the unique `SSL_read` and locates `SSL_write` as the
+  nearest match in a window after it (`resolve_windowed`) — robust to the small
+  per-build drift in the inter-function distance (observed 0xC90 on Bun 1.3.13
+  vs ~0xCA0 elsewhere) that a hardcoded delta would miss.
+
+The prologue bytes and this read-anchored approach come from the eunomia-bpf
+**AgentSight** project (MIT), whose patterns are from "Bun v1.3.x profile
+builds". They remain version-bound data — a future Bun line may shift the
+prologue; override via config when that happens.
+
+Validating a candidate offset without a signature (e.g. while deriving one for a
+new build) uses the loader's own attach path — `bpftrace`'s numeric uprobe
+(`uprobe:bin:0xADDR`) can't help, as it resolves addresses via the symbol table
+which is empty for BoringSSL (`Could not resolve address`):
+
+```
+HERON_EBPF_TARGET_BIN=/path/to/bun HERON_EBPF_WRITE_OFFSET=0x… \
+  ./target/debug/examples/ebpf_smoke   # prints captured HTTP/1.1 if RSI is plaintext
+```
 
 ## Status
 
-- Mechanism (sigscan + offset/sig attach + config + `sigscan_probe`): **done,
-  verified end-to-end** on a real SSL function (system libssl).
+- Mechanism (sigscan + offset/sig attach + read-anchored flavor + config +
+  `sigscan_probe`): **done**.
 - De-risking: **done** — Bun fetch is HTTP/1.1; Bun is stripped static BoringSSL,
   non-CET.
-- A validated Bun/Claude Code offset or signature: **open** — needs
-  disassembly-based entry identification (above), then it is per-release data.
+- **Bun / Claude Code live capture: done.** `flavor = "bun"` resolves
+  `SSL_read`/`SSL_write` from built-in signatures and captures real Bun HTTPS
+  plaintext (`GET / HTTP/1.1` / `HTTP/1.1 200 OK`), attributed to the owning
+  process (`HTTP Client(<pid>) …/bun`), verified end-to-end on a Linux 6.8 host
+  against Bun 1.3.13. A different Bun line needs re-derived signatures (above).

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +404,37 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.11.0",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.5",
+ "log",
+ "object",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -778,6 +821,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -1301,8 +1353,10 @@ name = "h-capture"
 version = "0.5.0"
 dependencies = [
  "async-trait",
+ "aya",
  "bytes",
  "h-common",
+ "h-ebpf-common",
  "libc",
  "pcap",
  "serde",
@@ -1328,6 +1382,10 @@ dependencies = [
  "toml_edit 0.22.27",
  "tracing",
 ]
+
+[[package]]
+name = "h-ebpf-common"
+version = "0.5.0"
 
 [[package]]
 name = "h-export"
@@ -1515,6 +1573,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2230,6 +2290,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1345,6 +1345,7 @@ version = "0.5.0"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "h-capture",
  "h-common",
  "h-protocol",
  "regex",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 members = ["h-*", "app/*"]
+# h-ebpf-prog is the BPF program: it builds for `bpfel-unknown-none` with a
+# pinned nightly toolchain (see its rust-toolchain.toml) and must never be
+# pulled into a host `cargo build`. h-capture's build.rs compiles it out-of-band
+# via aya-build when the `ebpf` feature is on.
+exclude = ["h-ebpf-prog"]
 resolver = "2"
 
 [workspace.package]

--- a/server/app/heron/src/bin/storage_bench.rs
+++ b/server/app/heron/src/bin/storage_bench.rs
@@ -110,6 +110,7 @@ fn make_call(i: usize, body: &str) -> LlmCall {
         tool_call_count: 0,
         tool_names: vec![],
         body_bytes_dropped: 0,
+        process: None,
     }
 }
 

--- a/server/app/heron/src/cmd/doctor.rs
+++ b/server/app/heron/src/cmd/doctor.rs
@@ -14,7 +14,8 @@ use std::path::Path;
 use clap::Args;
 use serde::Serialize;
 use h_common::config::{
-    config_search_paths, discover_config_path, AppConfig, ConfigIssue, IssueSeverity,
+    config_search_paths, discover_config_path, AppConfig, CaptureSourceConfig, ConfigIssue,
+    IssueSeverity,
 };
 
 #[derive(Debug, Args)]
@@ -75,6 +76,7 @@ pub async fn run(config_arg: Option<&Path>, args: &DoctorArgs) -> i32 {
     let cfg = collect_config_checks(config_arg, &mut checks);
 
     checks.push(check_capture_capabilities());
+    checks.push(check_ebpf_capabilities(cfg.as_ref()));
 
     if let Some(cfg) = &cfg {
         checks.push(check_storage_path(cfg));
@@ -277,6 +279,93 @@ fn check_capture_capabilities() -> DoctorCheck {
         "capture.capabilities",
         "platform-specific capture-privilege check not implemented",
     )
+}
+
+/// True if any configured pipeline uses an `ebpf` capture source. The eBPF
+/// capability check only `fail`s when one is actually configured, so the check
+/// is a no-op nuisance on the (common) hosts that capture from pcap/NIC/ZMQ.
+fn ebpf_source_configured(cfg: Option<&AppConfig>) -> bool {
+    cfg.map(|c| {
+        c.pipelines
+            .iter()
+            .flat_map(|p| &p.sources)
+            .any(|s| matches!(s, CaptureSourceConfig::Ebpf { .. }))
+    })
+    .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn check_ebpf_capabilities(cfg: Option<&AppConfig>) -> DoctorCheck {
+    // eBPF uprobe + ring-buffer loading needs CAP_BPF + CAP_PERFMON (kernel
+    // ≥5.8) or root, plus BTF for CO-RE relocations in the connect kprobe.
+    // Capability bits per capabilities(7); root's CapEff has them all set.
+    const CAP_PERFMON_BIT: u64 = 38;
+    const CAP_BPF_BIT: u64 = 39;
+
+    let configured = ebpf_source_configured(cfg);
+
+    let btf = Path::new("/sys/kernel/btf/vmlinux").exists();
+    let kernel = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    let (has_bpf, has_perfmon) = match std::fs::read_to_string("/proc/self/status") {
+        Ok(content) => content
+            .lines()
+            .find(|l| l.starts_with("CapEff:"))
+            .and_then(|l| u64::from_str_radix(l.trim_start_matches("CapEff:").trim(), 16).ok())
+            .map(|bits| {
+                (
+                    (bits >> CAP_BPF_BIT) & 1 == 1,
+                    (bits >> CAP_PERFMON_BIT) & 1 == 1,
+                )
+            })
+            .unwrap_or((false, false)),
+        Err(_) => (false, false),
+    };
+
+    let yesno = |b: bool| if b { "yes" } else { "no" };
+    let detail = format!(
+        "kernel {kernel}, BTF {}, CAP_BPF {}, CAP_PERFMON {}",
+        if btf { "present" } else { "missing" },
+        yesno(has_bpf),
+        yesno(has_perfmon),
+    );
+
+    if !configured {
+        return DoctorCheck::pass(
+            "capture.ebpf",
+            format!("no ebpf source configured; {detail}"),
+        );
+    }
+    match (btf, has_bpf && has_perfmon) {
+        (true, true) => DoctorCheck::pass("capture.ebpf", detail),
+        (false, _) => DoctorCheck::fail(
+            "capture.ebpf",
+            format!(
+                "BTF missing (/sys/kernel/btf/vmlinux) — kernel too old or built without \
+                 CONFIG_DEBUG_INFO_BTF; {detail}"
+            ),
+        ),
+        (true, false) => DoctorCheck::fail(
+            "capture.ebpf",
+            format!(
+                "insufficient privileges — run as root or grant \
+                 `setcap cap_bpf,cap_perfmon=eip <bin>`; {detail}"
+            ),
+        ),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn check_ebpf_capabilities(cfg: Option<&AppConfig>) -> DoctorCheck {
+    if ebpf_source_configured(cfg) {
+        DoctorCheck::fail(
+            "capture.ebpf",
+            "an ebpf capture source is configured but eBPF capture is only supported on Linux",
+        )
+    } else {
+        DoctorCheck::pass("capture.ebpf", "n/a (eBPF capture is Linux-only)")
+    }
 }
 
 fn check_storage_path(cfg: &AppConfig) -> DoctorCheck {

--- a/server/h-capture/Cargo.toml
+++ b/server/h-capture/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# eBPF SSL-uprobe capture (Linux only). Off by default so macOS dev builds and
+# the Linux CI stay green without the aya/BPF toolchain. Phase 1b adds the aya
+# loader (`src/ebpf/source.rs`) + BPF program under this gate; the cross-platform
+# pump (`src/ebpf/mod.rs`) is always built and tested.
+ebpf = []
+
 [dependencies]
 h-common.workspace = true
 pcap.workspace = true

--- a/server/h-capture/Cargo.toml
+++ b/server/h-capture/Cargo.toml
@@ -6,10 +6,10 @@ license.workspace = true
 
 [features]
 # eBPF SSL-uprobe capture (Linux only). Off by default so macOS dev builds and
-# the Linux CI stay green without the aya/BPF toolchain. Phase 1b adds the aya
-# loader (`src/ebpf/source.rs`) + BPF program under this gate; the cross-platform
-# pump (`src/ebpf/mod.rs`) is always built and tested.
-ebpf = []
+# the Linux CI stay green without the aya/BPF toolchain. Enables the aya loader
+# (`src/ebpf/source.rs`) + the out-of-band BPF program build (build.rs +
+# aya-build). The cross-platform pump (`src/ebpf/mod.rs`) is always built/tested.
+ebpf = ["dep:aya", "dep:h-ebpf-common", "tokio/net"]
 
 [dependencies]
 h-common.workspace = true
@@ -25,6 +25,18 @@ tokio-util.workspace = true
 serde.workspace = true
 snap = "1"
 
+# eBPF deps are Linux-only and optional (pulled in only by the `ebpf` feature),
+# so neither macOS nor a default Linux build compiles them.
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = { version = "0.13", optional = true }
+h-ebpf-common = { path = "../h-ebpf-common", optional = true }
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+# Smoke test for live eBPF capture: runs EbpfSource and prints captured HTTP
+# request lines. Linux + `--features ebpf` + CAP_BPF only.
+[[example]]
+name = "ebpf_smoke"
+required-features = ["ebpf"]

--- a/server/h-capture/build.rs
+++ b/server/h-capture/build.rs
@@ -1,0 +1,78 @@
+//! Build script: when the `ebpf` feature is on, compile the BPF program
+//! (`h-ebpf-prog`) for `bpfel-unknown-none` and embed the result so
+//! `src/ebpf/source.rs` can load it with `include_bytes_aligned!`. A no-op for
+//! every default (non-`ebpf`) build, so macOS dev and the Linux CI never need
+//! the BPF toolchain.
+//!
+//! We invoke `cargo` directly with `--manifest-path` (rather than aya-build's
+//! `--package`) because `h-ebpf-prog` is intentionally EXCLUDED from the server
+//! workspace — it builds for a different target with a pinned nightly toolchain,
+//! and a workspace member would be pulled into `cargo test --workspace` on the
+//! host and fail. `--manifest-path` resolves it as its own standalone workspace.
+
+fn main() {
+    #[cfg(feature = "ebpf")]
+    build_bpf();
+}
+
+#[cfg(feature = "ebpf")]
+fn build_bpf() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let prog_manifest = format!("{manifest_dir}/../h-ebpf-prog/Cargo.toml");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR");
+    let target_dir = format!("{out_dir}/h-ebpf-prog-target");
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".to_string());
+
+    println!("cargo:rerun-if-changed=../h-ebpf-prog/src");
+    println!("cargo:rerun-if-changed=../h-ebpf-prog/Cargo.toml");
+    println!("cargo:rerun-if-changed=../h-ebpf-common/src");
+
+    // RUSTFLAGS for the BPF compile, encoded for CARGO_ENCODED_RUSTFLAGS (one
+    // \x1f-separated token each). `bpf_target_arch` is read by aya-ebpf;
+    // `--btf` makes bpf-linker emit BTF for CO-RE.
+    let rustflags = [
+        "--cfg".to_string(),
+        format!("bpf_target_arch=\"{arch}\""),
+        "-Cdebuginfo=2".to_string(),
+        "-Clink-arg=--btf".to_string(),
+    ]
+    .join("\x1f");
+
+    let status = Command::new("rustup")
+        .args([
+            "run",
+            "nightly",
+            "cargo",
+            "build",
+            "--manifest-path",
+            &prog_manifest,
+            "-Z",
+            "build-std=core",
+            "--release",
+            "--target",
+            "bpfel-unknown-none",
+            "--target-dir",
+            &target_dir,
+        ])
+        .env("CARGO_ENCODED_RUSTFLAGS", rustflags)
+        // Don't leak the host workspace's rustc wrapper into the BPF build.
+        .env_remove("RUSTC")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .status()
+        .expect("spawn cargo for h-ebpf-prog");
+    assert!(status.success(), "h-ebpf-prog BPF build failed");
+
+    let produced =
+        PathBuf::from(&target_dir).join("bpfel-unknown-none/release/h-ebpf-prog");
+    let dest = PathBuf::from(&out_dir).join("h-ebpf-prog");
+    std::fs::copy(&produced, &dest).unwrap_or_else(|e| {
+        panic!(
+            "copy BPF object {} -> {}: {e}",
+            produced.display(),
+            dest.display()
+        )
+    });
+}

--- a/server/h-capture/examples/ebpf_smoke.rs
+++ b/server/h-capture/examples/ebpf_smoke.rs
@@ -23,10 +23,29 @@ use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() {
+    // Phase-3 mode: when HERON_EBPF_TARGET_BIN is set, attach by byte-signature
+    // offset to a static target instead of dynamic libssl. `*_SIG` are prologue
+    // patterns (see `sigscan_probe`). A sentinel `ssl_libs` path is filtered out
+    // by the loader, isolating the offset-attach path so this exercises Phase 3
+    // end-to-end (signature → scan → offset → attach → capture).
+    let (ssl_libs, targets) = match std::env::var("HERON_EBPF_TARGET_BIN") {
+        Ok(bin) if !bin.is_empty() => {
+            let target = h_common::config::EbpfTarget {
+                binary: bin,
+                flavor: std::env::var("HERON_EBPF_FLAVOR").unwrap_or_else(|_| "boringssl".into()),
+                write_sig: std::env::var("HERON_EBPF_WRITE_SIG").ok().filter(|s| !s.is_empty()),
+                read_sig: std::env::var("HERON_EBPF_READ_SIG").ok().filter(|s| !s.is_empty()),
+            };
+            eprintln!("ebpf-smoke: Phase-3 offset-attach target = {}", target.binary);
+            (vec!["/heron/no-dynamic-libssl".to_string()], vec![target])
+        }
+        _ => (vec![], vec![]), // default: autodetect dynamic libssl
+    };
+
     let config = CaptureSourceConfig::Ebpf {
         source_id: Some("ebpf-smoke".to_string()),
-        ssl_libs: vec![],     // autodetect
-        targets: vec![],
+        ssl_libs,
+        targets,
         pid_allowlist: vec![], // all processes
         segment_size: 16 * 1024,
     };

--- a/server/h-capture/examples/ebpf_smoke.rs
+++ b/server/h-capture/examples/ebpf_smoke.rs
@@ -30,11 +30,20 @@ async fn main() {
     // end-to-end (signature → scan → offset → attach → capture).
     let (ssl_libs, targets) = match std::env::var("HERON_EBPF_TARGET_BIN") {
         Ok(bin) if !bin.is_empty() => {
+            let parse_off = |k: &str| -> Option<u64> {
+                std::env::var(k).ok().and_then(|s| {
+                    let s = s.trim();
+                    let s = s.strip_prefix("0x").unwrap_or(s);
+                    u64::from_str_radix(s, 16).ok()
+                })
+            };
             let target = h_common::config::EbpfTarget {
                 binary: bin,
                 flavor: std::env::var("HERON_EBPF_FLAVOR").unwrap_or_else(|_| "boringssl".into()),
                 write_sig: std::env::var("HERON_EBPF_WRITE_SIG").ok().filter(|s| !s.is_empty()),
                 read_sig: std::env::var("HERON_EBPF_READ_SIG").ok().filter(|s| !s.is_empty()),
+                write_offset: parse_off("HERON_EBPF_WRITE_OFFSET"),
+                read_offset: parse_off("HERON_EBPF_READ_OFFSET"),
             };
             eprintln!("ebpf-smoke: Phase-3 offset-attach target = {}", target.binary);
             (vec!["/heron/no-dynamic-libssl".to_string()], vec![target])

--- a/server/h-capture/examples/ebpf_smoke.rs
+++ b/server/h-capture/examples/ebpf_smoke.rs
@@ -1,9 +1,10 @@
 //! Live eBPF capture smoke test.
 //!
 //! Runs the eBPF `SSL_read`/`SSL_write` capture source and prints the HTTP
-//! request lines it reconstructs from synthesized frames. Proves the
-//! uprobe → ring buffer → frame-synthesis path against real `libssl` traffic
-//! without the rest of the pipeline.
+//! request lines it reconstructs from synthesized frames, each tagged with the
+//! owning process (`comm`/pid/exe) the kernel attributed it to. Proves the
+//! uprobe → ring buffer → frame-synthesis → process-attribution path against
+//! real `libssl` traffic without the rest of the pipeline.
 //!
 //! Usage (Linux, needs CAP_BPF / root):
 //!   sudo -E ~/.cargo/bin/cargo run -p h-capture --features ebpf --example ebpf_smoke
@@ -63,12 +64,27 @@ async fn main() {
                     continue;
                 }
                 pkts += 1;
+                // The differentiating value of the eBPF path: each frame is
+                // attributed to the local process that owns the connection.
+                let who = pkt
+                    .process
+                    .as_ref()
+                    .map(|p| {
+                        let exe = p.exe.as_deref().map(|e| format!(" {e}")).unwrap_or_default();
+                        format!("{}({}){}", p.comm, p.pid, exe)
+                    })
+                    .unwrap_or_else(|| "—".to_string());
                 if let Some(line) = http_first_line(&pkt.data) {
                     req_lines += 1;
-                    println!("  [{pkts:>4}] {line}");
+                    println!("  [{pkts:>4}] {who:<40} {line}");
                     if req_lines >= 8 {
                         break;
                     }
+                } else if pkts <= 12 {
+                    // Even when the payload isn't an HTTP/1.x first line (HTTP/2
+                    // framing, TLS control, mid-body), show the attribution +
+                    // a printable preview so the process tagging is visible live.
+                    println!("  [{pkts:>4}] {who:<40} {}", payload_preview(&pkt.data));
                 }
             }
         }
@@ -81,6 +97,38 @@ async fn main() {
         eprintln!("ebpf-smoke: no HTTP lines captured — check libssl detection / privileges");
         std::process::exit(1);
     }
+}
+
+/// Return the TCP payload of a synthesized IPv4 frame, if any.
+fn tcp_payload(frame: &[u8]) -> Option<&[u8]> {
+    const ETH: usize = 14;
+    if frame.len() < ETH + 20 + 20 || (frame[ETH] >> 4) != 4 {
+        return None;
+    }
+    let ihl = ((frame[ETH] & 0x0f) as usize) * 4;
+    let tcp = ETH + ihl;
+    if frame.len() < tcp + 20 {
+        return None;
+    }
+    let data_off = ((frame[tcp + 12] >> 4) as usize) * 4;
+    frame.get(tcp + data_off..)
+}
+
+/// A short printable preview of a frame's TCP payload (non-printable bytes as
+/// `.`), for frames that aren't an HTTP/1.x first line.
+fn payload_preview(frame: &[u8]) -> String {
+    let Some(p) = tcp_payload(frame) else {
+        return "(no payload)".to_string();
+    };
+    if p.is_empty() {
+        return "(empty / control)".to_string();
+    }
+    let preview: String = p
+        .iter()
+        .take(40)
+        .map(|&b| if b.is_ascii_graphic() || b == b' ' { b as char } else { '.' })
+        .collect();
+    format!("{}B: {preview}", p.len())
 }
 
 /// Extract the first line of an HTTP message from a synthesized Ethernet+IPv4

--- a/server/h-capture/examples/ebpf_smoke.rs
+++ b/server/h-capture/examples/ebpf_smoke.rs
@@ -1,0 +1,113 @@
+//! Live eBPF capture smoke test.
+//!
+//! Runs the eBPF `SSL_read`/`SSL_write` capture source and prints the HTTP
+//! request lines it reconstructs from synthesized frames. Proves the
+//! uprobe → ring buffer → frame-synthesis path against real `libssl` traffic
+//! without the rest of the pipeline.
+//!
+//! Usage (Linux, needs CAP_BPF / root):
+//!   sudo -E ~/.cargo/bin/cargo run -p h-capture --features ebpf --example ebpf_smoke
+//! then, in another shell, generate TLS traffic:
+//!   python3 -c "import urllib.request as u; u.urlopen('https://example.com').read()"
+//!
+//! Exits after ~20s or once it has printed a few requests.
+
+use std::time::Duration;
+
+use h_capture::{build_source, RawPacket};
+use h_common::config::CaptureSourceConfig;
+use h_common::internal_metrics::{Metric, MetricsSystem};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::main]
+async fn main() {
+    let config = CaptureSourceConfig::Ebpf {
+        source_id: Some("ebpf-smoke".to_string()),
+        ssl_libs: vec![],     // autodetect
+        targets: vec![],
+        pid_allowlist: vec![], // all processes
+        segment_size: 16 * 1024,
+    };
+
+    let source = build_source(&config, None).expect("build ebpf source");
+
+    let mut sys = MetricsSystem::new();
+    let metrics = sys.register_worker("ebpf-smoke", Metric::ALL);
+    let _ = sys.start();
+
+    let (tx, mut rx) = mpsc::channel::<RawPacket>(1024);
+    let cancel = CancellationToken::new();
+    let cancel2 = cancel.clone();
+    let handle = tokio::spawn(async move {
+        if let Err(e) = source
+            .run(h_capture::RoutingSender::single(tx), metrics, cancel2)
+            .await
+        {
+            eprintln!("source error: {e}");
+        }
+    });
+
+    println!("ebpf-smoke: capturing for 20s — generate HTTPS traffic now...");
+    let deadline = tokio::time::sleep(Duration::from_secs(20));
+    tokio::pin!(deadline);
+
+    let mut pkts = 0u64;
+    let mut req_lines = 0u64;
+    loop {
+        tokio::select! {
+            _ = &mut deadline => break,
+            maybe = rx.recv() => {
+                let Some(pkt) = maybe else { break };
+                if pkt.is_heartbeat() {
+                    continue;
+                }
+                pkts += 1;
+                if let Some(line) = http_first_line(&pkt.data) {
+                    req_lines += 1;
+                    println!("  [{pkts:>4}] {line}");
+                    if req_lines >= 8 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    println!("ebpf-smoke: done — {pkts} data frames, {req_lines} HTTP request/response lines");
+    if req_lines == 0 {
+        eprintln!("ebpf-smoke: no HTTP lines captured — check libssl detection / privileges");
+        std::process::exit(1);
+    }
+}
+
+/// Extract the first line of an HTTP message from a synthesized Ethernet+IPv4
+/// +TCP frame, if the TCP payload starts with an HTTP request method or status.
+fn http_first_line(frame: &[u8]) -> Option<String> {
+    // Ethernet(14) + IPv4(IHL*4) + TCP(data_offset*4).
+    const ETH: usize = 14;
+    if frame.len() < ETH + 20 + 20 {
+        return None;
+    }
+    if (frame[ETH] >> 4) != 4 {
+        return None; // IPv4 only
+    }
+    let ihl = ((frame[ETH] & 0x0f) as usize) * 4;
+    let tcp = ETH + ihl;
+    if frame.len() < tcp + 20 {
+        return None;
+    }
+    let data_off = ((frame[tcp + 12] >> 4) as usize) * 4;
+    let payload = &frame[tcp + data_off..];
+    const METHODS: [&[u8]; 6] = [b"GET ", b"POST ", b"PUT ", b"HEAD ", b"PATCH ", b"HTTP"];
+    if !METHODS.iter().any(|m| payload.starts_with(m)) {
+        return None;
+    }
+    let end = payload
+        .iter()
+        .position(|&b| b == b'\r' || b == b'\n')
+        .unwrap_or(payload.len().min(80));
+    Some(String::from_utf8_lossy(&payload[..end]).into_owned())
+}

--- a/server/h-capture/examples/sigscan_probe.rs
+++ b/server/h-capture/examples/sigscan_probe.rs
@@ -1,0 +1,53 @@
+//! Offset-discovery helper for static-binary (Bun/BoringSSL) eBPF targets.
+//!
+//! Scans an ELF for a byte signature and prints the matching **file offsets** —
+//! the values to put in a `[[sources.targets]]` `write_sig` / `read_sig` config
+//! (the loader resolves the same offsets at attach time via the same scanner).
+//!
+//! Usage:
+//!   cargo run -p h-capture --example sigscan_probe -- <binary> "<hex pattern>"
+//! e.g.
+//!   cargo run -p h-capture --example sigscan_probe -- ~/.bun/bin/bun "55 41 57 ?? 48 8b"
+//!
+//! A unique single match is what a good signature yields; zero means the
+//! pattern is wrong for this build, and many means it is too loose.
+
+use h_capture::ebpf::sigscan::{scan_elf_executable, Signature};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let (Some(binary), Some(pattern)) = (args.next(), args.next()) else {
+        eprintln!("usage: sigscan_probe <binary> \"<hex pattern with ?? wildcards>\"");
+        std::process::exit(2);
+    };
+
+    let data = match std::fs::read(&binary) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("read {binary}: {e}");
+            std::process::exit(1);
+        }
+    };
+    let Some(sig) = Signature::parse(&pattern) else {
+        eprintln!("malformed pattern: {pattern:?}");
+        std::process::exit(2);
+    };
+
+    let hits = scan_elf_executable(&data, &sig);
+    println!(
+        "{binary}: {} byte signature, {} match(es) in executable segments",
+        sig.len(),
+        hits.len()
+    );
+    for off in &hits {
+        println!("  offset {off:#x} ({off})");
+    }
+    match hits.len() {
+        1 => println!("OK: unique offset — usable as a uprobe attach point"),
+        0 => {
+            println!("MISS: no match (wrong build / signature)");
+            std::process::exit(1);
+        }
+        n => println!("AMBIGUOUS: {n} matches — refine the signature for a unique hit"),
+    }
+}

--- a/server/h-capture/src/cloud_probe.rs
+++ b/server/h-capture/src/cloud_probe.rs
@@ -105,6 +105,7 @@ pub(crate) fn parse_batch(bytes: &[u8]) -> Result<(String, Vec<RawPacket>), Batc
             link_type: LINKTYPE_ETHERNET,
             data,
             source_id: String::new(),
+            process: None,
         });
     }
 
@@ -480,6 +481,7 @@ mod tests {
             link_type: LINKTYPE_ETHERNET,
             data: Bytes::from_static(&[0xAA, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x08, 0x00]),
             source_id: "u1".to_string(),
+            process: None,
         };
         assert!(t.on_packet(&p).is_none());
         p.timestamp_us += HEARTBEAT_INTERVAL_US;

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -1,0 +1,361 @@
+//! eBPF SSL-uprobe capture source (Linux only).
+//!
+//! An eBPF program attached to `SSL_read` / `SSL_write` (Phase 1: dynamically
+//! linked OpenSSL / BoringSSL) hands userspace the plaintext of TLS-encrypted
+//! traffic — per connection, per direction — before/after the library
+//! encrypts it. That lets Heron observe LLM API calls to external providers
+//! (e.g. `api.anthropic.com`) on the host, with no proxy in the request path.
+//!
+//! This module is split into:
+//! * a **cross-platform core** — [`SslEvent`], [`BootClock`], [`EbpfPump`] —
+//!   that turns a stream of decoded SSL events into synthetic [`RawPacket`]s
+//!   via [`FlowSynthesizer`](crate::synth::FlowSynthesizer), and
+//! * a **Linux-only loader** ([`EbpfSource`]) that loads the BPF programs,
+//!   attaches the uprobes, polls the ring buffer, decodes raw events, and
+//!   feeds them to the pump.
+//!
+//! The pump is the userspace half's only non-trivial logic, so it lives in the
+//! cross-platform core and is unit-tested on every platform. The loader is a
+//! thin, Linux-gated shell around it.
+
+use bytes::Bytes;
+
+use crate::heartbeat::HeartbeatTracker;
+use crate::packet::RawPacket;
+use crate::synth::{ConnTuple, FlowSynthesizer, StreamDir, SynthConfig};
+
+// The aya loader (`source.rs`, the `EbpfSource` CaptureSource impl) pulls in
+// Linux-only native dependencies and the off-tree BPF program. It is gated
+// behind both the target OS and the off-by-default `ebpf` cargo feature, so
+// default builds — macOS dev and the Linux CI alike — never compile it and stay
+// green. Enable with `--features ebpf` on a Linux host (CAP_BPF + BTF) to build
+// real capture. Landed in Phase 1b; until then the capture factory returns a
+// clear "not available" error for `ebpf` sources.
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
+mod source;
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
+pub use source::EbpfSource;
+
+/// Maximum length of a process `comm` (matches the kernel `TASK_COMM_LEN`).
+pub const COMM_LEN: usize = 16;
+
+/// A decoded event from the BPF ring buffer.
+///
+/// `conn_id` is a stable per-connection handle (the `SSL*` pointer value, which
+/// is unique among live connections in a process); combined with the pid it
+/// uniquely identifies one TLS connection. `ktime_ns` is the kernel monotonic
+/// timestamp (`bpf_ktime_get_ns`), converted to wall-clock by [`BootClock`].
+#[derive(Debug, Clone)]
+pub enum SslEvent {
+    /// A connection was established (`SSL_set_fd` / first activity). Carries the
+    /// real socket 5-tuple when recovered (connect kprobe), else `None` and the
+    /// pump synthesizes a stable placeholder tuple.
+    Connect {
+        conn_id: u64,
+        pid: u32,
+        comm: String,
+        tuple: Option<ConnTuple>,
+        ktime_ns: u64,
+    },
+    /// Plaintext bytes observed in one direction (`SSL_write` ⇒
+    /// [`StreamDir::ClientToServer`], `SSL_read` ⇒
+    /// [`StreamDir::ServerToClient`]).
+    Data {
+        conn_id: u64,
+        pid: u32,
+        comm: String,
+        dir: StreamDir,
+        data: Bytes,
+        ktime_ns: u64,
+    },
+    /// The connection was torn down (`SSL_shutdown` / `close`).
+    Close { conn_id: u64, ktime_ns: u64 },
+}
+
+impl SslEvent {
+    fn pid(&self) -> Option<u32> {
+        match self {
+            SslEvent::Connect { pid, .. } | SslEvent::Data { pid, .. } => Some(*pid),
+            SslEvent::Close { .. } => None,
+        }
+    }
+
+    fn ktime_ns(&self) -> u64 {
+        match self {
+            SslEvent::Connect { ktime_ns, .. }
+            | SslEvent::Data { ktime_ns, .. }
+            | SslEvent::Close { ktime_ns, .. } => *ktime_ns,
+        }
+    }
+}
+
+/// Converts a kernel monotonic timestamp (`bpf_ktime_get_ns`, nanoseconds since
+/// boot) into Unix-epoch microseconds, which is what [`RawPacket::timestamp_us`]
+/// requires. The offset between the two clocks is sampled once at construction.
+#[derive(Debug, Clone, Copy)]
+pub struct BootClock {
+    /// `epoch_us - monotonic_us`, added to every converted timestamp.
+    offset_us: i64,
+}
+
+impl BootClock {
+    /// Build a clock from an explicit offset. Used by tests and as the building
+    /// block for [`from_system`](Self::from_system).
+    pub fn with_offset_us(offset_us: i64) -> Self {
+        Self { offset_us }
+    }
+
+    /// Sample the live `CLOCK_REALTIME - CLOCK_MONOTONIC` offset (Linux). The
+    /// monotonic clock is the same source as `bpf_ktime_get_ns`.
+    #[cfg(target_os = "linux")]
+    pub fn from_system() -> Self {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        // SAFETY: clock_gettime with a valid clock id and timespec out-param.
+        let mono_ns = {
+            let mut ts = libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            };
+            unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+            ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
+        };
+        let epoch_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        Self {
+            offset_us: (epoch_ns - mono_ns) / 1_000,
+        }
+    }
+
+    /// Convert a `bpf_ktime_get_ns` value to Unix-epoch microseconds.
+    pub fn ktime_to_epoch_us(&self, ktime_ns: u64) -> i64 {
+        (ktime_ns / 1_000) as i64 + self.offset_us
+    }
+}
+
+/// Drives a [`FlowSynthesizer`] and [`HeartbeatTracker`] from a stream of
+/// [`SslEvent`]s, producing the [`RawPacket`]s to forward downstream.
+///
+/// This is the testable heart of the eBPF userspace path. The Linux loader does
+/// only IO around it: poll the ring buffer, decode bytes into [`SslEvent`],
+/// call [`on_event`](Self::on_event), and send the returned packets.
+#[derive(Debug)]
+pub struct EbpfPump {
+    synth: FlowSynthesizer,
+    heartbeat: HeartbeatTracker,
+    clock: BootClock,
+    /// When non-empty, only these PIDs are captured.
+    pid_allowlist: Vec<u32>,
+}
+
+impl EbpfPump {
+    pub fn new(cfg: SynthConfig, clock: BootClock, pid_allowlist: Vec<u32>) -> Self {
+        Self {
+            synth: FlowSynthesizer::new(cfg),
+            heartbeat: HeartbeatTracker::new(),
+            clock,
+            pid_allowlist,
+        }
+    }
+
+    /// Number of live connections currently tracked (for metrics/observability).
+    pub fn conn_count(&self) -> usize {
+        self.synth.conn_count()
+    }
+
+    /// Process one decoded SSL event and return the [`RawPacket`]s to forward,
+    /// in order. Each data/handshake/FIN frame is preceded by a synthesized
+    /// heartbeat when ≥1 s of event-time has elapsed since the last one, so the
+    /// downstream stages' time-driven windows advance even on sparse traffic.
+    pub fn on_event(&mut self, ev: SslEvent) -> Vec<RawPacket> {
+        // PID allowlist: drop events from processes we are not capturing. Close
+        // events have no pid; let them through so connections still finalize.
+        if !self.pid_allowlist.is_empty() {
+            if let Some(pid) = ev.pid() {
+                if !self.pid_allowlist.contains(&pid) {
+                    return Vec::new();
+                }
+            }
+        }
+
+        let ts_us = self.clock.ktime_to_epoch_us(ev.ktime_ns());
+        let frames = match ev {
+            SslEvent::Connect {
+                conn_id, tuple, ..
+            } => {
+                let tuple = tuple.unwrap_or_else(|| FlowSynthesizer::synthetic_tuple(conn_id));
+                self.synth.open(conn_id, tuple, ts_us)
+            }
+            SslEvent::Data {
+                conn_id, dir, data, ..
+            } => self.synth.data(conn_id, dir, &data, ts_us),
+            SslEvent::Close { conn_id, .. } => self.synth.close(conn_id, ts_us),
+        };
+
+        // Interleave heartbeats ahead of the frames they precede, mirroring
+        // cloud_probe.rs: the tracker emits at most one HB per interval.
+        let mut out = Vec::with_capacity(frames.len());
+        for frame in frames {
+            if let Some(hb) = self.heartbeat.on_packet(&frame) {
+                out.push(hb);
+            }
+            out.push(frame);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::heartbeat::HEARTBEAT_INTERVAL_US;
+
+    fn pump(allowlist: Vec<u32>) -> EbpfPump {
+        // Offset 0: ktime µs maps straight to epoch µs, keeping test math simple.
+        EbpfPump::new(SynthConfig::default(), BootClock::with_offset_us(0), allowlist)
+    }
+
+    fn tuple() -> ConnTuple {
+        ConnTuple {
+            client: "10.0.0.9:40000".parse().unwrap(),
+            server: "203.0.113.7:443".parse().unwrap(),
+        }
+    }
+
+    fn data_frame_count(pkts: &[RawPacket]) -> usize {
+        pkts.iter().filter(|p| !p.is_heartbeat()).count()
+    }
+
+    #[test]
+    fn boot_clock_converts_ktime_to_epoch() {
+        let c = BootClock::with_offset_us(1_000_000);
+        // 5_000_000 ns = 5_000 µs; + 1_000_000 µs offset = 1_005_000.
+        assert_eq!(c.ktime_to_epoch_us(5_000_000), 1_005_000);
+    }
+
+    #[test]
+    fn connect_with_handshake_emits_syn_synack() {
+        let mut p = pump(vec![]);
+        let frames = p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 100,
+            comm: "python3".into(),
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        assert_eq!(data_frame_count(&frames), 2, "SYN + SYN-ACK");
+        assert_eq!(p.conn_count(), 1);
+    }
+
+    #[test]
+    fn data_event_emits_segment() {
+        let mut p = pump(vec![]);
+        p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 100,
+            comm: "python3".into(),
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        let frames = p.on_event(SslEvent::Data {
+            conn_id: 1,
+            pid: 100,
+            comm: "python3".into(),
+            dir: StreamDir::ClientToServer,
+            data: Bytes::from_static(b"POST /v1/messages HTTP/1.1\r\n\r\n"),
+            ktime_ns: 1_100_000,
+        });
+        assert_eq!(data_frame_count(&frames), 1);
+    }
+
+    #[test]
+    fn close_event_emits_fins_and_forgets_conn() {
+        let mut p = pump(vec![]);
+        p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 100,
+            comm: "c".into(),
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        let frames = p.on_event(SslEvent::Close {
+            conn_id: 1,
+            ktime_ns: 1_200_000,
+        });
+        assert_eq!(data_frame_count(&frames), 2, "FIN both directions");
+        assert_eq!(p.conn_count(), 0);
+    }
+
+    #[test]
+    fn pid_allowlist_filters_other_processes() {
+        let mut p = pump(vec![100]);
+        // Allowed pid passes.
+        let ok = p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 100,
+            comm: "c".into(),
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        assert_eq!(data_frame_count(&ok), 2);
+        // Disallowed pid is dropped — no frames, no connection registered.
+        let dropped = p.on_event(SslEvent::Connect {
+            conn_id: 2,
+            pid: 999,
+            comm: "other".into(),
+            tuple: Some(tuple()),
+            ktime_ns: 1_050_000,
+        });
+        assert!(dropped.is_empty());
+        assert_eq!(p.conn_count(), 1, "only the allowed connection registered");
+    }
+
+    #[test]
+    fn unknown_tuple_falls_back_to_synthetic() {
+        let mut p = pump(vec![]);
+        // Connect with no recovered tuple → pump must synthesize one and still
+        // emit the handshake.
+        let frames = p.on_event(SslEvent::Connect {
+            conn_id: 77,
+            pid: 100,
+            comm: "c".into(),
+            tuple: None,
+            ktime_ns: 1_000_000,
+        });
+        assert_eq!(data_frame_count(&frames), 2);
+        assert!(p.conn_count() == 1);
+    }
+
+    #[test]
+    fn heartbeat_synthesized_after_interval() {
+        let mut p = pump(vec![]);
+        // First data primes the heartbeat baseline (no HB yet).
+        let f0 = p.on_event(SslEvent::Data {
+            conn_id: 1,
+            pid: 100,
+            comm: "c".into(),
+            dir: StreamDir::ClientToServer,
+            data: Bytes::from_static(b"GET / HTTP/1.1\r\n"),
+            ktime_ns: 1_000 * 1_000, // 1_000_000 ns = 1_000 µs
+        });
+        assert_eq!(f0.iter().filter(|p| p.is_heartbeat()).count(), 0);
+
+        // A data event > 1 s later (in event-time µs) must be preceded by a
+        // synthesized heartbeat.
+        let later_ns = (1_000 + HEARTBEAT_INTERVAL_US as u64) * 1_000;
+        let f1 = p.on_event(SslEvent::Data {
+            conn_id: 1,
+            pid: 100,
+            comm: "c".into(),
+            dir: StreamDir::ClientToServer,
+            data: Bytes::from_static(b"X"),
+            ktime_ns: later_ns,
+        });
+        assert_eq!(
+            f1.iter().filter(|p| p.is_heartbeat()).count(),
+            1,
+            "one heartbeat precedes the late frame"
+        );
+    }
+}

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -20,6 +20,8 @@
 
 use bytes::Bytes;
 
+use h_common::process::ProcessInfo;
+
 use crate::heartbeat::HeartbeatTracker;
 use crate::packet::RawPacket;
 use crate::synth::{ConnTuple, FlowSynthesizer, StreamDir, SynthConfig};
@@ -54,6 +56,9 @@ pub enum SslEvent {
         conn_id: u64,
         pid: u32,
         comm: String,
+        /// Best-effort absolute executable path, resolved in userspace by the
+        /// loader (`/proc/<pid>/exe`). `None` when unresolved.
+        exe: Option<String>,
         tuple: Option<ConnTuple>,
         ktime_ns: u64,
     },
@@ -64,6 +69,8 @@ pub enum SslEvent {
         conn_id: u64,
         pid: u32,
         comm: String,
+        /// Best-effort absolute executable path (see [`SslEvent::Connect`]).
+        exe: Option<String>,
         dir: StreamDir,
         data: Bytes,
         ktime_ns: u64,
@@ -76,6 +83,26 @@ impl SslEvent {
     fn pid(&self) -> Option<u32> {
         match self {
             SslEvent::Connect { pid, .. } | SslEvent::Data { pid, .. } => Some(*pid),
+            SslEvent::Close { .. } => None,
+        }
+    }
+
+    /// Process attribution carried by this event, if any. `Connect`/`Data`
+    /// events carry the owning process (pid + comm + best-effort exe); `Close`
+    /// events do not (the FIN frames they synthesize carry no HTTP payload, so
+    /// the flow has already learned the process from an earlier data frame).
+    fn process(&self) -> Option<ProcessInfo> {
+        match self {
+            SslEvent::Connect {
+                pid, comm, exe, ..
+            }
+            | SslEvent::Data {
+                pid, comm, exe, ..
+            } => Some(ProcessInfo {
+                pid: *pid,
+                comm: comm.clone(),
+                exe: exe.clone(),
+            }),
             SslEvent::Close { .. } => None,
         }
     }
@@ -180,6 +207,10 @@ impl EbpfPump {
         }
 
         let ts_us = self.clock.ktime_to_epoch_us(ev.ktime_ns());
+        // Snapshot the owning process before the match consumes `ev`. Stamped
+        // onto every synthesized data/handshake frame below so the flow learns
+        // the attribution; `Close` carries no process (its FINs need none).
+        let process = ev.process();
         let frames = match ev {
             SslEvent::Connect {
                 conn_id, tuple, ..
@@ -196,10 +227,12 @@ impl EbpfPump {
         // Interleave heartbeats ahead of the frames they precede, mirroring
         // cloud_probe.rs: the tracker emits at most one HB per interval.
         let mut out = Vec::with_capacity(frames.len());
-        for frame in frames {
+        for mut frame in frames {
             if let Some(hb) = self.heartbeat.on_packet(&frame) {
+                // Heartbeats are sentinels discarded before parse — no process.
                 out.push(hb);
             }
+            frame.process = process.clone();
             out.push(frame);
         }
         out
@@ -241,6 +274,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "python3".into(),
+            exe: None,
             tuple: Some(tuple()),
             ktime_ns: 1_000_000,
         });
@@ -255,6 +289,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "python3".into(),
+            exe: None,
             tuple: Some(tuple()),
             ktime_ns: 1_000_000,
         });
@@ -262,6 +297,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "python3".into(),
+            exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"POST /v1/messages HTTP/1.1\r\n\r\n"),
             ktime_ns: 1_100_000,
@@ -276,6 +312,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "c".into(),
+            exe: None,
             tuple: Some(tuple()),
             ktime_ns: 1_000_000,
         });
@@ -295,6 +332,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "c".into(),
+            exe: None,
             tuple: Some(tuple()),
             ktime_ns: 1_000_000,
         });
@@ -304,6 +342,7 @@ mod tests {
             conn_id: 2,
             pid: 999,
             comm: "other".into(),
+            exe: None,
             tuple: Some(tuple()),
             ktime_ns: 1_050_000,
         });
@@ -320,6 +359,7 @@ mod tests {
             conn_id: 77,
             pid: 100,
             comm: "c".into(),
+            exe: None,
             tuple: None,
             ktime_ns: 1_000_000,
         });
@@ -335,6 +375,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "c".into(),
+            exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"GET / HTTP/1.1\r\n"),
             ktime_ns: 1_000 * 1_000, // 1_000_000 ns = 1_000 µs
@@ -348,6 +389,7 @@ mod tests {
             conn_id: 1,
             pid: 100,
             comm: "c".into(),
+            exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"X"),
             ktime_ns: later_ns,
@@ -357,5 +399,58 @@ mod tests {
             1,
             "one heartbeat precedes the late frame"
         );
+    }
+
+    #[test]
+    fn data_frames_carry_process_attribution() {
+        let mut p = pump(vec![]);
+        p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 4242,
+            comm: "python3".into(),
+            exe: Some("/usr/bin/python3.12".into()),
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        let frames = p.on_event(SslEvent::Data {
+            conn_id: 1,
+            pid: 4242,
+            comm: "python3".into(),
+            exe: Some("/usr/bin/python3.12".into()),
+            dir: StreamDir::ClientToServer,
+            data: Bytes::from_static(b"POST /v1/messages HTTP/1.1\r\n\r\n"),
+            ktime_ns: 1_100_000,
+        });
+        // The data segment carries the owning process; pid/comm/exe survive
+        // synthesis intact.
+        let data = frames
+            .iter()
+            .find(|f| !f.is_heartbeat())
+            .expect("one data frame");
+        let proc = data.process.as_ref().expect("process stamped");
+        assert_eq!(proc.pid, 4242);
+        assert_eq!(proc.comm, "python3");
+        assert_eq!(proc.exe.as_deref(), Some("/usr/bin/python3.12"));
+    }
+
+    #[test]
+    fn close_frames_carry_no_process() {
+        let mut p = pump(vec![]);
+        p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 7,
+            comm: "node".into(),
+            exe: None,
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        let fins = p.on_event(SslEvent::Close {
+            conn_id: 1,
+            ktime_ns: 1_200_000,
+        });
+        // FIN frames carry no payload, hence no attribution to stamp.
+        for f in fins.iter().filter(|f| !f.is_heartbeat()) {
+            assert!(f.process.is_none());
+        }
     }
 }

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -38,6 +38,11 @@ mod source;
 #[cfg(all(target_os = "linux", feature = "ebpf"))]
 pub use source::EbpfSource;
 
+// Byte-signature scanning for offset-based uprobe attach on symbol-stripped
+// static TLS stacks (Bun/BoringSSL, Phase 3). Pure + cross-platform so the
+// matcher is built and unit-tested on every host, like `synth`.
+pub mod sigscan;
+
 /// Maximum length of a process `comm` (matches the kernel `TASK_COMM_LEN`).
 pub const COMM_LEN: usize = 16;
 

--- a/server/h-capture/src/ebpf/sigscan.rs
+++ b/server/h-capture/src/ebpf/sigscan.rs
@@ -1,0 +1,268 @@
+//! Byte-signature scanning for offset-based uprobe attach (Phase 3).
+//!
+//! Statically-linked, symbol-stripped TLS stacks — notably Bun's vendored
+//! BoringSSL inside the Claude Code binary — expose no `SSL_read` / `SSL_write`
+//! symbol to attach a uprobe to (`nm -D` and `.symtab` both empty of `SSL_*`).
+//! The only handle left is the machine code itself: locate the function by a
+//! masked byte signature of its prologue, then attach the uprobe at that **file
+//! offset** (the kernel uprobe API takes a file offset into the binary's inode,
+//! which for an executable segment equals the on-disk offset of the
+//! instruction).
+//!
+//! This module is **pure and cross-platform**: it parses an ELF image from a
+//! byte slice and scans its executable `PT_LOAD` segments. No kernel, no eBPF —
+//! so the matcher (the genuinely fiddly part) is unit-tested on every host. The
+//! Linux loader feeds it the mmap'd target binary and attaches by the returned
+//! offset.
+//!
+//! Signatures are inherently **version-specific**: a given prologue pattern
+//! pins one BoringSSL build. They are therefore data (carried per flavor /
+//! overridable from config), never logic — a new Bun release is a new
+//! signature, not a code change.
+
+/// A masked byte signature. `bytes[i]` is compared against the haystack only
+/// where `mask[i] != 0`; a zero mask byte is a wildcard (matches anything),
+/// which lets a signature skip over relocated addresses / immediates that vary
+/// between builds while pinning the stable opcodes around them.
+#[derive(Debug, Clone)]
+pub struct Signature {
+    pub bytes: Vec<u8>,
+    pub mask: Vec<u8>,
+}
+
+impl Signature {
+    /// Build a signature from a pattern string of space-separated hex bytes,
+    /// where `??` is a wildcard. e.g. `"55 48 89 e5 ?? ?? 48 8b"`.
+    /// Returns `None` on a malformed token.
+    pub fn parse(pattern: &str) -> Option<Self> {
+        let mut bytes = Vec::new();
+        let mut mask = Vec::new();
+        for tok in pattern.split_whitespace() {
+            if tok == "??" || tok == "?" {
+                bytes.push(0);
+                mask.push(0);
+            } else {
+                bytes.push(u8::from_str_radix(tok, 16).ok()?);
+                mask.push(0xFF);
+            }
+        }
+        if bytes.is_empty() {
+            return None;
+        }
+        Some(Self { bytes, mask })
+    }
+
+    /// Number of bytes the signature spans.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// True if the signature matches `hay` starting at `pos`.
+    fn matches_at(&self, hay: &[u8], pos: usize) -> bool {
+        if pos + self.bytes.len() > hay.len() {
+            return false;
+        }
+        self.bytes
+            .iter()
+            .zip(&self.mask)
+            .enumerate()
+            .all(|(i, (b, m))| *m == 0 || hay[pos + i] == *b)
+    }
+
+    /// Every index in `hay` where this signature matches (mask-aware).
+    pub fn find_all(&self, hay: &[u8]) -> Vec<usize> {
+        if self.bytes.is_empty() || hay.len() < self.bytes.len() {
+            return Vec::new();
+        }
+        // Anchor the linear scan on the first non-wildcard byte so a leading
+        // wildcard run doesn't force a full compare at every position.
+        let anchor = self.mask.iter().position(|m| *m != 0);
+        let last = hay.len() - self.bytes.len();
+        let mut hits = Vec::new();
+        match anchor {
+            Some(a) => {
+                let anchor_byte = self.bytes[a];
+                let mut pos = 0;
+                while pos <= last {
+                    if hay[pos + a] == anchor_byte && self.matches_at(hay, pos) {
+                        hits.push(pos);
+                    }
+                    pos += 1;
+                }
+            }
+            None => {
+                // All-wildcard signature: degenerate, every position matches.
+                hits.extend(0..=last);
+            }
+        }
+        hits
+    }
+}
+
+/// An executable `PT_LOAD` segment's file-resident byte range.
+struct ExecSegment {
+    file_off: u64,
+    file_size: u64,
+}
+
+/// Parse the executable `PT_LOAD` segments of a 64-bit little-endian ELF.
+/// Returns an empty vec for a non-ELF / unsupported image rather than erroring,
+/// so a misconfigured target degrades to "no offsets found" not a crash.
+fn exec_segments(data: &[u8]) -> Vec<ExecSegment> {
+    const PT_LOAD: u32 = 1;
+    const PF_X: u32 = 0x1;
+    // ELF header: magic + EI_CLASS(64) + EI_DATA(LE).
+    if data.len() < 64 || &data[0..4] != b"\x7fELF" || data[4] != 2 || data[5] != 1 {
+        return Vec::new();
+    }
+    let rd_u16 = |o: usize| u16::from_le_bytes([data[o], data[o + 1]]);
+    let rd_u32 = |o: usize| u32::from_le_bytes(data[o..o + 4].try_into().unwrap());
+    let rd_u64 = |o: usize| u64::from_le_bytes(data[o..o + 8].try_into().unwrap());
+
+    let e_phoff = rd_u64(0x20) as usize;
+    let e_phentsize = rd_u16(0x36) as usize;
+    let e_phnum = rd_u16(0x38) as usize;
+    if e_phentsize < 56 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for i in 0..e_phnum {
+        let ph = e_phoff + i * e_phentsize;
+        if ph + 56 > data.len() {
+            break;
+        }
+        let p_type = rd_u32(ph);
+        let p_flags = rd_u32(ph + 4);
+        let p_offset = rd_u64(ph + 8);
+        let p_filesz = rd_u64(ph + 32);
+        if p_type == PT_LOAD
+            && (p_flags & PF_X) != 0
+            && p_offset.saturating_add(p_filesz) as usize <= data.len()
+        {
+            out.push(ExecSegment {
+                file_off: p_offset,
+                file_size: p_filesz,
+            });
+        }
+    }
+    out
+}
+
+/// Scan every executable segment of the ELF image `data` for `sig`, returning
+/// the **file offsets** of all matches — exactly the values to hand the uprobe
+/// attach (`offset` arg, with `fn_name = None`).
+pub fn scan_elf_executable(data: &[u8], sig: &Signature) -> Vec<u64> {
+    let mut offsets = Vec::new();
+    for seg in exec_segments(data) {
+        let start = seg.file_off as usize;
+        let end = (seg.file_off + seg.file_size) as usize;
+        let slice = &data[start..end];
+        for local in sig.find_all(slice) {
+            offsets.push(seg.file_off + local as u64);
+        }
+    }
+    offsets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pattern_with_wildcards() {
+        let s = Signature::parse("55 48 ?? e5 ??").expect("parse");
+        assert_eq!(s.bytes, vec![0x55, 0x48, 0x00, 0xe5, 0x00]);
+        assert_eq!(s.mask, vec![0xFF, 0xFF, 0x00, 0xFF, 0x00]);
+        assert_eq!(s.len(), 5);
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert!(Signature::parse("zz").is_none());
+        assert!(Signature::parse("").is_none());
+    }
+
+    #[test]
+    fn find_all_exact_and_masked() {
+        let hay = b"\x00\x55\x48\x89\xe5\x00\x55\x48\x99\xe5\x00";
+        // Exact: prologue `55 48 89 e5` occurs once (at index 1).
+        let exact = Signature::parse("55 48 89 e5").unwrap();
+        assert_eq!(exact.find_all(hay), vec![1]);
+        // Masked: `55 48 ?? e5` matches both index 1 and index 6.
+        let masked = Signature::parse("55 48 ?? e5").unwrap();
+        assert_eq!(masked.find_all(hay), vec![1, 6]);
+    }
+
+    #[test]
+    fn find_all_no_match_returns_empty() {
+        let hay = b"\xde\xad\xbe\xef";
+        assert!(Signature::parse("12 34").unwrap().find_all(hay).is_empty());
+    }
+
+    #[test]
+    fn signature_at_end_of_buffer() {
+        let hay = b"\x90\x90\x55\x48";
+        assert_eq!(Signature::parse("55 48").unwrap().find_all(hay), vec![2]);
+        // One byte past the end must not match (bounds).
+        assert!(Signature::parse("55 48 89").unwrap().find_all(hay).is_empty());
+    }
+
+    /// Build a minimal 64-bit LE ELF with a single executable PT_LOAD segment
+    /// whose file-resident bytes contain a known prologue, and assert the
+    /// scanner reports the correct **file offset** (segment p_offset + local).
+    #[test]
+    fn scan_elf_returns_file_offset_within_exec_segment() {
+        let mut elf = vec![0u8; 0x200];
+        elf[0..4].copy_from_slice(b"\x7fELF");
+        elf[4] = 2; // 64-bit
+        elf[5] = 1; // little-endian
+        // e_phoff = 0x40, e_phentsize = 56, e_phnum = 1.
+        elf[0x20..0x28].copy_from_slice(&0x40u64.to_le_bytes());
+        elf[0x36..0x38].copy_from_slice(&56u16.to_le_bytes());
+        elf[0x38..0x3A].copy_from_slice(&1u16.to_le_bytes());
+        // Program header @0x40: PT_LOAD, PF_X, p_offset=0x100, p_filesz=0x40.
+        let ph = 0x40;
+        elf[ph..ph + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+        elf[ph + 4..ph + 8].copy_from_slice(&0x1u32.to_le_bytes()); // PF_X
+        elf[ph + 8..ph + 16].copy_from_slice(&0x100u64.to_le_bytes()); // p_offset
+        elf[ph + 32..ph + 40].copy_from_slice(&0x40u64.to_le_bytes()); // p_filesz
+        // Plant a prologue at file offset 0x110 (0x10 into the segment).
+        elf[0x110..0x114].copy_from_slice(&[0x55, 0x48, 0x89, 0xe5]);
+
+        let sig = Signature::parse("55 48 89 e5").unwrap();
+        assert_eq!(scan_elf_executable(&elf, &sig), vec![0x110]);
+    }
+
+    #[test]
+    fn non_elf_yields_no_segments() {
+        let sig = Signature::parse("55 48").unwrap();
+        assert!(scan_elf_executable(b"not an elf at all..........", &sig).is_empty());
+    }
+
+    #[test]
+    fn match_outside_exec_segment_is_ignored() {
+        // Same prologue planted BEFORE the exec segment's file range must not
+        // be reported — only executable bytes are scanned.
+        let mut elf = vec![0u8; 0x200];
+        elf[0..4].copy_from_slice(b"\x7fELF");
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[0x20..0x28].copy_from_slice(&0x40u64.to_le_bytes());
+        elf[0x36..0x38].copy_from_slice(&56u16.to_le_bytes());
+        elf[0x38..0x3A].copy_from_slice(&1u16.to_le_bytes());
+        let ph = 0x40;
+        elf[ph..ph + 4].copy_from_slice(&1u32.to_le_bytes());
+        elf[ph + 4..ph + 8].copy_from_slice(&0x1u32.to_le_bytes());
+        elf[ph + 8..ph + 16].copy_from_slice(&0x100u64.to_le_bytes());
+        elf[ph + 32..ph + 40].copy_from_slice(&0x40u64.to_le_bytes());
+        // Prologue at 0x80 — inside the header area, OUTSIDE [0x100, 0x140).
+        elf[0x80..0x84].copy_from_slice(&[0x55, 0x48, 0x89, 0xe5]);
+        let sig = Signature::parse("55 48 89 e5").unwrap();
+        assert!(scan_elf_executable(&elf, &sig).is_empty());
+    }
+}

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -406,33 +406,49 @@ fn attach_target(ebpf: &mut Ebpf, target: &EbpfTarget) -> crate::Result<bool> {
     let (builtin_w, builtin_r) = flavor_signatures(&target.flavor);
     let write_pat = target.write_sig.clone().or(builtin_w);
     let read_pat = target.read_sig.clone().or(builtin_r);
-    if write_pat.is_none() && read_pat.is_none() {
+    if target.write_offset.is_none()
+        && target.read_offset.is_none()
+        && write_pat.is_none()
+        && read_pat.is_none()
+    {
         tracing::warn!(
-            "ebpf: target {} (flavor={}) has no signature — set write_sig/read_sig in config",
+            "ebpf: target {} (flavor={}) has no offset or signature — set \
+             write_offset/read_offset or write_sig/read_sig in config",
             target.binary,
             target.flavor
         );
         return Ok(false);
     }
 
-    let data = std::fs::read(&path)
-        .map_err(|e| crate::CaptureError::Other(format!("read target {}: {e}", target.binary)))?;
+    // Read the binary only if a signature scan is actually needed.
+    let data = if (target.write_offset.is_none() && write_pat.is_some())
+        || (target.read_offset.is_none() && read_pat.is_some())
+    {
+        std::fs::read(&path)
+            .map_err(|e| crate::CaptureError::Other(format!("read target {}: {e}", target.binary)))?
+    } else {
+        Vec::new()
+    };
+
+    // Explicit offset wins over signature scanning for each function.
+    let write_off = target
+        .write_offset
+        .or_else(|| write_pat.and_then(|p| resolve_single_offset(&data, &p, "SSL_write", &target.binary)));
+    let read_off = target
+        .read_offset
+        .or_else(|| read_pat.and_then(|p| resolve_single_offset(&data, &p, "SSL_read", &target.binary)));
 
     let mut any = false;
-    if let Some(pat) = write_pat {
-        if let Some(off) = resolve_single_offset(&data, &pat, "SSL_write", &target.binary) {
-            attach_offset(ebpf, "ssl_write", off, &path, false)?;
-            any = true;
-        }
+    if let Some(off) = write_off {
+        attach_offset(ebpf, "ssl_write", off, &path, false)?;
+        any = true;
     }
-    if let Some(pat) = read_pat {
-        if let Some(off) = resolve_single_offset(&data, &pat, "SSL_read", &target.binary) {
-            // Entry probe captures the buffer pointer; the return probe reads
-            // the bytes SSL_read filled in. Both attach at the function entry.
-            attach_offset(ebpf, "ssl_read_enter", off, &path, false)?;
-            attach_offset(ebpf, "ssl_read_exit", off, &path, true)?;
-            any = true;
-        }
+    if let Some(off) = read_off {
+        // Entry probe captures the buffer pointer; the return probe reads the
+        // bytes SSL_read filled in. Both attach at the function entry.
+        attach_offset(ebpf, "ssl_read_enter", off, &path, false)?;
+        attach_offset(ebpf, "ssl_read_exit", off, &path, true)?;
+        any = true;
     }
     Ok(any)
 }

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -11,6 +11,7 @@
 //! line (`emit_handshake = false`). Real-tuple recovery via a `tcp_connect`
 //! kprobe is a follow-up refinement.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -125,6 +126,11 @@ impl CaptureSource for EbpfSource {
 
         tracing::info!("ebpf: capture started (source_id={})", self.source_id);
 
+        // pid → resolved `/proc/<pid>/exe`, memoized so we readlink once per
+        // process rather than once per event. Bounded: cleared if it grows past
+        // a generous ceiling (defends against pid churn over a long capture).
+        let mut exe_cache: HashMap<u32, Option<String>> = HashMap::new();
+
         loop {
             tokio::select! {
                 biased;
@@ -150,7 +156,7 @@ impl CaptureSource for EbpfSource {
                     };
                     let ring = guard.get_inner_mut();
                     while let Some(item) = ring.next() {
-                        let Some(ev) = decode_event(&item) else { continue };
+                        let Some(ev) = decode_event(&item, &mut exe_cache) else { continue };
                         for pkt in pump.on_event(ev) {
                             let is_hb = pkt.is_heartbeat();
                             if tx.send(pkt).await.is_err() {
@@ -172,8 +178,12 @@ impl CaptureSource for EbpfSource {
     }
 }
 
+/// Cap on the pid→exe memo so a long capture across heavy pid churn can't grow
+/// it without bound. Cleared wholesale on overflow (cheap; re-warms on demand).
+const EXE_CACHE_CAP: usize = 4096;
+
 /// Decode one ring-buffer record into a cross-platform [`SslEvent`].
-fn decode_event(bytes: &[u8]) -> Option<SslEvent> {
+fn decode_event(bytes: &[u8], exe_cache: &mut HashMap<u32, Option<String>>) -> Option<SslEvent> {
     if bytes.len() < RawSslEvent::SIZE {
         return None;
     }
@@ -196,6 +206,7 @@ fn decode_event(bytes: &[u8]) -> Option<SslEvent> {
                 conn_id: raw.conn_id,
                 pid: raw.pid,
                 comm,
+                exe: resolve_exe(raw.pid, exe_cache),
                 dir,
                 data: Bytes::copy_from_slice(&raw.data[..len]),
                 ktime_ns: raw.ktime_ns,
@@ -203,6 +214,25 @@ fn decode_event(bytes: &[u8]) -> Option<SslEvent> {
         }
         _ => None,
     }
+}
+
+/// Best-effort `/proc/<pid>/exe` resolution, memoized. Returns the absolute
+/// executable path, or `None` when the link can't be read (process exited,
+/// permission denied). Requires the capturing process to out-rank the target —
+/// satisfied when running as root / CAP_SYS_PTRACE, which the eBPF source needs
+/// anyway.
+fn resolve_exe(pid: u32, cache: &mut HashMap<u32, Option<String>>) -> Option<String> {
+    if let Some(v) = cache.get(&pid) {
+        return v.clone();
+    }
+    if cache.len() >= EXE_CACHE_CAP {
+        cache.clear();
+    }
+    let resolved = std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+    cache.insert(pid, resolved.clone());
+    resolved
 }
 
 fn comm_to_string(comm: &[u8]) -> String {

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -24,10 +24,11 @@ use aya::maps::RingBuf;
 use aya::programs::UProbe;
 use aya::Ebpf;
 
-use h_common::config::CaptureSourceConfig;
+use h_common::config::{CaptureSourceConfig, EbpfTarget};
 use h_common::internal_metrics::{Metric, MetricsWorker};
 use h_ebpf_common::{kind, SslEvent as RawSslEvent, DATA_CAP};
 
+use crate::ebpf::sigscan::{scan_elf_executable, Signature};
 use crate::ebpf::{BootClock, EbpfPump, SslEvent};
 use crate::packet::RawPacket;
 use crate::pcap_dump::PacketDumperConfig;
@@ -39,6 +40,7 @@ use crate::synth::{StreamDir, SynthConfig};
 pub struct EbpfSource {
     source_id: String,
     ssl_libs: Vec<String>,
+    targets: Vec<EbpfTarget>,
     pid_allowlist: Vec<u32>,
     segment_size: u32,
 }
@@ -51,9 +53,9 @@ impl EbpfSource {
         let CaptureSourceConfig::Ebpf {
             source_id,
             ssl_libs,
+            targets,
             pid_allowlist,
             segment_size,
-            ..
         } = config
         else {
             return Err(crate::CaptureError::Other(
@@ -63,6 +65,7 @@ impl EbpfSource {
         Ok(Self {
             source_id: source_id.clone().unwrap_or_else(|| "ebpf".to_string()),
             ssl_libs: ssl_libs.clone(),
+            targets: targets.clone(),
             pid_allowlist: pid_allowlist.clone(),
             segment_size: *segment_size,
         })
@@ -88,22 +91,60 @@ impl CaptureSource for EbpfSource {
         )))
         .map_err(|e| crate::CaptureError::Other(format!("load BPF program: {e}")))?;
 
-        let libs = if self.ssl_libs.is_empty() {
+        let libs: Vec<PathBuf> = if self.ssl_libs.is_empty() {
             detect_libssl()
         } else {
             self.ssl_libs.iter().map(PathBuf::from).collect()
-        };
-        if libs.is_empty() {
+        }
+        .into_iter()
+        // Drop libs that don't exist on disk so an explicit-but-stale
+        // `ssl_libs` entry doesn't fail the whole attach; also lets a
+        // targets-only deployment pass a sentinel path to skip symbol attach.
+        .filter(|p| p.exists())
+        .collect();
+        if libs.is_empty() && self.targets.is_empty() {
             return Err(crate::CaptureError::Other(
-                "no libssl found to attach to (set sources.ssl_libs explicitly)".to_string(),
+                "no libssl found and no static targets configured (set sources.ssl_libs or \
+                 sources.targets)"
+                    .to_string(),
             ));
         }
-        tracing::info!("ebpf: attaching SSL uprobes to {:?}", libs);
 
-        attach_uprobe(&mut ebpf, "ssl_write", "SSL_write", &libs, false)?;
-        attach_uprobe(&mut ebpf, "ssl_read_enter", "SSL_read", &libs, false)?;
-        attach_uprobe(&mut ebpf, "ssl_read_exit", "SSL_read", &libs, true)?;
-        attach_uprobe(&mut ebpf, "ssl_shutdown", "SSL_shutdown", &libs, false)?;
+        // Load every BPF program once; a program is attached to many sites
+        // (each libssl, each static target) but the kernel only accepts a
+        // single `load()` per program.
+        for name in ["ssl_write", "ssl_read_enter", "ssl_read_exit", "ssl_shutdown"] {
+            load_program(&mut ebpf, name)?;
+        }
+
+        // Dynamically-linked OpenSSL/BoringSSL: attach by exported symbol.
+        if !libs.is_empty() {
+            tracing::info!("ebpf: attaching SSL uprobes to {:?}", libs);
+            attach_sym(&mut ebpf, "ssl_write", "SSL_write", &libs, false)?;
+            attach_sym(&mut ebpf, "ssl_read_enter", "SSL_read", &libs, false)?;
+            attach_sym(&mut ebpf, "ssl_read_exit", "SSL_read", &libs, true)?;
+            attach_sym(&mut ebpf, "ssl_shutdown", "SSL_shutdown", &libs, false)?;
+        }
+
+        // Static, symbol-stripped targets (Phase 3, e.g. Claude Code's Bun
+        // binary): locate SSL_read/SSL_write by byte signature and attach by
+        // file offset. A target that yields no usable signature is logged and
+        // skipped — it must not take down capture for the dynamic libs.
+        let mut attached_targets = 0;
+        for target in &self.targets {
+            match attach_target(&mut ebpf, target) {
+                Ok(true) => attached_targets += 1,
+                Ok(false) => {}
+                Err(e) => tracing::warn!("ebpf: target {} attach failed: {e}", target.binary),
+            }
+        }
+        if libs.is_empty() && attached_targets == 0 {
+            return Err(crate::CaptureError::Other(
+                "no uprobes attached: every configured static target failed signature \
+                 resolution (check `flavor` / `write_sig` / `read_sig`)"
+                    .to_string(),
+            ));
+        }
 
         let ring = RingBuf::try_from(
             ebpf.take_map("EVENTS")
@@ -240,8 +281,25 @@ fn comm_to_string(comm: &[u8]) -> String {
     String::from_utf8_lossy(&comm[..end]).into_owned()
 }
 
-/// Attach one uprobe (or uretprobe when `ret`) to `symbol` in each library.
-fn attach_uprobe(
+/// Load a BPF program by name. Called once per program before any attach,
+/// because the kernel rejects a second `load()` while the program is attached
+/// at multiple sites (each libssl + each static target).
+fn load_program(ebpf: &mut Ebpf, prog_name: &str) -> crate::Result<()> {
+    let program: &mut UProbe = ebpf
+        .program_mut(prog_name)
+        .ok_or_else(|| crate::CaptureError::Other(format!("program {prog_name} missing")))?
+        .try_into()
+        .map_err(|e| crate::CaptureError::Other(format!("program {prog_name} not a uprobe: {e}")))?;
+    program
+        .load()
+        .map_err(|e| crate::CaptureError::Other(format!("load {prog_name}: {e}")))?;
+    Ok(())
+}
+
+/// Attach an already-loaded program to `symbol` in each dynamically-linked
+/// library (uretprobe vs uprobe is fixed by the program definition; `ret` is
+/// only for diagnostics).
+fn attach_sym(
     ebpf: &mut Ebpf,
     prog_name: &str,
     symbol: &str,
@@ -253,9 +311,6 @@ fn attach_uprobe(
         .ok_or_else(|| crate::CaptureError::Other(format!("program {prog_name} missing")))?
         .try_into()
         .map_err(|e| crate::CaptureError::Other(format!("program {prog_name} not a uprobe: {e}")))?;
-    program
-        .load()
-        .map_err(|e| crate::CaptureError::Other(format!("load {prog_name}: {e}")))?;
     let mut attached = 0;
     for lib in libs {
         match program.attach(Some(symbol), 0, lib, None) {
@@ -272,6 +327,114 @@ fn attach_uprobe(
         )));
     }
     Ok(())
+}
+
+/// Attach an already-loaded program to a static binary at a resolved **file
+/// offset** (no symbol). The path for the Bun/BoringSSL Phase-3 case.
+fn attach_offset(
+    ebpf: &mut Ebpf,
+    prog_name: &str,
+    offset: u64,
+    binary: &std::path::Path,
+    ret: bool,
+) -> crate::Result<()> {
+    let program: &mut UProbe = ebpf
+        .program_mut(prog_name)
+        .ok_or_else(|| crate::CaptureError::Other(format!("program {prog_name} missing")))?
+        .try_into()
+        .map_err(|e| crate::CaptureError::Other(format!("program {prog_name} not a uprobe: {e}")))?;
+    program
+        .attach(None, offset, binary, None)
+        .map_err(|e| {
+            crate::CaptureError::Other(format!(
+                "attach {prog_name} at offset {offset:#x} in {} (ret={ret}): {e}",
+                binary.display()
+            ))
+        })?;
+    Ok(())
+}
+
+/// Built-in `(write_sig, read_sig)` prologue patterns for a flavor. None ship
+/// for `boringssl` today: a BoringSSL prologue is specific to one statically-
+/// linked build (one Bun / Claude Code release), so it must be supplied per
+/// deployment via `write_sig` / `read_sig` in config rather than guessed in
+/// code. The mechanism (scan → offset → attach) is flavor-agnostic; only the
+/// data is version-bound.
+fn flavor_signatures(_flavor: &str) -> (Option<String>, Option<String>) {
+    (None, None)
+}
+
+/// Resolve a unique uprobe file offset for `pattern` in `data`. Requires
+/// exactly one match: zero means a stale/wrong signature (skip, don't attach
+/// blindly), and more than one is ambiguous (a too-loose signature would attach
+/// the probe to the wrong function). Both cases log and return `None`.
+fn resolve_single_offset(data: &[u8], pattern: &str, what: &str, binary: &str) -> Option<u64> {
+    let Some(sig) = Signature::parse(pattern) else {
+        tracing::warn!("ebpf: {binary}: malformed {what} signature {pattern:?}");
+        return None;
+    };
+    let hits = scan_elf_executable(data, &sig);
+    match hits.as_slice() {
+        [] => {
+            tracing::warn!("ebpf: {binary}: {what} signature matched nothing (wrong build?)");
+            None
+        }
+        [off] => {
+            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x}");
+            Some(*off)
+        }
+        many => {
+            tracing::warn!(
+                "ebpf: {binary}: {what} signature is ambiguous ({} matches) — refine it",
+                many.len()
+            );
+            None
+        }
+    }
+}
+
+/// Locate SSL_read/SSL_write in a symbol-stripped static target by byte
+/// signature and attach the (already-loaded) uprobes by file offset. Returns
+/// `Ok(true)` if at least one probe attached, `Ok(false)` if the target had no
+/// usable signature (logged, skipped — never fatal).
+fn attach_target(ebpf: &mut Ebpf, target: &EbpfTarget) -> crate::Result<bool> {
+    let path = PathBuf::from(&target.binary);
+    if !path.exists() {
+        tracing::warn!("ebpf: target binary {} not found", target.binary);
+        return Ok(false);
+    }
+    let (builtin_w, builtin_r) = flavor_signatures(&target.flavor);
+    let write_pat = target.write_sig.clone().or(builtin_w);
+    let read_pat = target.read_sig.clone().or(builtin_r);
+    if write_pat.is_none() && read_pat.is_none() {
+        tracing::warn!(
+            "ebpf: target {} (flavor={}) has no signature — set write_sig/read_sig in config",
+            target.binary,
+            target.flavor
+        );
+        return Ok(false);
+    }
+
+    let data = std::fs::read(&path)
+        .map_err(|e| crate::CaptureError::Other(format!("read target {}: {e}", target.binary)))?;
+
+    let mut any = false;
+    if let Some(pat) = write_pat {
+        if let Some(off) = resolve_single_offset(&data, &pat, "SSL_write", &target.binary) {
+            attach_offset(ebpf, "ssl_write", off, &path, false)?;
+            any = true;
+        }
+    }
+    if let Some(pat) = read_pat {
+        if let Some(off) = resolve_single_offset(&data, &pat, "SSL_read", &target.binary) {
+            // Entry probe captures the buffer pointer; the return probe reads
+            // the bytes SSL_read filled in. Both attach at the function entry.
+            attach_offset(ebpf, "ssl_read_enter", off, &path, false)?;
+            attach_offset(ebpf, "ssl_read_exit", off, &path, true)?;
+            any = true;
+        }
+    }
+    Ok(any)
 }
 
 /// Discover `libssl` shared objects on the host. Tries `ldconfig -p` first, then

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -354,14 +354,70 @@ fn attach_offset(
     Ok(())
 }
 
-/// Built-in `(write_sig, read_sig)` prologue patterns for a flavor. None ship
-/// for `boringssl` today: a BoringSSL prologue is specific to one statically-
-/// linked build (one Bun / Claude Code release), so it must be supplied per
-/// deployment via `write_sig` / `read_sig` in config rather than guessed in
-/// code. The mechanism (scan → offset → attach) is flavor-agnostic; only the
-/// data is version-bound.
-fn flavor_signatures(_flavor: &str) -> (Option<String>, Option<String>) {
-    (None, None)
+/// Built-in BoringSSL prologue signatures for a flavor, using the anchor + window
+/// technique. `SSL_read`'s prologue is distinctive enough to match uniquely; the
+/// `SSL_write` prologue is generic (a common register-save sequence appears many
+/// times), so it is located as the nearest match in a window *after* the
+/// `SSL_read` anchor — robust to the small per-build drift in the inter-function
+/// distance that a hardcoded delta would miss.
+struct FlavorSig {
+    /// Distinctive `SSL_read` prologue — must match uniquely (the anchor).
+    read_sig: &'static str,
+    /// `SSL_write` prologue — generic; resolved as the first match within
+    /// `write_window` bytes after the `SSL_read` anchor.
+    write_sig: &'static str,
+    write_window: u64,
+}
+
+/// Built-in signatures per flavor. Returns `None` for `boringssl` (generic): a
+/// prologue is specific to one statically-linked build, so a bare `boringssl`
+/// target must supply `write_sig`/`read_sig`/`*_offset` in config.
+///
+/// The `bun` signatures are the BoringSSL `SSL_read`/`SSL_write` x86-64
+/// prologues from Bun v1.3.x profile builds (the runtime Claude Code ships),
+/// matching the read-anchored, windowed-write approach from the eunomia-bpf
+/// AgentSight project (MIT). They are still version-bound data — a future Bun
+/// line may shift the prologue; override via config when that happens.
+fn flavor_signatures(flavor: &str) -> Option<FlavorSig> {
+    match flavor {
+        "bun" | "boringssl-bun" | "claude-code" => Some(FlavorSig {
+            read_sig: "55 48 89 e5 41 57 41 56 53 50 48 83 bf 98 00 00 00 00 74",
+            write_sig:
+                "55 48 89 e5 41 57 41 56 41 55 41 54 53 48 83 ec 18 41 89 d7 49 89 f6 48 89 fb",
+            write_window: 0x10000,
+        }),
+        _ => None,
+    }
+}
+
+/// Locate a function as the first signature match within `window` bytes after an
+/// `anchor` offset. Used for the generic `SSL_write` prologue once the unique
+/// `SSL_read` anchor is known — handles a prologue that occurs many times across
+/// the binary by scoping to the SSL function's neighborhood.
+fn resolve_windowed(
+    data: &[u8],
+    pattern: &str,
+    anchor: u64,
+    window: u64,
+    what: &str,
+    binary: &str,
+) -> Option<u64> {
+    let sig = Signature::parse(pattern)?;
+    let hit = scan_elf_executable(data, &sig)
+        .into_iter()
+        .find(|&o| o >= anchor && o < anchor.saturating_add(window));
+    match hit {
+        Some(off) => {
+            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x} (anchored)");
+            Some(off)
+        }
+        None => {
+            tracing::warn!(
+                "ebpf: {binary}: {what} not found within {window:#x} of anchor {anchor:#x}"
+            );
+            None
+        }
+    }
 }
 
 /// Resolve a unique uprobe file offset for `pattern` in `data`. Requires
@@ -403,40 +459,70 @@ fn attach_target(ebpf: &mut Ebpf, target: &EbpfTarget) -> crate::Result<bool> {
         tracing::warn!("ebpf: target binary {} not found", target.binary);
         return Ok(false);
     }
-    let (builtin_w, builtin_r) = flavor_signatures(&target.flavor);
-    let write_pat = target.write_sig.clone().or(builtin_w);
-    let read_pat = target.read_sig.clone().or(builtin_r);
-    if target.write_offset.is_none()
-        && target.read_offset.is_none()
-        && write_pat.is_none()
-        && read_pat.is_none()
-    {
+
+    let flavor_sig = flavor_signatures(&target.flavor);
+    let has_source = target.write_offset.is_some()
+        || target.read_offset.is_some()
+        || target.write_sig.is_some()
+        || target.read_sig.is_some()
+        || flavor_sig.is_some();
+    if !has_source {
         tracing::warn!(
             "ebpf: target {} (flavor={}) has no offset or signature — set \
-             write_offset/read_offset or write_sig/read_sig in config",
+             write_offset/read_offset or write_sig/read_sig in config (or use a \
+             flavor with built-in signatures, e.g. \"bun\")",
             target.binary,
             target.flavor
         );
         return Ok(false);
     }
 
-    // Read the binary only if a signature scan is actually needed.
-    let data = if (target.write_offset.is_none() && write_pat.is_some())
-        || (target.read_offset.is_none() && read_pat.is_some())
-    {
-        std::fs::read(&path)
-            .map_err(|e| crate::CaptureError::Other(format!("read target {}: {e}", target.binary)))?
-    } else {
-        Vec::new()
-    };
+    let mut write_off = target.write_offset;
+    let mut read_off = target.read_offset;
 
-    // Explicit offset wins over signature scanning for each function.
-    let write_off = target
-        .write_offset
-        .or_else(|| write_pat.and_then(|p| resolve_single_offset(&data, &p, "SSL_write", &target.binary)));
-    let read_off = target
-        .read_offset
-        .or_else(|| read_pat.and_then(|p| resolve_single_offset(&data, &p, "SSL_read", &target.binary)));
+    // Scan the binary only if at least one offset still needs resolving.
+    if write_off.is_none() || read_off.is_none() {
+        let data = std::fs::read(&path)
+            .map_err(|e| crate::CaptureError::Other(format!("read target {}: {e}", target.binary)))?;
+
+        // Config-supplied signatures take precedence and must match uniquely.
+        if read_off.is_none() {
+            if let Some(p) = &target.read_sig {
+                read_off = resolve_single_offset(&data, p, "SSL_read", &target.binary);
+            }
+        }
+        if write_off.is_none() {
+            if let Some(p) = &target.write_sig {
+                write_off = resolve_single_offset(&data, p, "SSL_write", &target.binary);
+            }
+        }
+
+        // Fall back to built-in flavor signatures: anchor on the unique
+        // SSL_read prologue, then locate SSL_write (generic prologue) as the
+        // nearest match in the window after it.
+        if let Some(fs) = &flavor_sig {
+            if read_off.is_none() {
+                read_off = resolve_single_offset(&data, fs.read_sig, "SSL_read", &target.binary);
+            }
+            if write_off.is_none() {
+                if let Some(anchor) = read_off {
+                    write_off = resolve_windowed(
+                        &data,
+                        fs.write_sig,
+                        anchor,
+                        fs.write_window,
+                        "SSL_write",
+                        &target.binary,
+                    );
+                } else {
+                    tracing::warn!(
+                        "ebpf: {}: no SSL_read anchor — cannot locate SSL_write by window",
+                        target.binary
+                    );
+                }
+            }
+        }
+    }
 
     let mut any = false;
     if let Some(off) = write_off {

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -1,0 +1,299 @@
+//! Linux aya loader for eBPF SSL-uprobe capture.
+//!
+//! Loads the embedded BPF program (`h-ebpf-prog`, built by `build.rs`), attaches
+//! uprobes to `SSL_write` / `SSL_read` / `SSL_shutdown` on the host's `libssl`,
+//! polls the ring buffer, decodes [`RawSslEvent`] records into the
+//! cross-platform [`SslEvent`], and drives an [`EbpfPump`] whose synthesized
+//! [`RawPacket`]s flow into the standard pipeline.
+//!
+//! Phase 1 MVP: no connect-side 5-tuple recovery yet — connections use a
+//! synthetic tuple and the reassembler syncs mid-stream on the first request
+//! line (`emit_handshake = false`). Real-tuple recovery via a `tcp_connect`
+//! kprobe is a follow-up refinement.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tokio::io::unix::AsyncFd;
+use tokio_util::sync::CancellationToken;
+
+use aya::maps::RingBuf;
+use aya::programs::UProbe;
+use aya::Ebpf;
+
+use h_common::config::CaptureSourceConfig;
+use h_common::internal_metrics::{Metric, MetricsWorker};
+use h_ebpf_common::{kind, SslEvent as RawSslEvent, DATA_CAP};
+
+use crate::ebpf::{BootClock, EbpfPump, SslEvent};
+use crate::packet::RawPacket;
+use crate::pcap_dump::PacketDumperConfig;
+use crate::routing::RoutingSender;
+use crate::source::CaptureSource;
+use crate::synth::{StreamDir, SynthConfig};
+
+/// eBPF SSL-uprobe capture source.
+pub struct EbpfSource {
+    source_id: String,
+    ssl_libs: Vec<String>,
+    pid_allowlist: Vec<u32>,
+    segment_size: u32,
+}
+
+impl EbpfSource {
+    pub fn from_config(
+        config: &CaptureSourceConfig,
+        _pcap_dump: Option<PacketDumperConfig>,
+    ) -> crate::Result<Self> {
+        let CaptureSourceConfig::Ebpf {
+            source_id,
+            ssl_libs,
+            pid_allowlist,
+            segment_size,
+            ..
+        } = config
+        else {
+            return Err(crate::CaptureError::Other(
+                "build_ebpf_source called with a non-ebpf config".to_string(),
+            ));
+        };
+        Ok(Self {
+            source_id: source_id.clone().unwrap_or_else(|| "ebpf".to_string()),
+            ssl_libs: ssl_libs.clone(),
+            pid_allowlist: pid_allowlist.clone(),
+            segment_size: *segment_size,
+        })
+    }
+}
+
+#[async_trait]
+impl CaptureSource for EbpfSource {
+    async fn run(
+        self: Box<Self>,
+        tx: RoutingSender,
+        metrics: MetricsWorker,
+        cancel: CancellationToken,
+    ) -> crate::Result<()> {
+        // Loosen the kernel lock limit so the BPF program + maps can be loaded.
+        if let Err(e) = bump_memlock_rlimit() {
+            tracing::warn!("ebpf: could not raise RLIMIT_MEMLOCK: {e}");
+        }
+
+        let mut ebpf = Ebpf::load(aya::include_bytes_aligned!(concat!(
+            env!("OUT_DIR"),
+            "/h-ebpf-prog"
+        )))
+        .map_err(|e| crate::CaptureError::Other(format!("load BPF program: {e}")))?;
+
+        let libs = if self.ssl_libs.is_empty() {
+            detect_libssl()
+        } else {
+            self.ssl_libs.iter().map(PathBuf::from).collect()
+        };
+        if libs.is_empty() {
+            return Err(crate::CaptureError::Other(
+                "no libssl found to attach to (set sources.ssl_libs explicitly)".to_string(),
+            ));
+        }
+        tracing::info!("ebpf: attaching SSL uprobes to {:?}", libs);
+
+        attach_uprobe(&mut ebpf, "ssl_write", "SSL_write", &libs, false)?;
+        attach_uprobe(&mut ebpf, "ssl_read_enter", "SSL_read", &libs, false)?;
+        attach_uprobe(&mut ebpf, "ssl_read_exit", "SSL_read", &libs, true)?;
+        attach_uprobe(&mut ebpf, "ssl_shutdown", "SSL_shutdown", &libs, false)?;
+
+        let ring = RingBuf::try_from(
+            ebpf.take_map("EVENTS")
+                .ok_or_else(|| crate::CaptureError::Other("EVENTS map missing".to_string()))?,
+        )
+        .map_err(|e| crate::CaptureError::Other(format!("ring buffer: {e}")))?;
+        let mut async_fd = AsyncFd::new(ring)
+            .map_err(|e| crate::CaptureError::Other(format!("async ring fd: {e}")))?;
+
+        let cfg = SynthConfig {
+            source_id: self.source_id.clone(),
+            segment_size: self.segment_size as usize,
+            // No connect event / real tuple yet → rely on mid-stream sync.
+            emit_handshake: false,
+        };
+        let mut pump = EbpfPump::new(cfg, BootClock::from_system(), self.pid_allowlist.clone());
+
+        let mut idle_hb = tokio::time::interval(Duration::from_secs(1));
+        idle_hb.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        tracing::info!("ebpf: capture started (source_id={})", self.source_id);
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    tracing::debug!("ebpf: cancellation requested, stopping");
+                    break;
+                }
+                _ = idle_hb.tick() => {
+                    // Drive downstream time-advance during traffic idle.
+                    let hb = RawPacket::heartbeat(now_epoch_us(), self.source_id.clone());
+                    if tx.send(hb).await.is_err() {
+                        break;
+                    }
+                    metrics.counter(Metric::CaptureHeartbeatsEmitted).inc();
+                }
+                guard = async_fd.readable_mut() => {
+                    let mut guard = match guard {
+                        Ok(g) => g,
+                        Err(e) => {
+                            tracing::warn!("ebpf: ring readable error: {e}");
+                            continue;
+                        }
+                    };
+                    let ring = guard.get_inner_mut();
+                    while let Some(item) = ring.next() {
+                        let Some(ev) = decode_event(&item) else { continue };
+                        for pkt in pump.on_event(ev) {
+                            let is_hb = pkt.is_heartbeat();
+                            if tx.send(pkt).await.is_err() {
+                                tracing::debug!("ebpf: channel closed, stopping");
+                                return Ok(());
+                            }
+                            if is_hb {
+                                metrics.counter(Metric::CaptureHeartbeatsEmitted).inc();
+                            } else {
+                                metrics.counter(Metric::CapturePacketsReceived).inc();
+                            }
+                        }
+                    }
+                    guard.clear_ready();
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Decode one ring-buffer record into a cross-platform [`SslEvent`].
+fn decode_event(bytes: &[u8]) -> Option<SslEvent> {
+    if bytes.len() < RawSslEvent::SIZE {
+        return None;
+    }
+    // The ring buffer gives an unaligned slice; read the POD struct unaligned.
+    let raw: RawSslEvent = unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RawSslEvent) };
+    let comm = comm_to_string(&raw.comm);
+    match raw.kind {
+        kind::CLOSE => Some(SslEvent::Close {
+            conn_id: raw.conn_id,
+            ktime_ns: raw.ktime_ns,
+        }),
+        kind::DATA_WRITE | kind::DATA_READ => {
+            let len = (raw.data_len as usize).min(DATA_CAP);
+            let dir = if raw.kind == kind::DATA_WRITE {
+                StreamDir::ClientToServer
+            } else {
+                StreamDir::ServerToClient
+            };
+            Some(SslEvent::Data {
+                conn_id: raw.conn_id,
+                pid: raw.pid,
+                comm,
+                dir,
+                data: Bytes::copy_from_slice(&raw.data[..len]),
+                ktime_ns: raw.ktime_ns,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn comm_to_string(comm: &[u8]) -> String {
+    let end = comm.iter().position(|&b| b == 0).unwrap_or(comm.len());
+    String::from_utf8_lossy(&comm[..end]).into_owned()
+}
+
+/// Attach one uprobe (or uretprobe when `ret`) to `symbol` in each library.
+fn attach_uprobe(
+    ebpf: &mut Ebpf,
+    prog_name: &str,
+    symbol: &str,
+    libs: &[PathBuf],
+    ret: bool,
+) -> crate::Result<()> {
+    let program: &mut UProbe = ebpf
+        .program_mut(prog_name)
+        .ok_or_else(|| crate::CaptureError::Other(format!("program {prog_name} missing")))?
+        .try_into()
+        .map_err(|e| crate::CaptureError::Other(format!("program {prog_name} not a uprobe: {e}")))?;
+    program
+        .load()
+        .map_err(|e| crate::CaptureError::Other(format!("load {prog_name}: {e}")))?;
+    let mut attached = 0;
+    for lib in libs {
+        match program.attach(Some(symbol), 0, lib, None) {
+            Ok(_) => attached += 1,
+            Err(e) => tracing::warn!(
+                "ebpf: attach {prog_name} to {symbol} in {} failed: {e}",
+                lib.display()
+            ),
+        }
+    }
+    if attached == 0 {
+        return Err(crate::CaptureError::Other(format!(
+            "could not attach {prog_name} to {symbol} on any libssl (ret={ret})"
+        )));
+    }
+    Ok(())
+}
+
+/// Discover `libssl` shared objects on the host. Tries `ldconfig -p` first, then
+/// falls back to well-known multiarch paths.
+fn detect_libssl() -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    if let Ok(out) = std::process::Command::new("ldconfig").arg("-p").output() {
+        let text = String::from_utf8_lossy(&out.stdout);
+        for line in text.lines() {
+            if line.contains("libssl.so") {
+                if let Some(path) = line.split("=>").nth(1) {
+                    let p = PathBuf::from(path.trim());
+                    if p.exists() && !found.contains(&p) {
+                        found.push(p);
+                    }
+                }
+            }
+        }
+    }
+    if found.is_empty() {
+        for cand in [
+            "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+            "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
+            "/lib/x86_64-linux-gnu/libssl.so.3",
+            "/usr/lib/aarch64-linux-gnu/libssl.so.3",
+        ] {
+            let p = PathBuf::from(cand);
+            if p.exists() {
+                found.push(p);
+            }
+        }
+    }
+    found
+}
+
+fn now_epoch_us() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0)
+}
+
+/// Raise `RLIMIT_MEMLOCK` to infinity so map/program allocation isn't capped on
+/// older kernels. On kernels with the BPF memcg accounting this is a no-op.
+fn bump_memlock_rlimit() -> std::io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/server/h-capture/src/factory.rs
+++ b/server/h-capture/src/factory.rs
@@ -56,7 +56,33 @@ pub fn build_source(
         CaptureSourceConfig::CloudProbe { endpoint, recv_hwm } => Ok(Box::new(
             CloudProbeSource::new(endpoint.clone(), *recv_hwm, pcap_dump),
         )),
+        CaptureSourceConfig::Ebpf { .. } => build_ebpf_source(config, pcap_dump),
     }
+}
+
+/// Construct the eBPF capture source. Only available on Linux builds compiled
+/// with the `ebpf` feature; every other build returns a clear error so a config
+/// referencing an `ebpf` source fails loudly instead of silently doing nothing.
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
+fn build_ebpf_source(
+    config: &CaptureSourceConfig,
+    pcap_dump: Option<PacketDumperConfig>,
+) -> crate::Result<Box<dyn CaptureSource>> {
+    Ok(Box::new(crate::ebpf::EbpfSource::from_config(
+        config, pcap_dump,
+    )?))
+}
+
+#[cfg(not(all(target_os = "linux", feature = "ebpf")))]
+fn build_ebpf_source(
+    _config: &CaptureSourceConfig,
+    _pcap_dump: Option<PacketDumperConfig>,
+) -> crate::Result<Box<dyn CaptureSource>> {
+    Err(crate::CaptureError::Other(
+        "ebpf capture is only available on Linux builds compiled with \
+         `--features ebpf` (requires CAP_BPF + BTF on the host)"
+            .to_string(),
+    ))
 }
 
 #[cfg(test)]
@@ -94,5 +120,28 @@ mod tests {
             recv_hwm: 1000,
         };
         assert!(build_source(&config, None).is_ok());
+    }
+
+    /// On default builds (no `ebpf` feature) the factory must reject an `ebpf`
+    /// source with a clear error rather than silently producing nothing.
+    #[cfg(not(all(target_os = "linux", feature = "ebpf")))]
+    #[test]
+    fn test_build_ebpf_source_unavailable_without_feature() {
+        let config = CaptureSourceConfig::Ebpf {
+            source_id: None,
+            ssl_libs: vec![],
+            targets: vec![],
+            pid_allowlist: vec![],
+            segment_size: 16 * 1024,
+        };
+        // `Box<dyn CaptureSource>` is not Debug, so avoid `unwrap_err`.
+        let err = match build_source(&config, None) {
+            Ok(_) => panic!("ebpf source should be unavailable without the feature"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("ebpf"),
+            "error should mention ebpf, got: {err}"
+        );
     }
 }

--- a/server/h-capture/src/heartbeat.rs
+++ b/server/h-capture/src/heartbeat.rs
@@ -89,6 +89,7 @@ mod tests {
             link_type: 1,
             data: Bytes::copy_from_slice(&buf),
             source_id: source_id.to_string(),
+            process: None,
         }
     }
 

--- a/server/h-capture/src/lib.rs
+++ b/server/h-capture/src/lib.rs
@@ -24,6 +24,7 @@ mod pcap_live;
 mod pcap_retention;
 mod routing;
 mod source;
+pub mod synth;
 
 pub use cloud_probe::CloudProbeSource;
 pub use factory::build_source;
@@ -34,6 +35,7 @@ pub use pcap_live::PcapLiveSource;
 pub use pcap_retention::spawn_pcap_retention_task;
 pub use routing::RoutingSender;
 pub use source::CaptureSource;
+pub use synth::{ConnTuple, FlowSynthesizer, StreamDir, SynthConfig};
 
 use thiserror::Error;
 

--- a/server/h-capture/src/lib.rs
+++ b/server/h-capture/src/lib.rs
@@ -14,6 +14,7 @@
 //! strictly an I/O boundary.
 
 mod cloud_probe;
+pub mod ebpf;
 mod factory;
 pub mod heartbeat;
 pub mod interfaces;
@@ -27,6 +28,7 @@ mod source;
 pub mod synth;
 
 pub use cloud_probe::CloudProbeSource;
+pub use ebpf::{BootClock, EbpfPump, SslEvent};
 pub use factory::build_source;
 pub use packet::{RawPacket, HEARTBEAT_ETHER_TYPE, HEARTBEAT_PACKET_LEN};
 pub use pcap_dump::{pcap_dump_dir_for, PacketDumper, PacketDumperConfig};

--- a/server/h-capture/src/lib.rs
+++ b/server/h-capture/src/lib.rs
@@ -30,6 +30,7 @@ pub mod synth;
 pub use cloud_probe::CloudProbeSource;
 pub use ebpf::{BootClock, EbpfPump, SslEvent};
 pub use factory::build_source;
+pub use h_common::process::ProcessInfo;
 pub use packet::{RawPacket, HEARTBEAT_ETHER_TYPE, HEARTBEAT_PACKET_LEN};
 pub use pcap_dump::{pcap_dump_dir_for, PacketDumper, PacketDumperConfig};
 pub use pcap_file::PcapFileSource;

--- a/server/h-capture/src/packet.rs
+++ b/server/h-capture/src/packet.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
 
+use h_common::process::ProcessInfo;
+
 /// Sentinel EtherType used by cloud-probe (and mimicked by pcap-live) to mark
 /// a [`RawPacket`] as a heartbeat signal rather than real traffic. Matches
 /// cloud-probe's `ZMQ_HEARTBEAT_ETHER_TYPE` compile-time constant.
@@ -30,6 +32,9 @@ pub struct RawPacket {
     /// this is the interface name (or user-configured override); for cloud-probe
     /// it is the UUID extracted from the batch header.
     pub source_id: String,
+    /// Owning process, when the source can attribute it (eBPF). `None` for
+    /// passive taps (pcap live / file, cloud-probe), which see only the wire.
+    pub process: Option<ProcessInfo>,
 }
 
 impl RawPacket {
@@ -66,6 +71,7 @@ impl RawPacket {
             link_type: 1,
             data: Bytes::copy_from_slice(&buf),
             source_id,
+            process: None,
         }
     }
 }
@@ -96,6 +102,7 @@ mod tests {
             link_type: 1,
             data: Bytes::copy_from_slice(&buf),
             source_id: String::new(),
+            process: None,
         };
         assert!(!pkt.is_heartbeat());
     }
@@ -112,6 +119,7 @@ mod tests {
             link_type: 1,
             data: Bytes::copy_from_slice(&buf),
             source_id: String::new(),
+            process: None,
         };
         assert!(!pkt.is_heartbeat());
     }
@@ -128,6 +136,7 @@ mod tests {
             link_type: 101, // Raw IP
             data: Bytes::copy_from_slice(&buf),
             source_id: String::new(),
+            process: None,
         };
         assert!(!pkt.is_heartbeat());
     }

--- a/server/h-capture/src/pcap_dump.rs
+++ b/server/h-capture/src/pcap_dump.rs
@@ -509,6 +509,7 @@ mod tests {
             link_type: 1,
             data: Bytes::copy_from_slice(data),
             source_id: source_id.to_string(),
+            process: None,
         }
     }
 

--- a/server/h-capture/src/pcap_file.rs
+++ b/server/h-capture/src/pcap_file.rs
@@ -161,6 +161,7 @@ impl CaptureSource for PcapFileSource {
                                 link_type,
                                 data: Bytes::copy_from_slice(packet.data),
                                 source_id: pass_source_id.clone(),
+                                process: None,
                             };
 
                             if let Some(d) = dumper.as_mut() {

--- a/server/h-capture/src/pcap_live.rs
+++ b/server/h-capture/src/pcap_live.rs
@@ -198,6 +198,7 @@ impl CaptureSource for PcapLiveSource {
                             link_type,
                             data: Bytes::copy_from_slice(packet.data),
                             source_id: source_id.clone(),
+                            process: None,
                         };
 
                         // Packet-driven heartbeat: if event-time has advanced a

--- a/server/h-capture/src/synth.rs
+++ b/server/h-capture/src/synth.rs
@@ -343,6 +343,10 @@ impl FlowSynthesizer {
             link_type: LINKTYPE_ETHERNET,
             data: Bytes::from(data),
             source_id: self.cfg.source_id.clone(),
+            // Synthesis is process-agnostic: the eBPF pump (which owns the
+            // pid/comm) stamps process attribution onto these frames after
+            // synthesis. Passive callers (tests) leave it `None`.
+            process: None,
         }
     }
 }

--- a/server/h-capture/src/synth.rs
+++ b/server/h-capture/src/synth.rs
@@ -1,0 +1,569 @@
+//! Stream-to-packet frame synthesis.
+//!
+//! Converts per-connection plaintext byte chunks — as produced by an eBPF
+//! `SSL_read` / `SSL_write` uprobe — into synthetic Ethernet + IPv4/IPv6 + TCP
+//! [`RawPacket`]s that feed Heron's existing dispatcher → TCP reassembler →
+//! HTTP parser pipeline unchanged. No new ingress layer is needed: the
+//! reassembler already handles mid-stream sync, multi-segment bodies, and
+//! connection teardown, so an eBPF source only has to dress its plaintext
+//! chunks as well-formed TCP segments.
+//!
+//! This module is **pure and cross-platform**: it has no eBPF dependency and
+//! compiles/tests on any host. The Linux-only `EbpfSource` (Phase 1) drives it
+//! from ring-buffer events, but the synthesis logic — the one genuinely novel
+//! correctness surface — is validated here and in `h-protocol`'s integration
+//! tests without a kernel.
+//!
+//! # Invariants the reassembler imposes (see `h-protocol`)
+//!
+//! * **IP length must cover exactly the payload present.** `de::decode` derives
+//!   the on-wire segment length from the IP/TCP header fields; if it claims more
+//!   bytes than are captured, `tcp.rs`'s truncation guard discards the flow.
+//!   Every frame here sets the IP length to exactly `headers + payload`, so
+//!   `wire_payload_len == payload.len()` always.
+//! * **No checksums are validated** (`de/l3.rs`, `de/l4.rs` never read them), so
+//!   IP/TCP checksum fields are left zero.
+//! * **Sequence numbers advance monotonically per direction** by the emitted
+//!   payload length. There are no retransmits or out-of-order frames — the
+//!   plaintext stream is already in order.
+//! * **Heartbeat sentinels are distinct.** Synthetic frames carry a real IPv4 /
+//!   IPv6 ethertype, never `0xFFFF`, so [`RawPacket::is_heartbeat`] is false.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+
+use bytes::Bytes;
+
+use crate::packet::RawPacket;
+
+// Wire constants. Mirrored locally (same pattern as `cloud_probe.rs`) because
+// `h-capture` must not depend on `h-protocol`, where the canonical copies live.
+const LINKTYPE_ETHERNET: u32 = 1;
+const ETHERTYPE_IPV4: u16 = 0x0800;
+const ETHERTYPE_IPV6: u16 = 0x86DD;
+const IP_PROTO_TCP: u8 = 6;
+
+const ETH_HDR_LEN: usize = 14;
+const IPV4_HDR_LEN: usize = 20;
+const IPV6_HDR_LEN: usize = 40;
+const TCP_HDR_LEN: usize = 20;
+
+// TCP flags.
+const TCP_FIN: u8 = 0x01;
+const TCP_SYN: u8 = 0x02;
+const TCP_PSH: u8 = 0x08;
+const TCP_ACK: u8 = 0x10;
+
+/// Largest TCP payload a single synthesized segment may carry. The IPv4
+/// `total_length` (and IPv6 `payload_length`) field is 16-bit, so a segment
+/// plus its headers must stay under 65535. We cap well below that for headroom.
+const MAX_SEGMENT_PAYLOAD: usize = 60_000;
+
+/// Default per-segment payload size. A single large `SSL_write` is sliced into
+/// segments of this size, mirroring real on-wire MSS behavior. 16 KiB keeps the
+/// frame count low while staying comfortably under [`MAX_SEGMENT_PAYLOAD`].
+pub const DEFAULT_SEGMENT_SIZE: usize = 16 * 1024;
+
+/// Direction of a plaintext chunk, named from the connection's point of view.
+/// `SSL_write` is the client emitting a request; `SSL_read` is the client
+/// receiving a response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamDir {
+    /// Client → server. Maps to an `SSL_write` (outbound request bytes).
+    ClientToServer,
+    /// Server → client. Maps to an `SSL_read` (inbound response bytes).
+    ServerToClient,
+}
+
+/// The endpoints of a synthesized connection. `client` is whichever side issues
+/// the HTTP request (the process running the SSL uprobe); `server` is the peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConnTuple {
+    pub client: SocketAddr,
+    pub server: SocketAddr,
+}
+
+/// Configuration for a [`FlowSynthesizer`].
+#[derive(Debug, Clone)]
+pub struct SynthConfig {
+    /// `source_id` stamped on every emitted [`RawPacket`]. Routes the flow to a
+    /// dispatcher shard and namespaces its `FlowKey`.
+    pub source_id: String,
+    /// Target payload size per synthesized TCP segment. Clamped to
+    /// [`MAX_SEGMENT_PAYLOAD`]; zero falls back to [`DEFAULT_SEGMENT_SIZE`].
+    pub segment_size: usize,
+    /// Emit a synthetic SYN / SYN-ACK on [`FlowSynthesizer::open`] so the
+    /// reassembler pins the client side deterministically. When false (or for a
+    /// connection first seen mid-stream via [`FlowSynthesizer::data`]), the
+    /// reassembler instead syncs on the first HTTP request line.
+    pub emit_handshake: bool,
+}
+
+impl Default for SynthConfig {
+    fn default() -> Self {
+        Self {
+            source_id: "ebpf".to_string(),
+            segment_size: DEFAULT_SEGMENT_SIZE,
+            emit_handshake: true,
+        }
+    }
+}
+
+impl SynthConfig {
+    fn effective_segment(&self) -> usize {
+        match self.segment_size {
+            0 => DEFAULT_SEGMENT_SIZE,
+            n => n.min(MAX_SEGMENT_PAYLOAD),
+        }
+    }
+}
+
+/// Per-connection synthesis state: the endpoints and the next sequence number
+/// to use in each direction.
+#[derive(Debug)]
+struct ConnState {
+    tuple: ConnTuple,
+    /// Next sequence number for client→server segments.
+    seq_c2s: u32,
+    /// Next sequence number for server→client segments.
+    seq_s2c: u32,
+}
+
+impl ConnState {
+    /// Initial sequence numbers. With a synthesized handshake the SYN carries
+    /// ISN 0 and consumes one sequence number, so data starts at 1; without a
+    /// handshake the absolute base is irrelevant (the reassembler re-baselines
+    /// mid-stream), and 1 keeps the two paths identical.
+    fn new(tuple: ConnTuple) -> Self {
+        Self {
+            tuple,
+            seq_c2s: 1,
+            seq_s2c: 1,
+        }
+    }
+
+    fn seq_mut(&mut self, dir: StreamDir) -> &mut u32 {
+        match dir {
+            StreamDir::ClientToServer => &mut self.seq_c2s,
+            StreamDir::ServerToClient => &mut self.seq_s2c,
+        }
+    }
+
+    /// `(src, dst)` endpoints for a segment travelling in `dir`.
+    fn endpoints(&self, dir: StreamDir) -> (SocketAddr, SocketAddr) {
+        match dir {
+            StreamDir::ClientToServer => (self.tuple.client, self.tuple.server),
+            StreamDir::ServerToClient => (self.tuple.server, self.tuple.client),
+        }
+    }
+}
+
+/// Turns per-connection plaintext byte chunks into synthetic [`RawPacket`]s.
+///
+/// Lifecycle per connection:
+/// 1. [`open`](Self::open) — register endpoints, optionally emit a handshake.
+/// 2. [`data`](Self::data) — emit one or more TCP segments per chunk.
+/// 3. [`close`](Self::close) — emit FINs so the reassembler finalizes promptly.
+///
+/// A connection first observed via [`data`](Self::data) (uprobe attached
+/// mid-stream) is opened lazily with a [synthetic tuple](Self::synthetic_tuple)
+/// and no handshake.
+#[derive(Debug)]
+pub struct FlowSynthesizer {
+    cfg: SynthConfig,
+    conns: HashMap<u64, ConnState>,
+}
+
+impl FlowSynthesizer {
+    pub fn new(cfg: SynthConfig) -> Self {
+        Self {
+            cfg,
+            conns: HashMap::new(),
+        }
+    }
+
+    /// True if `conn_id` has been opened and not yet closed.
+    pub fn is_open(&self, conn_id: u64) -> bool {
+        self.conns.contains_key(&conn_id)
+    }
+
+    /// Number of live connections currently tracked.
+    pub fn conn_count(&self) -> usize {
+        self.conns.len()
+    }
+
+    /// Register a connection and, when [`SynthConfig::emit_handshake`] is set,
+    /// emit a SYN / SYN-ACK pair. Re-opening an existing `conn_id` replaces its
+    /// state (and re-handshakes) — the caller is expected to have closed the
+    /// prior connection first.
+    pub fn open(&mut self, conn_id: u64, tuple: ConnTuple, ts_us: i64) -> Vec<RawPacket> {
+        let state = ConnState::new(tuple);
+        let mut out = Vec::new();
+        if self.cfg.emit_handshake {
+            // SYN (client→server, ISN 0) then SYN-ACK (server→client, ISN 0).
+            let (csrc, cdst) = state.endpoints(StreamDir::ClientToServer);
+            out.push(self.frame(csrc, cdst, 0, 0, TCP_SYN, &[], ts_us));
+            let (ssrc, sdst) = state.endpoints(StreamDir::ServerToClient);
+            out.push(self.frame(ssrc, sdst, 0, 1, TCP_SYN | TCP_ACK, &[], ts_us));
+        }
+        self.conns.insert(conn_id, state);
+        out
+    }
+
+    /// Emit TCP segments carrying `bytes` in direction `dir`. A chunk larger
+    /// than the configured segment size is split across multiple in-order
+    /// segments. An empty chunk emits nothing. Unknown connections are opened
+    /// lazily (synthetic tuple, no handshake).
+    pub fn data(
+        &mut self,
+        conn_id: u64,
+        dir: StreamDir,
+        bytes: &[u8],
+        ts_us: i64,
+    ) -> Vec<RawPacket> {
+        if bytes.is_empty() {
+            return Vec::new();
+        }
+        // Mid-stream attach (unknown conn): open lazily with a synthetic tuple
+        // and no handshake. The reassembler re-baselines on the first request
+        // line. Known connections keep their registered state untouched.
+        self.conns
+            .entry(conn_id)
+            .or_insert_with(|| ConnState::new(Self::synthetic_tuple(conn_id)));
+
+        let seg = self.cfg.effective_segment();
+        // Snapshot the routing inputs while we hold the connection borrow, then
+        // drop it so `self.frame` can borrow `self` immutably per segment.
+        let (src, dst, mut seq) = {
+            let state = self.conns.get(&conn_id).expect("just inserted");
+            let (src, dst) = state.endpoints(dir);
+            (src, dst, *self.peek_seq(conn_id, dir))
+        };
+
+        let mut out = Vec::with_capacity(bytes.len().div_ceil(seg));
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let end = (offset + seg).min(bytes.len());
+            let chunk = &bytes[offset..end];
+            out.push(self.frame(src, dst, seq, 1, TCP_PSH | TCP_ACK, chunk, ts_us));
+            seq = seq.wrapping_add(chunk.len() as u32);
+            offset = end;
+        }
+
+        *self.conns.get_mut(&conn_id).expect("present").seq_mut(dir) = seq;
+        out
+    }
+
+    /// Emit FIN segments in both directions and forget the connection. The
+    /// reassembler finalizes any pending response on FIN, so a turn does not
+    /// have to wait out the 120 s idle sweep. A no-op for unknown connections.
+    pub fn close(&mut self, conn_id: u64, ts_us: i64) -> Vec<RawPacket> {
+        let Some(state) = self.conns.remove(&conn_id) else {
+            return Vec::new();
+        };
+        let (csrc, cdst) = state.endpoints(StreamDir::ClientToServer);
+        let (ssrc, sdst) = state.endpoints(StreamDir::ServerToClient);
+        vec![
+            self.frame(csrc, cdst, state.seq_c2s, 1, TCP_FIN | TCP_ACK, &[], ts_us),
+            self.frame(ssrc, sdst, state.seq_s2c, 1, TCP_FIN | TCP_ACK, &[], ts_us),
+        ]
+    }
+
+    /// Deterministic placeholder 5-tuple for a connection whose real socket
+    /// addresses are unknown (uprobe gave `SSL*`/pid but no socket). Stable and
+    /// collision-resistant per `conn_id`, so both directions of one connection
+    /// share a `FlowKey`. The client side maps into `127.64.0.0/10` and the
+    /// server into a documentation address; wire-API detection keys on the HTTP
+    /// `Host`/path, not on these IPs, so they affect only the displayed tuple.
+    pub fn synthetic_tuple(conn_id: u64) -> ConnTuple {
+        let lo = conn_id as u32;
+        let hi = (conn_id >> 32) as u32;
+        // Client: 127.64.x.y to stay inside loopback's /8 but clear of 127.0.0.1.
+        let client_ip = IpAddr::from([127, 64, (lo >> 8) as u8, lo as u8]);
+        let client_port = 1024u16.wrapping_add((lo >> 16) as u16);
+        // Server: 192.0.2.0/24 (TEST-NET-1, RFC 5737) — never a real host.
+        let server_ip = IpAddr::from([192, 0, 2, (hi & 0xFF) as u8]);
+        ConnTuple {
+            client: SocketAddr::new(client_ip, client_port.max(1024)),
+            server: SocketAddr::new(server_ip, 443),
+        }
+    }
+
+    fn peek_seq(&self, conn_id: u64, dir: StreamDir) -> &u32 {
+        let state = self.conns.get(&conn_id).expect("present");
+        match dir {
+            StreamDir::ClientToServer => &state.seq_c2s,
+            StreamDir::ServerToClient => &state.seq_s2c,
+        }
+    }
+
+    /// Build one Ethernet + IP + TCP frame around `payload`.
+    #[allow(clippy::too_many_arguments)]
+    fn frame(
+        &self,
+        src: SocketAddr,
+        dst: SocketAddr,
+        seq: u32,
+        ack: u32,
+        flags: u8,
+        payload: &[u8],
+        ts_us: i64,
+    ) -> RawPacket {
+        debug_assert!(payload.len() <= MAX_SEGMENT_PAYLOAD);
+        let ip_hdr_len = if src.is_ipv4() && dst.is_ipv4() {
+            IPV4_HDR_LEN
+        } else {
+            IPV6_HDR_LEN
+        };
+        let mut data = Vec::with_capacity(ETH_HDR_LEN + ip_hdr_len + TCP_HDR_LEN + payload.len());
+
+        // Ethernet II: zero MACs. The ethertype is a real IP type (never the
+        // 0xFFFF heartbeat sentinel), so `is_heartbeat()` stays false.
+        data.extend_from_slice(&[0u8; 12]);
+        match (src.ip(), dst.ip()) {
+            (IpAddr::V4(s), IpAddr::V4(d)) => {
+                data.extend_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+                push_ipv4(&mut data, s.octets(), d.octets(), TCP_HDR_LEN + payload.len());
+            }
+            (s, d) => {
+                let s = to_ipv6(s);
+                let d = to_ipv6(d);
+                data.extend_from_slice(&ETHERTYPE_IPV6.to_be_bytes());
+                push_ipv6(&mut data, s, d, TCP_HDR_LEN + payload.len());
+            }
+        }
+        push_tcp(&mut data, src.port(), dst.port(), seq, ack, flags);
+        data.extend_from_slice(payload);
+
+        let len = data.len() as u32;
+        RawPacket {
+            timestamp_us: ts_us,
+            caplen: len,
+            wirelen: len,
+            link_type: LINKTYPE_ETHERNET,
+            data: Bytes::from(data),
+            source_id: self.cfg.source_id.clone(),
+        }
+    }
+}
+
+/// Map any IP into 16 IPv6 bytes (v4 → v4-mapped) so a mixed-family tuple still
+/// produces a well-formed IPv6 frame. Matched families take the clean path.
+fn to_ipv6(ip: IpAddr) -> [u8; 16] {
+    match ip {
+        IpAddr::V6(a) => a.octets(),
+        IpAddr::V4(a) => a.to_ipv6_mapped().octets(),
+    }
+}
+
+/// Push a 20-byte IPv4 header. `l4_len` is the TCP header + payload length, so
+/// `total_length = 20 + l4_len` and the decoder recovers
+/// `payload_length = total_length - 20 = l4_len`.
+fn push_ipv4(buf: &mut Vec<u8>, src: [u8; 4], dst: [u8; 4], l4_len: usize) {
+    let total_length = (IPV4_HDR_LEN + l4_len) as u16;
+    let mut h = [0u8; IPV4_HDR_LEN];
+    h[0] = 0x45; // version 4, IHL 5 (20 bytes)
+    h[2..4].copy_from_slice(&total_length.to_be_bytes());
+    h[8] = 64; // TTL
+    h[9] = IP_PROTO_TCP;
+    // checksum (h[10..12]) intentionally zero — not validated.
+    h[12..16].copy_from_slice(&src);
+    h[16..20].copy_from_slice(&dst);
+    buf.extend_from_slice(&h);
+}
+
+/// Push a 40-byte IPv6 header. The `payload_length` field is the TCP header +
+/// payload length, which the decoder uses directly.
+fn push_ipv6(buf: &mut Vec<u8>, src: [u8; 16], dst: [u8; 16], l4_len: usize) {
+    let payload_length = l4_len as u16;
+    let mut h = [0u8; IPV6_HDR_LEN];
+    h[0] = 0x60; // version 6
+    h[4..6].copy_from_slice(&payload_length.to_be_bytes());
+    h[6] = IP_PROTO_TCP; // next header
+    h[7] = 64; // hop limit
+    h[8..24].copy_from_slice(&src);
+    h[24..40].copy_from_slice(&dst);
+    buf.extend_from_slice(&h);
+}
+
+/// Push a 20-byte TCP header (no options, `data_offset = 5`).
+fn push_tcp(buf: &mut Vec<u8>, src_port: u16, dst_port: u16, seq: u32, ack: u32, flags: u8) {
+    let mut h = [0u8; TCP_HDR_LEN];
+    h[0..2].copy_from_slice(&src_port.to_be_bytes());
+    h[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    h[4..8].copy_from_slice(&seq.to_be_bytes());
+    h[8..12].copy_from_slice(&ack.to_be_bytes());
+    h[12] = 0x50; // data offset 5 → 20-byte header
+    h[13] = flags;
+    h[14..16].copy_from_slice(&0xFFFFu16.to_be_bytes()); // advertised window
+                                                         // checksum + urgent ptr left zero.
+    buf.extend_from_slice(&h);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4_tuple() -> ConnTuple {
+        ConnTuple {
+            client: "10.0.0.5:54321".parse().unwrap(),
+            server: "93.184.216.34:443".parse().unwrap(),
+        }
+    }
+
+    /// Parse the ethertype (bytes 12..14) from a synthesized Ethernet frame.
+    fn ethertype(pkt: &RawPacket) -> u16 {
+        u16::from_be_bytes([pkt.data[12], pkt.data[13]])
+    }
+
+    /// Extract `(seq, flags, payload)` from an IPv4 frame for assertions.
+    fn ipv4_tcp(pkt: &RawPacket) -> (u32, u8, &[u8]) {
+        let ip = ETH_HDR_LEN;
+        let tcp = ip + IPV4_HDR_LEN;
+        let seq = u32::from_be_bytes([
+            pkt.data[tcp + 4],
+            pkt.data[tcp + 5],
+            pkt.data[tcp + 6],
+            pkt.data[tcp + 7],
+        ]);
+        let flags = pkt.data[tcp + 13];
+        let payload = &pkt.data[tcp + TCP_HDR_LEN..];
+        (seq, flags, payload)
+    }
+
+    #[test]
+    fn open_with_handshake_emits_syn_synack() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        let frames = s.open(1, v4_tuple(), 1_000);
+        assert_eq!(frames.len(), 2);
+        let (_, syn_flags, syn_pl) = ipv4_tcp(&frames[0]);
+        assert_eq!(syn_flags, TCP_SYN);
+        assert!(syn_pl.is_empty());
+        let (_, sa_flags, sa_pl) = ipv4_tcp(&frames[1]);
+        assert_eq!(sa_flags, TCP_SYN | TCP_ACK);
+        assert!(sa_pl.is_empty());
+        assert!(!frames[0].is_heartbeat() && !frames[1].is_heartbeat());
+    }
+
+    #[test]
+    fn open_without_handshake_emits_nothing() {
+        let cfg = SynthConfig {
+            emit_handshake: false,
+            ..Default::default()
+        };
+        let mut s = FlowSynthesizer::new(cfg);
+        assert!(s.open(1, v4_tuple(), 0).is_empty());
+        assert!(s.is_open(1));
+    }
+
+    #[test]
+    fn data_emits_single_segment_with_payload_and_advancing_seq() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        let body = b"GET / HTTP/1.1\r\n\r\n";
+        let frames = s.data(1, StreamDir::ClientToServer, body, 10);
+        assert_eq!(frames.len(), 1);
+        let (seq, flags, payload) = ipv4_tcp(&frames[0]);
+        assert_eq!(seq, 1, "first data seq follows SYN's ISN+1");
+        assert_eq!(flags, TCP_PSH | TCP_ACK);
+        assert_eq!(payload, body);
+        assert_eq!(ethertype(&frames[0]), ETHERTYPE_IPV4);
+
+        // Next chunk continues from the advanced seq.
+        let more = s.data(1, StreamDir::ClientToServer, b"XYZ", 20);
+        let (seq2, _, _) = ipv4_tcp(&more[0]);
+        assert_eq!(seq2, 1 + body.len() as u32);
+    }
+
+    #[test]
+    fn large_chunk_splits_into_segments_with_contiguous_seq() {
+        let cfg = SynthConfig {
+            segment_size: 1000,
+            ..Default::default()
+        };
+        let mut s = FlowSynthesizer::new(cfg);
+        s.open(1, v4_tuple(), 0);
+        let body = vec![b'A'; 2500];
+        let frames = s.data(1, StreamDir::ServerToClient, &body, 5);
+        assert_eq!(frames.len(), 3, "2500 / 1000 = 3 segments");
+
+        let mut expected_seq = 1u32;
+        let mut total = 0usize;
+        for f in &frames {
+            let (seq, _, payload) = ipv4_tcp(f);
+            assert_eq!(seq, expected_seq);
+            assert!(payload.len() <= 1000);
+            expected_seq += payload.len() as u32;
+            total += payload.len();
+        }
+        assert_eq!(total, 2500, "no payload bytes lost across segments");
+    }
+
+    #[test]
+    fn empty_chunk_emits_nothing() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        assert!(s.data(1, StreamDir::ClientToServer, &[], 0).is_empty());
+    }
+
+    #[test]
+    fn unknown_conn_opens_lazily_without_handshake() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        // No open() first — data() must lazily register the connection.
+        let frames = s.data(7, StreamDir::ClientToServer, b"POST / HTTP/1.1\r\n", 0);
+        assert_eq!(frames.len(), 1, "exactly the data segment, no handshake");
+        assert!(s.is_open(7));
+    }
+
+    #[test]
+    fn close_emits_fin_both_directions_and_forgets_conn() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        let frames = s.close(1, 99);
+        assert_eq!(frames.len(), 2);
+        for f in &frames {
+            let (_, flags, pl) = ipv4_tcp(f);
+            assert_eq!(flags, TCP_FIN | TCP_ACK);
+            assert!(pl.is_empty());
+        }
+        assert!(!s.is_open(1));
+        assert!(s.close(1, 100).is_empty(), "second close is a no-op");
+    }
+
+    #[test]
+    fn ipv6_tuple_produces_ipv6_ethertype_and_header() {
+        let cfg = SynthConfig::default();
+        let mut s = FlowSynthesizer::new(cfg);
+        let tuple = ConnTuple {
+            client: "[2001:db8::1]:50000".parse().unwrap(),
+            server: "[2606:4700::1]:443".parse().unwrap(),
+        };
+        s.open(1, tuple, 0);
+        let frames = s.data(1, StreamDir::ClientToServer, b"GET / HTTP/1.1\r\n", 0);
+        assert_eq!(ethertype(&frames[0]), ETHERTYPE_IPV6);
+        // Ethernet(14) + IPv6(40) + TCP(20) + payload.
+        assert_eq!(frames[0].data.len(), ETH_HDR_LEN + IPV6_HDR_LEN + TCP_HDR_LEN + 16);
+    }
+
+    #[test]
+    fn synthetic_tuple_is_stable_and_distinct() {
+        let a1 = FlowSynthesizer::synthetic_tuple(42);
+        let a2 = FlowSynthesizer::synthetic_tuple(42);
+        let b = FlowSynthesizer::synthetic_tuple(43);
+        assert_eq!(a1, a2, "same conn_id → same tuple");
+        assert_ne!(a1, b, "different conn_id → different tuple");
+    }
+
+    #[test]
+    fn segment_size_zero_falls_back_to_default() {
+        let cfg = SynthConfig {
+            segment_size: 0,
+            ..Default::default()
+        };
+        let mut s = FlowSynthesizer::new(cfg);
+        s.open(1, v4_tuple(), 0);
+        let body = vec![b'Z'; DEFAULT_SEGMENT_SIZE + 1];
+        let frames = s.data(1, StreamDir::ClientToServer, &body, 0);
+        assert_eq!(frames.len(), 2, "default segment size still chunks");
+    }
+}

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -301,6 +301,54 @@ pub enum CaptureSourceConfig {
         #[serde(default = "default_cloud_probe_hwm")]
         recv_hwm: i32,
     },
+    /// eBPF SSL-uprobe capture (Linux only). Attaches uprobes to `SSL_read` /
+    /// `SSL_write` to observe the plaintext of TLS-encrypted LLM API calls
+    /// without a proxy, then reconstructs synthetic TCP frames that feed the
+    /// existing pipeline. Construction is Linux-gated in the capture factory;
+    /// the config itself parses on every platform so a shared config file is
+    /// portable.
+    Ebpf {
+        #[serde(default)]
+        source_id: Option<String>,
+        /// Explicit `libssl` paths to attach to. Empty = autodetect by scanning
+        /// running processes' mapped libraries (`/proc/*/maps`).
+        #[serde(default)]
+        ssl_libs: Vec<String>,
+        /// Static-binary targets (Phase 3): binaries with no dynamic `libssl`
+        /// whose TLS functions are located by symbol or byte-pattern offset.
+        #[serde(default)]
+        targets: Vec<EbpfTarget>,
+        /// Restrict capture to these PIDs. Empty = all processes.
+        #[serde(default)]
+        pid_allowlist: Vec<u32>,
+        /// Target payload size (bytes) per synthesized TCP segment.
+        #[serde(default = "default_ebpf_segment_size")]
+        segment_size: u32,
+    },
+}
+
+/// A static-binary uprobe target for eBPF capture (Phase 3). Used for runtimes
+/// that statically link their TLS library (e.g. Claude Code's Bun binary), so
+/// there is no `libssl.so` to attach to by name.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct EbpfTarget {
+    /// Absolute path to the executable to attach uprobes to.
+    pub binary: String,
+    /// TLS library flavor baked into the binary, selecting the symbol /
+    /// byte-pattern strategy used to locate `SSL_read` / `SSL_write`.
+    /// e.g. `"openssl"`, `"boringssl"`.
+    #[serde(default = "default_ebpf_target_flavor")]
+    pub flavor: String,
+}
+
+fn default_ebpf_target_flavor() -> String {
+    "boringssl".to_string()
+}
+
+fn default_ebpf_segment_size() -> u32 {
+    // 16 KiB — matches h-capture's synth DEFAULT_SEGMENT_SIZE. Kept in sync by
+    // value (h-common must not depend on h-capture).
+    16 * 1024
 }
 
 impl CaptureSourceConfig {
@@ -325,6 +373,9 @@ impl CaptureSourceConfig {
                 Some(source_id.clone().unwrap_or(base))
             }
             Self::CloudProbe { .. } => None,
+            Self::Ebpf { source_id, .. } => {
+                Some(source_id.clone().unwrap_or_else(|| "ebpf".to_string()))
+            }
         }
     }
 }

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -339,6 +339,19 @@ pub struct EbpfTarget {
     /// e.g. `"openssl"`, `"boringssl"`.
     #[serde(default = "default_ebpf_target_flavor")]
     pub flavor: String,
+    /// Optional byte-signature override for `SSL_write`'s prologue, as a pattern
+    /// of space-separated hex bytes with `??` wildcards
+    /// (e.g. `"55 41 57 ?? 48 8b"`). Signatures are version-specific to one
+    /// statically-linked TLS build, so they live in config (data) rather than
+    /// code: an operator can pin their exact Bun / Claude Code release without a
+    /// rebuild. When unset, the loader falls back to the built-in signature for
+    /// `flavor` (if any).
+    #[serde(default)]
+    pub write_sig: Option<String>,
+    /// Optional byte-signature override for `SSL_read`'s prologue. See
+    /// [`Self::write_sig`].
+    #[serde(default)]
+    pub read_sig: Option<String>,
 }
 
 fn default_ebpf_target_flavor() -> String {

--- a/server/h-common/src/config.rs
+++ b/server/h-common/src/config.rs
@@ -352,6 +352,14 @@ pub struct EbpfTarget {
     /// [`Self::write_sig`].
     #[serde(default)]
     pub read_sig: Option<String>,
+    /// Explicit `SSL_write` file offset, bypassing signature scanning entirely.
+    /// For when the offset is already known (e.g. from `sigscan_probe` or RE) —
+    /// also the validation path used while deriving a signature for a new build.
+    #[serde(default)]
+    pub write_offset: Option<u64>,
+    /// Explicit `SSL_read` file offset. See [`Self::write_offset`].
+    #[serde(default)]
+    pub read_offset: Option<u64>,
 }
 
 fn default_ebpf_target_flavor() -> String {

--- a/server/h-common/src/config_edit.rs
+++ b/server/h-common/src/config_edit.rs
@@ -172,6 +172,12 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
                     let mut tt = Table::new();
                     tt["binary"] = value(target.binary.as_str());
                     tt["flavor"] = value(target.flavor.as_str());
+                    if let Some(sig) = &target.write_sig {
+                        tt["write_sig"] = value(sig.as_str());
+                    }
+                    if let Some(sig) = &target.read_sig {
+                        tt["read_sig"] = value(sig.as_str());
+                    }
                     arr.push(tt);
                 }
                 t["targets"] = toml_edit::Item::ArrayOfTables(arr);

--- a/server/h-common/src/config_edit.rs
+++ b/server/h-common/src/config_edit.rs
@@ -178,6 +178,12 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
                     if let Some(sig) = &target.read_sig {
                         tt["read_sig"] = value(sig.as_str());
                     }
+                    if let Some(off) = target.write_offset {
+                        tt["write_offset"] = value(off as i64);
+                    }
+                    if let Some(off) = target.read_offset {
+                        tt["read_offset"] = value(off as i64);
+                    }
                     arr.push(tt);
                 }
                 t["targets"] = toml_edit::Item::ArrayOfTables(arr);

--- a/server/h-common/src/config_edit.rs
+++ b/server/h-common/src/config_edit.rs
@@ -134,6 +134,49 @@ fn source_to_table(s: &CaptureSourceConfig) -> Table {
             t["endpoint"] = value(endpoint.as_str());
             t["recv_hwm"] = value(i64::from(*recv_hwm));
         }
+        CaptureSourceConfig::Ebpf {
+            source_id,
+            ssl_libs,
+            targets,
+            pid_allowlist,
+            segment_size,
+        } => {
+            t["type"] = value("ebpf");
+            if let Some(id) = source_id {
+                t["source_id"] = value(id.as_str());
+            }
+            // Emit list/scalar knobs only when non-default so an autodetecting
+            // ebpf source's TOML stays minimal.
+            if !ssl_libs.is_empty() {
+                let mut arr = toml_edit::Array::new();
+                for lib in ssl_libs {
+                    arr.push(lib.as_str());
+                }
+                t["ssl_libs"] = value(arr);
+            }
+            if !pid_allowlist.is_empty() {
+                let mut arr = toml_edit::Array::new();
+                for pid in pid_allowlist {
+                    arr.push(i64::from(*pid));
+                }
+                t["pid_allowlist"] = value(arr);
+            }
+            if *segment_size != 16 * 1024 {
+                t["segment_size"] = value(i64::from(*segment_size));
+            }
+            // `targets` (static-binary Phase 3) is an array-of-tables; emit it
+            // as such when present.
+            if !targets.is_empty() {
+                let mut arr = toml_edit::ArrayOfTables::new();
+                for target in targets {
+                    let mut tt = Table::new();
+                    tt["binary"] = value(target.binary.as_str());
+                    tt["flavor"] = value(target.flavor.as_str());
+                    arr.push(tt);
+                }
+                t["targets"] = toml_edit::Item::ArrayOfTables(arr);
+            }
+        }
     }
     t
 }

--- a/server/h-common/src/lib.rs
+++ b/server/h-common/src/lib.rs
@@ -17,5 +17,6 @@ pub mod config_edit;
 pub mod error;
 pub mod internal_metrics;
 pub mod path;
+pub mod process;
 pub mod throttle;
 pub mod version;

--- a/server/h-common/src/process.rs
+++ b/server/h-common/src/process.rs
@@ -1,0 +1,53 @@
+//! Process attribution for a captured connection.
+//!
+//! Packet-tap sources (pcap live / file, cloud-probe) observe traffic on the
+//! wire and cannot know which local process owns a connection, so their packets
+//! carry no [`ProcessInfo`]. The eBPF SSL-uprobe source, by contrast, runs in
+//! the kernel context of the calling process and learns its pid / `comm` (and,
+//! best-effort in userspace, its executable path) for free — that on-host
+//! attribution is the eBPF path's differentiating value over a passive tap.
+//!
+//! The type lives here (not in `h-capture` where `RawPacket` is defined) so
+//! every pipeline crate — capture, protocol, llm, storage — can name it through
+//! its existing `h-common` dependency without adding a cross-crate edge. It sits
+//! alongside the [`agent`](crate::agent) taxonomies for the same reason.
+
+use serde::{Deserialize, Serialize};
+
+/// Identifies the local process that owns a captured connection.
+///
+/// Only ever `Some(_)` on packets produced by an attribution-capable source
+/// (today: eBPF). Threaded end-to-end — `RawPacket` → `ParsedPacket` →
+/// `TcpFlow` → `Http{Request,Response}Data` → `LlmCall` → storage → API — so a
+/// call surfaced in the console can be traced back to the agent process that
+/// made it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessInfo {
+    /// Kernel process id of the connection owner.
+    pub pid: u32,
+    /// The process `comm` (kernel `TASK_COMM_LEN`-bounded name, ≤15 chars), e.g.
+    /// `python3`, `node`, `claude`. Cheap to obtain in the BPF program.
+    pub comm: String,
+    /// Absolute executable path (`/proc/<pid>/exe`), resolved best-effort in
+    /// userspace. `None` when the link could not be read (process already exited,
+    /// permission denied) or on a source that does not resolve it.
+    pub exe: Option<String>,
+}
+
+impl ProcessInfo {
+    /// Construct from the fields an eBPF event always carries (pid + comm),
+    /// leaving the userspace-resolved `exe` empty.
+    pub fn new(pid: u32, comm: impl Into<String>) -> Self {
+        Self {
+            pid,
+            comm: comm.into(),
+            exe: None,
+        }
+    }
+
+    /// Builder-style setter for the best-effort executable path.
+    pub fn with_exe(mut self, exe: Option<String>) -> Self {
+        self.exe = exe;
+        self
+    }
+}

--- a/server/h-ebpf-common/Cargo.toml
+++ b/server/h-ebpf-common/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "h-ebpf-common"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Shared, no_std-compatible event layout used by BOTH the BPF program
+# (h-ebpf-prog) and the userspace loader (h-capture's `ebpf` feature). It has no
+# dependencies so it builds for the `bpfel-unknown-none` target and for the host
+# alike.
+[dependencies]
+
+[lib]
+path = "src/lib.rs"

--- a/server/h-ebpf-common/src/lib.rs
+++ b/server/h-ebpf-common/src/lib.rs
@@ -1,0 +1,60 @@
+//! Shared event layout for the eBPF SSL-uprobe capture path.
+//!
+//! Defined once and used by both sides of the ring buffer:
+//! * the BPF program (`h-ebpf-prog`, compiled for `bpfel-unknown-none`) writes
+//!   these records, and
+//! * the userspace loader (`h-capture`'s `ebpf` feature) reads them back.
+//!
+//! `#![no_std]` with no dependencies so it builds for the BPF target and the
+//! host identically. The layout is `#[repr(C)]` and POD; the loader reads each
+//! ring-buffer slice with an unaligned read, so no alignment guarantees are
+//! required from the ring buffer.
+
+#![no_std]
+
+/// Length of a process `comm` (kernel `TASK_COMM_LEN`).
+pub const COMM_LEN: usize = 16;
+
+/// Maximum plaintext bytes carried in a single event. A larger `SSL_read` /
+/// `SSL_write` is emitted as several consecutive same-direction events, which
+/// the userspace synthesizer concatenates by sequence number — so this cap
+/// never loses bytes, it only bounds per-event size (BPF stack/verifier
+/// limits make one giant copy impossible).
+pub const DATA_CAP: usize = 4096;
+
+/// Event kind discriminants (`SslEvent::kind`).
+pub mod kind {
+    /// Plaintext written by the client (`SSL_write`) — client→server.
+    pub const DATA_WRITE: u32 = 1;
+    /// Plaintext read by the client (`SSL_read`) — server→client.
+    pub const DATA_READ: u32 = 2;
+    /// Connection torn down (`SSL_shutdown` / `SSL_free`).
+    pub const CLOSE: u32 = 3;
+}
+
+/// One ring-buffer record. Fixed size (`DATA_CAP` payload) so the BPF program
+/// can reserve it in the ring buffer and fill `data[..data_len]`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SslEvent {
+    /// One of [`kind`].
+    pub kind: u32,
+    /// Userspace PID (thread-group id) that made the call.
+    pub pid: u32,
+    /// Per-connection handle: the `SSL*` pointer value, unique among live
+    /// connections in a process. Identifies the logical connection.
+    pub conn_id: u64,
+    /// Kernel monotonic timestamp (`bpf_ktime_get_ns`).
+    pub ktime_ns: u64,
+    /// Valid bytes in `data` (0 for `CLOSE`).
+    pub data_len: u32,
+    /// Process name (`bpf_get_current_comm`), NUL-padded.
+    pub comm: [u8; COMM_LEN],
+    /// Plaintext payload, valid for `data_len` bytes.
+    pub data: [u8; DATA_CAP],
+}
+
+impl SslEvent {
+    /// Total size of the record on the wire.
+    pub const SIZE: usize = core::mem::size_of::<Self>();
+}

--- a/server/h-ebpf-prog/.cargo/config.toml
+++ b/server/h-ebpf-prog/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Build this crate for the BPF target with a freshly-built `core`. bpf-linker
+# (cargo install bpf-linker) performs the final link.
+[build]
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core"]

--- a/server/h-ebpf-prog/Cargo.toml
+++ b/server/h-ebpf-prog/Cargo.toml
@@ -1,0 +1,32 @@
+# Standalone workspace: detaches this crate from the server workspace so
+# `cargo build --package h-ebpf-prog` (invoked by aya-build) resolves it as its
+# own root rather than an excluded member of the parent.
+[workspace]
+
+[package]
+name = "h-ebpf-prog"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# The BPF program. Compiled for `bpfel-unknown-none` (see rust-toolchain.toml +
+# .cargo/config.toml), linked by bpf-linker, and embedded into h-capture by its
+# build.rs (aya-build). EXCLUDED from the server workspace — it uses a different
+# target and toolchain, so it must never be pulled into a host `cargo build`.
+
+[dependencies]
+aya-ebpf = "0.1"
+h-ebpf-common = { path = "../h-ebpf-common" }
+
+[[bin]]
+name = "h-ebpf-prog"
+path = "src/main.rs"
+
+# BPF must be optimized; the verifier rejects most debug-profile output.
+[profile.dev]
+opt-level = 3
+debug = false
+[profile.release]
+opt-level = 3
+debug = false
+lto = true

--- a/server/h-ebpf-prog/rust-toolchain.toml
+++ b/server/h-ebpf-prog/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]

--- a/server/h-ebpf-prog/src/main.rs
+++ b/server/h-ebpf-prog/src/main.rs
@@ -1,0 +1,138 @@
+//! BPF program for eBPF SSL-uprobe capture.
+//!
+//! Attaches to OpenSSL / BoringSSL `SSL_write`, `SSL_read` and `SSL_shutdown`
+//! and streams the plaintext (and connection lifecycle) to userspace over a
+//! ring buffer as [`SslEvent`] records. The userspace loader (h-capture's
+//! `EbpfSource`) turns those into synthetic TCP frames.
+//!
+//! Direction mapping: `SSL_write` ⇒ client→server (request), `SSL_read` ⇒
+//! server→client (response). `SSL_read` reads its buffer only on return, so we
+//! stash its args on entry and emit on the uretprobe using the real byte count.
+
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    helpers::{
+        bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_ktime_get_ns,
+        gen::bpf_probe_read_user,
+    },
+    macros::{map, uprobe, uretprobe},
+    maps::{HashMap, RingBuf},
+    programs::{ProbeContext, RetProbeContext},
+};
+use core::ffi::c_void;
+use h_ebpf_common::{kind, SslEvent, DATA_CAP};
+
+/// Ring buffer carrying [`SslEvent`]s to userspace (16 MiB).
+#[map]
+static EVENTS: RingBuf = RingBuf::with_byte_size(16 * 1024 * 1024, 0);
+
+/// `SSL_read` entry args stashed by tid until the matching uretprobe fires.
+#[map]
+static READ_ARGS: HashMap<u32, ReadArgs> = HashMap::with_max_entries(10240, 0);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ReadArgs {
+    ssl: u64,
+    buf: u64,
+}
+
+#[uprobe]
+pub fn ssl_write(ctx: ProbeContext) -> u32 {
+    let ssl: u64 = ctx.arg(0).unwrap_or(0);
+    let buf: u64 = ctx.arg(1).unwrap_or(0);
+    let num: i32 = ctx.arg(2).unwrap_or(0);
+    if buf != 0 && num > 0 {
+        emit_data(kind::DATA_WRITE, ssl, buf, num as u32);
+    }
+    0
+}
+
+#[uprobe]
+pub fn ssl_read_enter(ctx: ProbeContext) -> u32 {
+    let ssl: u64 = ctx.arg(0).unwrap_or(0);
+    let buf: u64 = ctx.arg(1).unwrap_or(0);
+    let tid = bpf_get_current_pid_tgid() as u32;
+    let args = ReadArgs { ssl, buf };
+    let _ = READ_ARGS.insert(&tid, &args, 0);
+    0
+}
+
+#[uretprobe]
+pub fn ssl_read_exit(ctx: RetProbeContext) -> u32 {
+    let tid = bpf_get_current_pid_tgid() as u32;
+    let args = match unsafe { READ_ARGS.get(&tid) } {
+        Some(a) => *a,
+        None => return 0,
+    };
+    let _ = READ_ARGS.remove(&tid);
+    let ret: i32 = ctx.ret().unwrap_or(0);
+    if args.buf != 0 && ret > 0 {
+        emit_data(kind::DATA_READ, args.ssl, args.buf, ret as u32);
+    }
+    0
+}
+
+#[uprobe]
+pub fn ssl_shutdown(ctx: ProbeContext) -> u32 {
+    let ssl: u64 = ctx.arg(0).unwrap_or(0);
+    emit_close(ssl);
+    0
+}
+
+/// Reserve a ring-buffer record, fill the header, and copy up to [`DATA_CAP`]
+/// plaintext bytes from the userspace buffer. A larger call is truncated to
+/// `DATA_CAP` here; the userspace synthesizer treats each event as a contiguous
+/// segment, so consecutive events on the same connection reassemble in order.
+fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
+    let n = if len as usize > DATA_CAP {
+        DATA_CAP as u32
+    } else {
+        len
+    };
+    let mut entry = match EVENTS.reserve::<SslEvent>(0) {
+        Some(e) => e,
+        None => return,
+    };
+    let ev = entry.as_mut_ptr();
+    unsafe {
+        (*ev).kind = ev_kind;
+        (*ev).pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+        (*ev).conn_id = ssl;
+        (*ev).ktime_ns = bpf_ktime_get_ns();
+        (*ev).data_len = n;
+        if let Ok(comm) = bpf_get_current_comm() {
+            (*ev).comm = comm;
+        }
+        let dst = core::ptr::addr_of_mut!((*ev).data) as *mut c_void;
+        let _ = bpf_probe_read_user(dst, n, buf as *const c_void);
+    }
+    entry.submit(0);
+}
+
+fn emit_close(ssl: u64) {
+    let mut entry = match EVENTS.reserve::<SslEvent>(0) {
+        Some(e) => e,
+        None => return,
+    };
+    let ev = entry.as_mut_ptr();
+    unsafe {
+        (*ev).kind = kind::CLOSE;
+        (*ev).pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+        (*ev).conn_id = ssl;
+        (*ev).ktime_ns = bpf_ktime_get_ns();
+        (*ev).data_len = 0;
+        if let Ok(comm) = bpf_get_current_comm() {
+            (*ev).comm = comm;
+        }
+    }
+    entry.submit(0);
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/server/h-llm/Cargo.toml
+++ b/server/h-llm/Cargo.toml
@@ -27,3 +27,8 @@ required-features = ["test-support"]
 
 [dev-dependencies]
 toml = "0.8"
+# tests/synth_e2e.rs drives the full capture→protocol→llm chain from
+# synthesized eBPF-style frames. h-protocol is already a normal dependency;
+# h-capture is restated so the integration test can name it directly.
+h-capture.workspace = true
+h-protocol.workspace = true

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -293,6 +293,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/agents/codex_cli.rs
+++ b/server/h-llm/src/agents/codex_cli.rs
@@ -303,6 +303,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/agents/generic.rs
+++ b/server/h-llm/src/agents/generic.rs
@@ -326,6 +326,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/agents/hermes.rs
+++ b/server/h-llm/src/agents/hermes.rs
@@ -280,6 +280,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/agents/mod.rs
+++ b/server/h-llm/src/agents/mod.rs
@@ -100,6 +100,7 @@ mod priority_tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/agents/openclaw.rs
+++ b/server/h-llm/src/agents/openclaw.rs
@@ -380,6 +380,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/agents/opencode.rs
+++ b/server/h-llm/src/agents/opencode.rs
@@ -190,6 +190,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         })
     }
 

--- a/server/h-llm/src/model.rs
+++ b/server/h-llm/src/model.rs
@@ -75,6 +75,12 @@ pub struct LlmCall {
     /// Extraction (usage/model) always runs on the full body upstream, so a
     /// non-zero value never implies lost metrics — only a truncated stored body.
     pub body_bytes_dropped: u64,
+    /// Owning process (pid / comm / exe), when the capture source attributes it
+    /// (eBPF). `None` for passive taps (pcap / cloud-probe). Copied from the
+    /// request's process attribution (falling back to the response's) in the
+    /// LLM stage, persisted to storage, and surfaced in the console so a call
+    /// can be traced back to the agent process that made it.
+    pub process: Option<h_common::process::ProcessInfo>,
 }
 
 /// Per-call agent-side info produced once an `AgentProfile` has matched —
@@ -393,6 +399,7 @@ mod extension_tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         };
         let arc = Arc::new(call);
         let id = AgentCallInfo {
@@ -457,6 +464,7 @@ mod extension_tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         };
         assert!(call.finish_reason.is_none());
     }

--- a/server/h-llm/src/processor.rs
+++ b/server/h-llm/src/processor.rs
@@ -344,6 +344,13 @@ impl LlmProcessor {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped,
+            // Process attribution rides on the request (the SSL_write side that
+            // the eBPF probe sees first); fall back to the response in case the
+            // flow only learned it on the inbound direction.
+            process: request
+                .process
+                .clone()
+                .or_else(|| response.process.clone()),
         };
 
         let agent = build_agent_call_info_with_parsed(
@@ -532,6 +539,7 @@ mod tests {
             ],
             body: Bytes::from(body_json.to_string()),
             timestamp_us: 1_000_000,
+            process: None,
         }
     }
 
@@ -561,6 +569,7 @@ mod tests {
             body: if is_sse { Bytes::new() } else { resp_body },
             first_byte_timestamp_us: timestamp_us + 100_000,
             complete_timestamp_us: timestamp_us + 200_000,
+            process: None,
         };
         (Arc::new(req), resp)
     }
@@ -574,6 +583,7 @@ mod tests {
             event_type: event_type.to_string(),
             data: data.to_string(),
             timestamp_us: ts,
+            process: None,
         }
     }
 
@@ -608,6 +618,7 @@ mod tests {
             headers: vec![],
             body: Bytes::new(),
             timestamp_us: 0,
+            process: None,
         };
         let events = proc.process(HttpJoinerEvent::Request(Arc::new(req)));
         assert!(events.is_empty());
@@ -1099,6 +1110,7 @@ mod tests {
             ],
             body: Bytes::from(body.to_string()),
             timestamp_us: 1_000_000,
+            process: None,
         };
         let resp_body = serde_json::json!({
             "id": "msg_01",
@@ -1170,6 +1182,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/profile.rs
+++ b/server/h-llm/src/profile.rs
@@ -250,6 +250,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/stage.rs
+++ b/server/h-llm/src/stage.rs
@@ -272,6 +272,7 @@ mod tests {
             ],
             body: Bytes::from(body.to_string()),
             timestamp_us: ts_us,
+            process: None,
         }
     }
 
@@ -295,6 +296,7 @@ mod tests {
             body: Bytes::from(body.to_string()),
             first_byte_timestamp_us: ts_us + 100_000,
             complete_timestamp_us: ts_us + 200_000,
+            process: None,
         }
     }
 
@@ -320,6 +322,7 @@ mod tests {
             ],
             body: Bytes::from(body.to_string()),
             timestamp_us: ts_us,
+            process: None,
         }
     }
 
@@ -342,6 +345,7 @@ mod tests {
             body: Bytes::from(body.to_string()),
             first_byte_timestamp_us: ts_us + 100_000,
             complete_timestamp_us: ts_us + 200_000,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/test_support.rs
+++ b/server/h-llm/src/test_support.rs
@@ -44,5 +44,6 @@ pub fn empty_llm_call() -> LlmCall {
         tool_call_count: 0,
         tool_names: vec![],
         body_bytes_dropped: 0,
+        process: None,
     }
 }

--- a/server/h-llm/src/wire_api_registry.rs
+++ b/server/h-llm/src/wire_api_registry.rs
@@ -174,6 +174,7 @@ mod tests {
                 .collect(),
             body,
             timestamp_us: 0,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/wire_apis/anthropic.rs
+++ b/server/h-llm/src/wire_apis/anthropic.rs
@@ -805,6 +805,7 @@ mod tests {
             event_type: event_type.to_string(),
             data: data.to_string(),
             timestamp_us: 0,
+            process: None,
         }
     }
 
@@ -1081,6 +1082,7 @@ mod tests {
             body: bytes::Bytes::from(body.to_string()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(resp.body.clone());
         let info = extract_from_response(&resp, &cache);

--- a/server/h-llm/src/wire_apis/gemini_aistudio.rs
+++ b/server/h-llm/src/wire_apis/gemini_aistudio.rs
@@ -791,6 +791,7 @@ mod tests {
             headers: vec![],
             body: Bytes::copy_from_slice(body.as_bytes()),
             timestamp_us: 0,
+            process: None,
         }
     }
 
@@ -806,6 +807,7 @@ mod tests {
             body: Bytes::copy_from_slice(body.as_bytes()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         }
     }
 
@@ -819,6 +821,7 @@ mod tests {
             event_type: String::new(),
             data: data.to_string(),
             timestamp_us: 0,
+            process: None,
         }
     }
 

--- a/server/h-llm/src/wire_apis/openai/chat.rs
+++ b/server/h-llm/src/wire_apis/openai/chat.rs
@@ -715,6 +715,7 @@ mod tests {
             event_type: event_type.to_string(),
             data: data.to_string(),
             timestamp_us: 0,
+            process: None,
         }
     }
 
@@ -935,6 +936,7 @@ mod tests {
             headers: vec![("authorization".to_string(), "Bearer sk-test".to_string())],
             body: bytes::Bytes::from(body.to_string()),
             timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(req.body.clone());
         let info = extract_request(&req, &cache);
@@ -1019,6 +1021,7 @@ mod tests {
             body: bytes::Bytes::from(body.to_string()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(resp.body.clone());
         let info = extract_response(&resp, &cache);
@@ -1058,6 +1061,7 @@ mod tests {
             body: bytes::Bytes::from(body.to_string()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(resp.body.clone());
         let info = extract_response(&resp, &cache);
@@ -1095,6 +1099,7 @@ mod tests {
             body: bytes::Bytes::from(body.to_string()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(resp.body.clone());
         let info = extract_response(&resp, &cache);

--- a/server/h-llm/src/wire_apis/openai/responses.rs
+++ b/server/h-llm/src/wire_apis/openai/responses.rs
@@ -727,6 +727,7 @@ mod tests {
             event_type: event_type.to_string(),
             data: data.to_string(),
             timestamp_us: 0,
+            process: None,
         }
     }
 
@@ -841,6 +842,7 @@ mod tests {
             body: bytes::Bytes::from(body.to_string()),
             first_byte_timestamp_us: 0,
             complete_timestamp_us: 0,
+            process: None,
         };
         let cache = ParsedJson::from_bytes(resp.body.clone());
         let info = extract_response(&resp, &cache);

--- a/server/h-llm/tests/synth_e2e.rs
+++ b/server/h-llm/tests/synth_e2e.rs
@@ -1,0 +1,102 @@
+//! End-to-end Phase 0 test: synthesized eBPF-style plaintext chunks all the way
+//! to an extracted `LlmCall`.
+//!
+//! This is the strongest validation that the stream→packet synthesis path is
+//! sound: it drives the entire production chain — [`FlowSynthesizer`] →
+//! `de::decode` → `FlowWorker` (TCP reassembly + HTTP parse) → `HttpJoiner`
+//! (request/response pairing) → `LlmProcessor` (wire-API detection + LLM
+//! extraction) — and asserts a real `LlmCall` emerges with the right model,
+//! path and token accounting. No kernel, no privileges: runs in CI everywhere.
+
+use std::sync::Arc;
+
+use h_capture::{ConnTuple, FlowSynthesizer, RawPacket, StreamDir, SynthConfig};
+use h_common::internal_metrics::{Metric, MetricsSystem, MetricsWorker};
+use h_llm::model::{LlmCall, LlmEvent};
+use h_llm::processor::LlmProcessor;
+use h_llm::wire_apis::build_default_wire_api_registry;
+use h_llm::AgentProfileRegistry;
+use h_protocol::de::decode;
+use h_protocol::joiner::HttpJoiner;
+use h_protocol::tcp::FlowWorker;
+use h_protocol::WorkerInput;
+
+fn metrics(role: &str) -> MetricsWorker {
+    let mut sys = MetricsSystem::new();
+    let w = sys.register_worker(role, Metric::ALL);
+    let _ = sys.start();
+    w
+}
+
+/// Run synthesized frames through the entire capture→protocol→llm chain and
+/// return every emitted `LlmEvent`.
+fn drive(frames: Vec<RawPacket>) -> Vec<LlmEvent> {
+    let mut worker = FlowWorker::new(metrics("synth-flow"));
+    let mut joiner = HttpJoiner::new(metrics("synth-joiner"));
+    let mut proc = LlmProcessor::new(
+        Arc::new(build_default_wire_api_registry()),
+        Arc::new(AgentProfileRegistry::new()),
+        metrics("synth-llm"),
+    );
+
+    let mut out = Vec::new();
+    for p in frames {
+        let parsed = decode(&p.data, p.link_type, p.timestamp_us, p.source_id.clone())
+            .unwrap_or_else(|e| panic!("synthesized frame must decode: {e:?}"));
+        for parse_ev in worker.process(WorkerInput::Packet(parsed)) {
+            for join_ev in joiner.process(parse_ev) {
+                out.extend(proc.process(join_ev));
+            }
+        }
+    }
+    out
+}
+
+fn completed_calls(events: &[LlmEvent]) -> Vec<Arc<LlmCall>> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            LlmEvent::Complete { call, .. } => Some(call.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn synthesized_anthropic_call_extracts_llmcall() {
+    let mut s = FlowSynthesizer::new(SynthConfig::default());
+    let tuple = ConnTuple {
+        client: "10.4.4.4:51000".parse().unwrap(),
+        server: "160.79.104.10:443".parse().unwrap(),
+    };
+
+    let req_body = r#"{"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}"#;
+    let req = format!(
+        "POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{req_body}",
+        req_body.len()
+    );
+    let resp_body =
+        r#"{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":10,"output_tokens":5}}"#;
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{resp_body}",
+        resp_body.len()
+    );
+
+    let mut frames = s.open(1, tuple, 1_000);
+    frames.extend(s.data(1, StreamDir::ClientToServer, req.as_bytes(), 2_000));
+    frames.extend(s.data(1, StreamDir::ServerToClient, resp.as_bytes(), 3_000));
+    frames.extend(s.close(1, 4_000));
+
+    let events = drive(frames);
+    let calls = completed_calls(&events);
+    assert_eq!(calls.len(), 1, "exactly one LlmCall should be extracted");
+
+    let call = &calls[0];
+    assert_eq!(call.model, "claude-sonnet-4-6");
+    assert_eq!(call.request_path, "/v1/messages");
+    assert_eq!(call.status_code, Some(200));
+    assert_eq!(call.input_tokens, Some(10));
+    assert_eq!(call.output_tokens, Some(5));
+    assert_eq!(call.source_id, "ebpf", "carries the synthesizer's source_id");
+}

--- a/server/h-llm/tests/synth_e2e.rs
+++ b/server/h-llm/tests/synth_e2e.rs
@@ -72,8 +72,8 @@ fn completed_calls(events: &[LlmEvent]) -> Vec<Arc<LlmCall>> {
 fn synthesized_anthropic_call_extracts_llmcall() {
     let mut s = FlowSynthesizer::new(SynthConfig::default());
     let tuple = ConnTuple {
-        client: "10.4.4.4:51000".parse().unwrap(),
-        server: "160.79.104.10:443".parse().unwrap(),
+        client: "203.0.113.4:51000".parse().unwrap(),
+        server: "192.0.2.10:443".parse().unwrap(),
     };
 
     let req_body = r#"{"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}"#;
@@ -118,8 +118,8 @@ fn synthesized_call_via_pump_carries_process_attribution() {
     // Offset-0 clock: ktime µs maps straight to epoch µs. No pid allowlist.
     let mut pump = EbpfPump::new(SynthConfig::default(), BootClock::with_offset_us(0), vec![]);
     let tuple = ConnTuple {
-        client: "10.4.4.4:51000".parse().unwrap(),
-        server: "160.79.104.10:443".parse().unwrap(),
+        client: "203.0.113.4:51000".parse().unwrap(),
+        server: "192.0.2.10:443".parse().unwrap(),
     };
 
     let req_body = r#"{"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}"#;

--- a/server/h-llm/tests/synth_e2e.rs
+++ b/server/h-llm/tests/synth_e2e.rs
@@ -10,7 +10,10 @@
 
 use std::sync::Arc;
 
-use h_capture::{ConnTuple, FlowSynthesizer, RawPacket, StreamDir, SynthConfig};
+use bytes::Bytes;
+use h_capture::{
+    BootClock, ConnTuple, EbpfPump, FlowSynthesizer, RawPacket, SslEvent, StreamDir, SynthConfig,
+};
 use h_common::internal_metrics::{Metric, MetricsSystem, MetricsWorker};
 use h_llm::model::{LlmCall, LlmEvent};
 use h_llm::processor::LlmProcessor;
@@ -41,8 +44,11 @@ fn drive(frames: Vec<RawPacket>) -> Vec<LlmEvent> {
 
     let mut out = Vec::new();
     for p in frames {
-        let parsed = decode(&p.data, p.link_type, p.timestamp_us, p.source_id.clone())
+        let mut parsed = decode(&p.data, p.link_type, p.timestamp_us, p.source_id.clone())
             .unwrap_or_else(|e| panic!("synthesized frame must decode: {e:?}"));
+        // Mirror the production `FlowDispatcher`: carry process attribution from
+        // the raw packet onto the parsed one (`decode` sees only wire bytes).
+        parsed.process = p.process.clone();
         for parse_ev in worker.process(WorkerInput::Packet(parsed)) {
             for join_ev in joiner.process(parse_ev) {
                 out.extend(proc.process(join_ev));
@@ -99,4 +105,77 @@ fn synthesized_anthropic_call_extracts_llmcall() {
     assert_eq!(call.input_tokens, Some(10));
     assert_eq!(call.output_tokens, Some(5));
     assert_eq!(call.source_id, "ebpf", "carries the synthesizer's source_id");
+}
+
+/// The differentiating value of the eBPF path: drive the chain from
+/// [`EbpfPump`] (which stamps pid/comm/exe onto the synthesized frames from the
+/// `SslEvent`s) and assert the attribution survives all the way to the
+/// `LlmCall`. This is the end-to-end proof that process attribution threads
+/// `RawPacket` → `ParsedPacket` → `TcpFlow` → `Http{Request,Response}Data` →
+/// `LlmCall` intact.
+#[test]
+fn synthesized_call_via_pump_carries_process_attribution() {
+    // Offset-0 clock: ktime µs maps straight to epoch µs. No pid allowlist.
+    let mut pump = EbpfPump::new(SynthConfig::default(), BootClock::with_offset_us(0), vec![]);
+    let tuple = ConnTuple {
+        client: "10.4.4.4:51000".parse().unwrap(),
+        server: "160.79.104.10:443".parse().unwrap(),
+    };
+
+    let req_body = r#"{"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}"#;
+    let req = format!(
+        "POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{req_body}",
+        req_body.len()
+    );
+    let resp_body =
+        r#"{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":10,"output_tokens":5}}"#;
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{resp_body}",
+        resp_body.len()
+    );
+
+    let exe = Some("/usr/bin/python3.12".to_string());
+    let mut frames = pump.on_event(SslEvent::Connect {
+        conn_id: 1,
+        pid: 31337,
+        comm: "python3".into(),
+        exe: exe.clone(),
+        tuple: Some(tuple),
+        ktime_ns: 1_000_000,
+    });
+    frames.extend(pump.on_event(SslEvent::Data {
+        conn_id: 1,
+        pid: 31337,
+        comm: "python3".into(),
+        exe: exe.clone(),
+        dir: StreamDir::ClientToServer,
+        data: Bytes::from(req.into_bytes()),
+        ktime_ns: 2_000_000,
+    }));
+    frames.extend(pump.on_event(SslEvent::Data {
+        conn_id: 1,
+        pid: 31337,
+        comm: "python3".into(),
+        exe: exe.clone(),
+        dir: StreamDir::ServerToClient,
+        data: Bytes::from(resp.into_bytes()),
+        ktime_ns: 3_000_000,
+    }));
+    frames.extend(pump.on_event(SslEvent::Close {
+        conn_id: 1,
+        ktime_ns: 4_000_000,
+    }));
+
+    let events = drive(frames);
+    let calls = completed_calls(&events);
+    assert_eq!(calls.len(), 1, "exactly one LlmCall should be extracted");
+
+    let proc = calls[0]
+        .process
+        .as_ref()
+        .expect("process attribution must survive the full chain");
+    assert_eq!(proc.pid, 31337);
+    assert_eq!(proc.comm, "python3");
+    assert_eq!(proc.exe.as_deref(), Some("/usr/bin/python3.12"));
 }

--- a/server/h-metrics/src/aggregator.rs
+++ b/server/h-metrics/src/aggregator.rs
@@ -444,6 +444,7 @@ mod tests {
                 tool_call_count: 0,
                 tool_names: vec![],
                 body_bytes_dropped: 0,
+                process: None,
             }),
             agent: None,
         }

--- a/server/h-metrics/src/bucket.rs
+++ b/server/h-metrics/src/bucket.rs
@@ -401,6 +401,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-metrics/src/stage.rs
+++ b/server/h-metrics/src/stage.rs
@@ -160,6 +160,7 @@ mod tests {
                 tool_call_count: 0,
                 tool_names: vec![],
                 body_bytes_dropped: 0,
+                process: None,
             }),
             agent: Some(AgentCallInfo {
                 agent_kind: "x",

--- a/server/h-metrics/tests/dimensions.rs
+++ b/server/h-metrics/tests/dimensions.rs
@@ -62,6 +62,7 @@ fn make_completed_call(request_time: i64, tool_surface: Option<ToolSurface>) -> 
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }),
         agent: None,
     }

--- a/server/h-protocol/Cargo.toml
+++ b/server/h-protocol/Cargo.toml
@@ -18,6 +18,9 @@ uuid.workspace = true
 [dev-dependencies]
 pcap.workspace = true
 criterion.workspace = true
+# Already a normal dependency above; restated here so integration tests
+# (tests/synth_pipeline.rs) can name `h_capture` directly.
+h-capture.workspace = true
 
 [[bench]]
 name = "hot_paths"

--- a/server/h-protocol/src/de/mod.rs
+++ b/server/h-protocol/src/de/mod.rs
@@ -87,6 +87,9 @@ pub fn decode(
         payload,
         wire_payload_len,
         timestamp_us,
+        // `decode` works on raw bytes only; the dispatcher copies process
+        // attribution from the owning `RawPacket` after decode.
+        process: None,
     })
 }
 

--- a/server/h-protocol/src/flow.rs
+++ b/server/h-protocol/src/flow.rs
@@ -43,7 +43,7 @@ impl FlowDispatcher {
     }
 
     async fn dispatch_packet(&self, raw: &RawPacket) -> bool {
-        let parsed = match de::decode(
+        let mut parsed = match de::decode(
             &raw.data,
             raw.link_type,
             raw.timestamp_us,
@@ -63,6 +63,10 @@ impl FlowDispatcher {
                 return true;
             }
         };
+
+        // Carry process attribution (eBPF) from the raw packet onto the parsed
+        // one — `decode` saw only wire bytes. No-op for passive taps (`None`).
+        parsed.process = raw.process.clone();
 
         self.metrics.counter(Metric::DispatcherPacketsRouted).inc();
 

--- a/server/h-protocol/src/http.rs
+++ b/server/h-protocol/src/http.rs
@@ -330,6 +330,8 @@ impl SseParser {
             event_type,
             data: data_parts.join("\n"),
             timestamp_us: timestamp,
+            // The flow stamps process attribution onto emitted events.
+            process: None,
         }))
     }
 }
@@ -441,6 +443,7 @@ impl HttpParser {
                                 headers: std::mem::take(&mut self.pending_req_headers),
                                 body,
                                 timestamp_us: self.pending_req_timestamp,
+                                process: None,
                             }));
                             self.state = ParserState::WaitingForResponse;
                             break;
@@ -479,6 +482,7 @@ impl HttpParser {
                             body: Bytes::new(),
                             first_byte_timestamp_us: self.pending_resp_timestamp,
                             complete_timestamp_us: server_ts,
+                            process: None,
                         }));
                         self.state = ParserState::WaitingForRequest;
                         continue;
@@ -543,6 +547,7 @@ impl HttpParser {
                                 body: emitted_body,
                                 first_byte_timestamp_us: self.pending_resp_timestamp,
                                 complete_timestamp_us: server_last_ts,
+                                process: None,
                             }));
                             self.state = ParserState::WaitingForRequest;
                             break;
@@ -601,6 +606,7 @@ impl HttpParser {
             body: emitted_body,
             first_byte_timestamp_us: self.pending_resp_timestamp,
             complete_timestamp_us: server_last_ts,
+            process: None,
         }));
         self.state = ParserState::WaitingForRequest;
     }

--- a/server/h-protocol/src/joiner.rs
+++ b/server/h-protocol/src/joiner.rs
@@ -335,6 +335,7 @@ mod tests {
             headers: vec![("content-type".to_string(), "application/json".to_string())],
             body: Bytes::from_static(b"{}"),
             timestamp_us: ts_us,
+            process: None,
         }
     }
 
@@ -359,6 +360,7 @@ mod tests {
             },
             first_byte_timestamp_us: ts_us + 100,
             complete_timestamp_us: ts_us + 200,
+            process: None,
         }
     }
 
@@ -371,6 +373,7 @@ mod tests {
             event_type: event_type.to_string(),
             data: data.to_string(),
             timestamp_us: ts_us,
+            process: None,
         }
     }
 

--- a/server/h-protocol/src/model.rs
+++ b/server/h-protocol/src/model.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use h_common::process::ProcessInfo;
 
 use crate::net::FlowKey;
 
@@ -31,6 +32,8 @@ pub struct SseEventData {
     /// SSE `data:` field content.
     pub data: String,
     pub timestamp_us: i64,
+    /// Owning process, stamped by the flow when the source attributes it (eBPF).
+    pub process: Option<ProcessInfo>,
 }
 
 /// A fully parsed HTTP request.
@@ -47,6 +50,8 @@ pub struct HttpRequestData {
     pub headers: Vec<(String, String)>,
     pub body: Bytes,
     pub timestamp_us: i64,
+    /// Owning process, stamped by the flow when the source attributes it (eBPF).
+    pub process: Option<ProcessInfo>,
 }
 
 /// A fully parsed HTTP response.
@@ -65,6 +70,8 @@ pub struct HttpResponseData {
     pub first_byte_timestamp_us: i64,
     /// Timestamp when the response was fully received (for E2E latency).
     pub complete_timestamp_us: i64,
+    /// Owning process, stamped by the flow when the source attributes it (eBPF).
+    pub process: Option<ProcessInfo>,
 }
 
 impl HttpRequestData {
@@ -94,6 +101,21 @@ impl HttpResponseData {
     /// Get Content-Type header.
     pub fn content_type(&self) -> Option<&str> {
         self.header("content-type")
+    }
+}
+
+impl HttpParseEvent {
+    /// Stamp process attribution onto a content event (request / response / SSE).
+    /// A no-op for [`HttpParseEvent::Heartbeat`], which carries no process. The
+    /// flow calls this on every event it emits, once it has learned the owning
+    /// process from the connection's first attributed packet.
+    pub fn set_process(&mut self, process: Option<ProcessInfo>) {
+        match self {
+            HttpParseEvent::HttpRequest(r) => r.process = process,
+            HttpParseEvent::HttpResponse(r) => r.process = process,
+            HttpParseEvent::SseEvent(s) => s.process = process,
+            HttpParseEvent::Heartbeat { .. } => {}
+        }
     }
 }
 

--- a/server/h-protocol/src/net.rs
+++ b/server/h-protocol/src/net.rs
@@ -2,6 +2,7 @@ use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
 use bytes::Bytes;
+use h_common::process::ProcessInfo;
 
 /// Identifies a TCP connection. Normalized so the smaller (IP, port) pair is
 /// always `addr_a`, ensuring both directions hash to the same key.
@@ -95,6 +96,10 @@ pub struct ParsedPacket {
     /// desynchronize the per-direction byte stream.
     pub wire_payload_len: u32,
     pub timestamp_us: i64,
+    /// Owning process, propagated from [`RawPacket`](h_capture::RawPacket) when
+    /// the source attributes it (eBPF). `None` for passive taps. The flow stores
+    /// the first non-`None` value and stamps it onto emitted HTTP events.
+    pub process: Option<ProcessInfo>,
 }
 
 // TCP flag constants.

--- a/server/h-protocol/src/tcp.rs
+++ b/server/h-protocol/src/tcp.rs
@@ -4,6 +4,7 @@ use std::net::IpAddr;
 use bytes::{Bytes, BytesMut};
 
 use h_common::internal_metrics::{Metric, MetricsWorker};
+use h_common::process::ProcessInfo;
 
 use crate::flow::WorkerInput;
 use crate::http::{HttpParser, ParseResult};
@@ -112,6 +113,11 @@ pub struct TcpFlow {
     flow_key: FlowKey,
     addr_a: (IpAddr, u16),
     addr_b: (IpAddr, u16),
+
+    /// Owning process for this connection, learned from the first attributed
+    /// packet (eBPF source) and stamped onto every HTTP event the flow emits.
+    /// `None` for passive taps, which never attribute a packet.
+    process: Option<ProcessInfo>,
 }
 
 impl TcpFlow {
@@ -141,13 +147,36 @@ impl TcpFlow {
             flow_key,
             addr_a,
             addr_b,
+            process: None,
         }
     }
 
     /// Process a parsed packet belonging to this flow.
     /// Emits HttpParseEvents to the output vec.
     /// Returns `true` if a resync event occurred.
+    ///
+    /// Thin wrapper around [`push_inner`](Self::push_inner): it learns the
+    /// connection's owning process from the first attributed packet and stamps
+    /// it onto every event emitted by this call, regardless of which internal
+    /// path produced them (normal parse, RST flush, mid-stream resync). Passive
+    /// taps carry no process, so the stamp is a no-op there.
     pub fn push(&mut self, pkt: &ParsedPacket, output: &mut Vec<HttpParseEvent>) -> bool {
+        if self.process.is_none() {
+            if let Some(p) = &pkt.process {
+                self.process = Some(p.clone());
+            }
+        }
+        let stamp_from = output.len();
+        let resync = self.push_inner(pkt, output);
+        if let Some(proc) = &self.process {
+            for ev in &mut output[stamp_from..] {
+                ev.set_process(Some(proc.clone()));
+            }
+        }
+        resync
+    }
+
+    fn push_inner(&mut self, pkt: &ParsedPacket, output: &mut Vec<HttpParseEvent>) -> bool {
         let mut resync = false;
         self.last_pkt_ts = pkt.timestamp_us;
         let events_before = output.len();
@@ -793,6 +822,7 @@ mod tests {
             payload: Bytes::copy_from_slice(payload),
             wire_payload_len: payload.len() as u32,
             timestamp_us: 0,
+            process: None,
         }
     }
 

--- a/server/h-protocol/tests/synth_pipeline.rs
+++ b/server/h-protocol/tests/synth_pipeline.rs
@@ -1,0 +1,296 @@
+//! Integration test: stream→packet synthesis through the real pipeline.
+//!
+//! Phase 0 of the eBPF capture work. An eBPF `SSL_read`/`SSL_write` uprobe sees
+//! plaintext byte chunks per connection per direction — no packet headers.
+//! [`h_capture::FlowSynthesizer`] dresses those chunks as Ethernet+IP+TCP
+//! frames; this test pushes the synthesized frames through the *production*
+//! decode → `FlowWorker` (TCP reassembly + HTTP parse) → `HttpJoiner` path and
+//! asserts the reassembler/parser reconstruct the same HTTP requests, responses
+//! and SSE events a real capture would yield. It validates the only novel
+//! correctness surface (frame synthesis) without any kernel or privileges, so
+//! it runs unmodified in CI on every platform.
+
+use h_capture::{ConnTuple, FlowSynthesizer, RawPacket, StreamDir, SynthConfig};
+use h_common::internal_metrics::{Metric, MetricsSystem};
+use h_protocol::de::decode;
+use h_protocol::joiner::{HttpJoiner, HttpJoinerEvent};
+use h_protocol::model::HttpParseEvent;
+use h_protocol::tcp::FlowWorker;
+use h_protocol::WorkerInput;
+
+fn tuple() -> ConnTuple {
+    ConnTuple {
+        client: "10.4.4.4:51000".parse().unwrap(),
+        server: "160.79.104.10:443".parse().unwrap(),
+    }
+}
+
+fn flow_worker() -> FlowWorker {
+    let mut sys = MetricsSystem::new();
+    let metrics = sys.register_worker("synth-test", Metric::ALL);
+    let _ = sys.start();
+    FlowWorker::new(metrics)
+}
+
+fn joiner() -> HttpJoiner {
+    let mut sys = MetricsSystem::new();
+    let metrics = sys.register_worker("synth-joiner", Metric::ALL);
+    let _ = sys.start();
+    HttpJoiner::new(metrics)
+}
+
+/// Decode each synthesized frame and run it through the FlowWorker, collecting
+/// every emitted `HttpParseEvent`. Mirrors the production capture→protocol hop.
+fn run(worker: &mut FlowWorker, pkts: Vec<RawPacket>) -> Vec<HttpParseEvent> {
+    let mut out = Vec::new();
+    for p in pkts {
+        let parsed = decode(&p.data, p.link_type, p.timestamp_us, p.source_id.clone())
+            .unwrap_or_else(|e| panic!("synthesized frame must decode, got {e:?}"));
+        out.extend(worker.process(WorkerInput::Packet(parsed)));
+    }
+    out
+}
+
+fn count_reqs(events: &[HttpParseEvent]) -> usize {
+    events
+        .iter()
+        .filter(|e| matches!(e, HttpParseEvent::HttpRequest(_)))
+        .count()
+}
+
+fn count_resps(events: &[HttpParseEvent]) -> usize {
+    events
+        .iter()
+        .filter(|e| matches!(e, HttpParseEvent::HttpResponse(_)))
+        .count()
+}
+
+fn http_request(path: &str, host: &str, body: &str) -> Vec<u8> {
+    format!(
+        "POST {path} HTTP/1.1\r\nHost: {host}\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+    .into_bytes()
+}
+
+fn http_response(body: &str) -> Vec<u8> {
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+    .into_bytes()
+}
+
+/// Encode `pieces` as an HTTP/1.1 `text/event-stream` chunked response.
+fn sse_response(pieces: &[&str]) -> Vec<u8> {
+    let mut out =
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n"
+            .to_vec();
+    for piece in pieces {
+        out.extend_from_slice(format!("{:x}\r\n", piece.len()).as_bytes());
+        out.extend_from_slice(piece.as_bytes());
+        out.extend_from_slice(b"\r\n");
+    }
+    out.extend_from_slice(b"0\r\n\r\n");
+    out
+}
+
+#[test]
+fn synth_request_response_round_trips_through_reassembler() {
+    let mut s = FlowSynthesizer::new(SynthConfig::default());
+    let mut w = flow_worker();
+
+    let mut frames = s.open(1, tuple(), 1_000);
+    frames.extend(s.data(
+        1,
+        StreamDir::ClientToServer,
+        &http_request("/v1/messages", "api.anthropic.com", r#"{"model":"claude"}"#),
+        2_000,
+    ));
+    frames.extend(s.data(
+        1,
+        StreamDir::ServerToClient,
+        &http_response(r#"{"id":"msg_1","role":"assistant"}"#),
+        3_000,
+    ));
+    frames.extend(s.close(1, 4_000));
+
+    let events = run(&mut w, frames);
+    assert_eq!(count_reqs(&events), 1, "expected one HttpRequest");
+    assert_eq!(count_resps(&events), 1, "expected one HttpResponse");
+
+    // The request line and host must survive synthesis intact.
+    let req = events
+        .iter()
+        .find_map(|e| match e {
+            HttpParseEvent::HttpRequest(r) => Some(r),
+            _ => None,
+        })
+        .expect("request present");
+    assert_eq!(req.method, "POST");
+    assert_eq!(req.uri, "/v1/messages");
+    assert_eq!(req.header("host"), Some("api.anthropic.com"));
+}
+
+#[test]
+fn synth_large_body_split_across_segments_reassembles() {
+    // Force multi-segment: a body far larger than the segment size must be
+    // sliced into several TCP segments and stitched back together by the
+    // reassembler with no byte loss.
+    let cfg = SynthConfig {
+        segment_size: 512,
+        ..Default::default()
+    };
+    let mut s = FlowSynthesizer::new(cfg);
+    let mut w = flow_worker();
+
+    let big = "x".repeat(5000);
+    let body = format!(r#"{{"data":"{big}"}}"#);
+    let req = http_request("/v1/messages", "api.anthropic.com", &body);
+
+    let mut frames = s.open(1, tuple(), 1_000);
+    frames.extend(s.data(1, StreamDir::ClientToServer, &req, 2_000));
+    frames.extend(s.data(
+        1,
+        StreamDir::ServerToClient,
+        &http_response(r#"{"ok":true}"#),
+        3_000,
+    ));
+
+    // The request alone should span multiple segments (sanity on the harness).
+    let req_segments = s
+        .data(1, StreamDir::ClientToServer, &req, 9_000)
+        .len();
+    assert!(req_segments > 1, "request should be multi-segment");
+
+    let events = run(&mut w, frames);
+    assert_eq!(count_reqs(&events), 1);
+    assert_eq!(count_resps(&events), 1);
+    let req_event = events
+        .iter()
+        .find_map(|e| match e {
+            HttpParseEvent::HttpRequest(r) => Some(r),
+            _ => None,
+        })
+        .expect("request present");
+    assert_eq!(
+        req_event.body.len(),
+        body.len(),
+        "multi-segment body reassembled without loss"
+    );
+}
+
+#[test]
+fn synth_sse_streaming_response_emits_sse_events() {
+    let mut s = FlowSynthesizer::new(SynthConfig::default());
+    let mut w = flow_worker();
+
+    let mut frames = s.open(1, tuple(), 1_000);
+    frames.extend(s.data(
+        1,
+        StreamDir::ClientToServer,
+        &http_request("/v1/messages", "api.anthropic.com", r#"{"stream":true}"#),
+        2_000,
+    ));
+    // Each SSE event arrives as its own server→client chunk, mimicking a real
+    // streamed response delivered over successive SSL_read calls.
+    let sse = sse_response(&[
+        "event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+        "event: content_block_delta\ndata: {\"delta\":\"Hello\"}\n\n",
+        "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+    ]);
+    frames.extend(s.data(1, StreamDir::ServerToClient, &sse, 3_000));
+    frames.extend(s.close(1, 4_000));
+
+    let events = run(&mut w, frames);
+    let sse_count = events
+        .iter()
+        .filter(|e| matches!(e, HttpParseEvent::SseEvent(_)))
+        .count();
+    assert_eq!(count_reqs(&events), 1, "expected the request");
+    assert!(
+        sse_count >= 3,
+        "expected at least 3 SSE events, got {sse_count}"
+    );
+}
+
+#[test]
+fn synth_midstream_without_handshake_syncs_on_request() {
+    // Uprobe attached mid-connection: no SYN observed. The reassembler must
+    // still sync on the first HTTP request line (its mid-stream path).
+    let cfg = SynthConfig {
+        emit_handshake: false,
+        ..Default::default()
+    };
+    let mut s = FlowSynthesizer::new(cfg);
+    let mut w = flow_worker();
+
+    let mut frames = s.open(1, tuple(), 1_000);
+    assert!(frames.is_empty(), "no handshake emitted");
+    frames.extend(s.data(
+        1,
+        StreamDir::ClientToServer,
+        &http_request("/v1/chat/completions", "api.openai.com", r#"{"n":1}"#),
+        2_000,
+    ));
+    frames.extend(s.data(
+        1,
+        StreamDir::ServerToClient,
+        &http_response(r#"{"choices":[]}"#),
+        3_000,
+    ));
+
+    let events = run(&mut w, frames);
+    assert_eq!(count_reqs(&events), 1, "mid-stream request must parse");
+    assert_eq!(count_resps(&events), 1);
+}
+
+#[test]
+fn synth_two_keepalive_exchanges_pair_in_joiner() {
+    // Two sequential request/response pairs on one connection must join into
+    // exactly two HttpJoiner Exchanges — proving synthesized keep-alive framing
+    // is reconstructed end to end.
+    let mut s = FlowSynthesizer::new(SynthConfig::default());
+    let mut w = flow_worker();
+    let mut j = joiner();
+
+    let mut frames = s.open(1, tuple(), 1_000);
+    frames.extend(s.data(
+        1,
+        StreamDir::ClientToServer,
+        &http_request("/v1/messages", "api.anthropic.com", r#"{"q":1}"#),
+        2_000,
+    ));
+    frames.extend(s.data(
+        1,
+        StreamDir::ServerToClient,
+        &http_response(r#"{"a":1}"#),
+        3_000,
+    ));
+    frames.extend(s.data(
+        1,
+        StreamDir::ClientToServer,
+        &http_request("/v1/messages", "api.anthropic.com", r#"{"q":2}"#),
+        4_000,
+    ));
+    frames.extend(s.data(
+        1,
+        StreamDir::ServerToClient,
+        &http_response(r#"{"a":2}"#),
+        5_000,
+    ));
+    frames.extend(s.close(1, 6_000));
+
+    let parse_events = run(&mut w, frames);
+    let mut exchanges = 0;
+    for ev in parse_events {
+        for je in j.process(ev) {
+            if matches!(je, HttpJoinerEvent::Exchange { .. }) {
+                exchanges += 1;
+            }
+        }
+    }
+    assert_eq!(exchanges, 2, "two keep-alive exchanges must pair");
+}

--- a/server/h-protocol/tests/synth_pipeline.rs
+++ b/server/h-protocol/tests/synth_pipeline.rs
@@ -20,8 +20,8 @@ use h_protocol::WorkerInput;
 
 fn tuple() -> ConnTuple {
     ConnTuple {
-        client: "10.4.4.4:51000".parse().unwrap(),
-        server: "160.79.104.10:443".parse().unwrap(),
+        client: "203.0.113.4:51000".parse().unwrap(),
+        server: "192.0.2.10:443".parse().unwrap(),
     }
 }
 

--- a/server/h-storage-clickhouse/src/calls.rs
+++ b/server/h-storage-clickhouse/src/calls.rs
@@ -4,6 +4,7 @@ use clickhouse::Row;
 use serde::Deserialize;
 
 use h_common::error::Result;
+use h_common::process::ProcessInfo;
 use h_llm::model::LlmCall;
 use h_storage::convert::{derive_tokens_estimated, parse_json_string_list};
 use h_storage::dialect::sql_in_list;
@@ -53,6 +54,9 @@ struct CallListRow {
     agent_topology: Option<String>,
     tool_call_count: u32,
     tool_names_json: Option<String>,
+    process_pid: Option<u32>,
+    process_comm: Option<String>,
+    process_exe: Option<String>,
 }
 
 #[derive(Row, Deserialize)]
@@ -88,6 +92,9 @@ struct CallDetailRow {
     agent_topology: Option<String>,
     tool_call_count: u32,
     tool_names_json: Option<String>,
+    process_pid: Option<u32>,
+    process_comm: Option<String>,
+    process_exe: Option<String>,
 }
 
 #[derive(Row, Deserialize)]
@@ -192,7 +199,7 @@ impl ClickHouseBackend {
              wire_api, model, status_code, is_stream, finish_reason, ttft_ms, e2e_latency_ms, \
              input_tokens, output_tokens, client_ip, server_ip, server_port, request_path, \
              response_body, is_agent_request, tool_surface, agent_topology, tool_call_count, \
-             tool_names_json \
+             tool_names_json, process_pid, process_comm, process_exe \
              FROM llm_calls WHERE {where_sql} \
              ORDER BY {} {sort_order} LIMIT {} OFFSET {offset}",
             query.sort_by, query.page_size,
@@ -218,7 +225,7 @@ impl ClickHouseBackend {
              input_tokens, output_tokens, total_tokens, ttft_ms, e2e_latency_ms, response_id, \
              client_ip, client_port, server_ip, server_port, request_body, response_body, \
              request_headers, response_headers, is_agent_request, tool_surface, agent_topology, \
-             tool_call_count, tool_names_json \
+             tool_call_count, tool_names_json, process_pid, process_comm, process_exe \
              FROM llm_calls WHERE id = '{}' LIMIT 1",
             escape_str(id)
         );
@@ -370,10 +377,21 @@ fn join_nums<T: std::fmt::Display>(values: &[T]) -> String {
         .join(", ")
 }
 
+/// Build `Option<ProcessInfo>` from the three nullable `process_*` columns.
+/// `None` exactly when `pid` is NULL (passive-tap rows).
+fn row_process(pid: Option<u32>, comm: Option<String>, exe: Option<String>) -> Option<ProcessInfo> {
+    pid.map(|pid| ProcessInfo {
+        pid,
+        comm: comm.unwrap_or_default(),
+        exe,
+    })
+}
+
 fn call_list_item(r: CallListRow) -> CallListItem {
     let tokens_estimated =
         derive_tokens_estimated(r.input_tokens, r.output_tokens, r.response_body.as_deref());
     let tool_names = parse_json_string_list(r.tool_names_json.as_deref());
+    let process = row_process(r.process_pid, r.process_comm, r.process_exe);
     CallListItem {
         id: r.id,
         source_id: r.source_id,
@@ -397,6 +415,7 @@ fn call_list_item(r: CallListRow) -> CallListItem {
         agent_topology: r.agent_topology,
         tool_call_count: r.tool_call_count,
         tool_names,
+        process,
     }
 }
 
@@ -404,6 +423,7 @@ fn call_detail(r: CallDetailRow) -> CallDetail {
     let tokens_estimated =
         derive_tokens_estimated(r.input_tokens, r.output_tokens, r.response_body.as_deref());
     let tool_names = parse_json_string_list(r.tool_names_json.as_deref());
+    let process = row_process(r.process_pid, r.process_comm, r.process_exe);
     CallDetail {
         id: r.id,
         source_id: r.source_id,
@@ -437,5 +457,6 @@ fn call_detail(r: CallDetailRow) -> CallDetail {
         agent_topology: r.agent_topology,
         tool_call_count: r.tool_call_count,
         tool_names,
+        process,
     }
 }

--- a/server/h-storage-clickhouse/src/it.rs
+++ b/server/h-storage-clickhouse/src/it.rs
@@ -146,6 +146,7 @@ pub(crate) mod fixtures {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 
@@ -298,6 +299,7 @@ pub(crate) mod fixtures {
             headers: vec![("content-type".into(), "application/json".into())],
             body: Bytes::from_static(br#"{"model":"gpt-4"}"#),
             timestamp_us: request_time_us,
+            process: None,
         });
         let response = Arc::new(HttpResponseData {
             flow_key: request.flow_key.clone(),
@@ -309,6 +311,7 @@ pub(crate) mod fixtures {
             body: Bytes::from_static(br#"{"choices":[]}"#),
             first_byte_timestamp_us: request_time_us + 500_000,
             complete_timestamp_us: request_time_us + 1_000_000,
+            process: None,
         });
         HttpExchange {
             id: id.to_string(),

--- a/server/h-storage-clickhouse/src/rows.rs
+++ b/server/h-storage-clickhouse/src/rows.rs
@@ -54,6 +54,9 @@ pub(crate) struct CallRow {
     pub tool_call_count: u32,
     pub tool_names_json: Option<String>,
     pub body_bytes_dropped: u64,
+    pub process_pid: Option<u32>,
+    pub process_comm: Option<String>,
+    pub process_exe: Option<String>,
 }
 
 impl From<LlmCall> for CallRow {
@@ -95,6 +98,9 @@ impl From<LlmCall> for CallRow {
                 serde_json::to_string(&c.tool_names).unwrap_or_else(|_| "[]".to_string()),
             ),
             body_bytes_dropped: c.body_bytes_dropped,
+            process_pid: c.process.as_ref().map(|p| p.pid),
+            process_comm: c.process.as_ref().map(|p| p.comm.clone()),
+            process_exe: c.process.as_ref().and_then(|p| p.exe.clone()),
         }
     }
 }

--- a/server/h-storage-clickhouse/src/schema.rs
+++ b/server/h-storage-clickhouse/src/schema.rs
@@ -63,7 +63,10 @@ CREATE TABLE IF NOT EXISTS llm_calls (
     agent_topology    Nullable(String),
     tool_call_count   UInt32 DEFAULT 0,
     tool_names_json   Nullable(String),
-    body_bytes_dropped UInt64 DEFAULT 0
+    body_bytes_dropped UInt64 DEFAULT 0,
+    process_pid       Nullable(UInt32),
+    process_comm      Nullable(String),
+    process_exe       Nullable(String)
 ) ENGINE = MergeTree ORDER BY (request_time, id)
 ";
 

--- a/server/h-storage-duckdb/src/calls.rs
+++ b/server/h-storage-duckdb/src/calls.rs
@@ -3,6 +3,7 @@
 use duckdb::types::{TimeUnit, Value};
 use duckdb::Connection;
 use h_common::error::{AppError, Result};
+use h_common::process::ProcessInfo;
 use h_llm::model::LlmCall;
 use h_storage::query::*;
 
@@ -49,6 +50,9 @@ struct PreparedCall {
     tool_call_count: u32,
     tool_names_json: String,
     body_bytes_dropped: u64,
+    process_pid: Option<u32>,
+    process_comm: Option<String>,
+    process_exe: Option<String>,
 }
 
 fn prepare_call(call: LlmCall) -> PreparedCall {
@@ -92,7 +96,30 @@ fn prepare_call(call: LlmCall) -> PreparedCall {
         tool_names_json: serde_json::to_string(&call.tool_names)
             .unwrap_or_else(|_| "[]".to_string()),
         body_bytes_dropped: call.body_bytes_dropped,
+        process_pid: call.process.as_ref().map(|p| p.pid),
+        process_comm: call.process.as_ref().map(|p| p.comm.clone()),
+        process_exe: call.process.as_ref().and_then(|p| p.exe.clone()),
     }
+}
+
+/// Reconstruct an `Option<ProcessInfo>` from the three `process_*` columns at
+/// the given indices. `None` exactly when `process_pid` is NULL (passive-tap
+/// rows). Returns `duckdb::Error` so it composes with both the `map_err`-style
+/// list query and the `query_row` closure (which propagates `duckdb::Error`).
+fn read_process(
+    row: &duckdb::Row,
+    pid_idx: usize,
+    comm_idx: usize,
+    exe_idx: usize,
+) -> std::result::Result<Option<ProcessInfo>, duckdb::Error> {
+    let pid: Option<u32> = row.get(pid_idx)?;
+    let comm: Option<String> = row.get(comm_idx)?;
+    let exe: Option<String> = row.get(exe_idx)?;
+    Ok(pid.map(|pid| ProcessInfo {
+        pid,
+        comm: comm.unwrap_or_default(),
+        exe,
+    }))
 }
 
 /// Shared "fetch calls by id list" — used by both `query_turn_calls`
@@ -308,6 +335,9 @@ impl DuckDbBackend {
                         p.tool_call_count,
                         p.tool_names_json,
                         p.body_bytes_dropped,
+                        p.process_pid,
+                        p.process_comm,
+                        p.process_exe,
                     ])
                     .map_err(|e| AppError::Storage(format!("failed to append call: {e}")))?;
             }
@@ -444,7 +474,8 @@ impl DuckDbBackend {
                 "SELECT id, source_id, epoch_ms(request_time), wire_api, model, status_code, is_stream, \
                  finish_reason, ttft_ms, e2e_latency_ms, input_tokens, output_tokens, \
                  client_ip, server_ip, server_port, request_path, response_body, \
-                 is_agent_request, tool_surface, agent_topology, tool_call_count, tool_names_json \
+                 is_agent_request, tool_surface, agent_topology, tool_call_count, tool_names_json, \
+                 process_pid, process_comm, process_exe \
                  FROM llm_calls WHERE {where_sql} \
                  ORDER BY {sort_by} {sort_order} \
                  LIMIT {limit} OFFSET {offset}"
@@ -481,6 +512,8 @@ impl DuckDbBackend {
                     .as_deref()
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or_default();
+                let process = read_process(row, 22, 23, 24)
+                    .map_err(|e| AppError::Storage(format!("read error: {e}")))?;
                 items.push(CallListItem {
                     id: row
                         .get(0)
@@ -542,6 +575,7 @@ impl DuckDbBackend {
                         .map_err(|e| AppError::Storage(format!("read error: {e}")))?
                         .unwrap_or(0),
                     tool_names,
+                    process,
                 });
             }
 
@@ -571,7 +605,8 @@ impl DuckDbBackend {
                     request_body, response_body,
                     request_headers, response_headers,
                     is_agent_request, tool_surface, agent_topology,
-                    tool_call_count, tool_names_json
+                    tool_call_count, tool_names_json,
+                    process_pid, process_comm, process_exe
                 FROM llm_calls
                 WHERE id = ?
                 LIMIT 1
@@ -625,6 +660,7 @@ impl DuckDbBackend {
                     agent_topology: row.get(28)?,
                     tool_call_count: row.get::<_, Option<u32>>(29)?.unwrap_or(0),
                     tool_names,
+                    process: read_process(row, 31, 32, 33)?,
                 })
             });
 
@@ -753,6 +789,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-storage-duckdb/src/concurrent_tests.rs
+++ b/server/h-storage-duckdb/src/concurrent_tests.rs
@@ -50,6 +50,7 @@ fn mk_call(i: usize) -> LlmCall {
         tool_call_count: 0,
         tool_names: vec![],
         body_bytes_dropped: 0,
+        process: None,
     }
 }
 

--- a/server/h-storage-duckdb/src/exchanges.rs
+++ b/server/h-storage-duckdb/src/exchanges.rs
@@ -378,6 +378,7 @@ mod tests {
             headers: vec![("content-type".into(), "application/json".into())],
             body: Bytes::from_static(br#"{"model":"gpt-4"}"#),
             timestamp_us: 1_700_000_000_000_000,
+            process: None,
         });
         let response = Arc::new(HttpResponseData {
             flow_key: request.flow_key.clone(),
@@ -389,6 +390,7 @@ mod tests {
             body: Bytes::from_static(br#"{"choices":[]}"#),
             first_byte_timestamp_us: 1_700_000_000_500_000,
             complete_timestamp_us: 1_700_000_001_000_000,
+            process: None,
         });
         let exchange = h_protocol::HttpExchange {
             id: "xchg-rt-1".to_string(),
@@ -435,6 +437,7 @@ mod tests {
             headers: vec![],
             body: Bytes::new(),
             timestamp_us: 1,
+            process: None,
         });
         let response = Arc::new(HttpResponseData {
             flow_key: request.flow_key.clone(),
@@ -449,6 +452,7 @@ mod tests {
             body: Bytes::new(),
             first_byte_timestamp_us: 2,
             complete_timestamp_us: 3,
+            process: None,
         });
         let exchange = h_protocol::HttpExchange {
             id: "xchg-sse-1".to_string(),

--- a/server/h-storage-duckdb/src/retention.rs
+++ b/server/h-storage-duckdb/src/retention.rs
@@ -151,6 +151,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-storage-duckdb/src/schema.rs
+++ b/server/h-storage-duckdb/src/schema.rs
@@ -41,7 +41,10 @@ CREATE TABLE IF NOT EXISTS llm_calls (
     agent_topology    VARCHAR,
     tool_call_count   UINTEGER NOT NULL DEFAULT 0,
     tool_names_json   VARCHAR,
-    body_bytes_dropped UBIGINT NOT NULL DEFAULT 0
+    body_bytes_dropped UBIGINT NOT NULL DEFAULT 0,
+    process_pid       UINTEGER,
+    process_comm      VARCHAR,
+    process_exe       VARCHAR
 );
 ";
 
@@ -355,6 +358,31 @@ pub(crate) async fn init(backend: &DuckDbBackend) -> Result<()> {
             ),
             Err(e) => {
                 tracing::info!("phase6 migration: llm_calls.body_bytes_dropped add skipped: {e}")
+            }
+        }
+
+        // Phase 7 migration: add process-attribution columns to llm_calls — the
+        // pid / comm / executable path of the local process that owns the
+        // connection, populated only by attribution-capable sources (eBPF) and
+        // NULL for passive taps. Added nullable for the same reason documented
+        // on the Phase 5 block (DuckDB rejects `ALTER ... ADD COLUMN ... NOT
+        // NULL DEFAULT`); these columns are inherently nullable anyway. They sit
+        // at the tail of the table in both CREATE and ALTER so the appender's
+        // positional writes stay aligned.
+        let process_columns = [
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS process_pid UINTEGER;",
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS process_comm VARCHAR;",
+            "ALTER TABLE llm_calls ADD COLUMN IF NOT EXISTS process_exe VARCHAR;",
+        ];
+        for stmt in process_columns {
+            match conn.execute_batch(stmt) {
+                Ok(()) => tracing::debug!(
+                    sql = stmt,
+                    "phase7 migration: llm_calls process column added (or already present)"
+                ),
+                Err(e) => tracing::info!(
+                    "phase7 migration: llm_calls process column add skipped: {e} (sql: {stmt})"
+                ),
             }
         }
 

--- a/server/h-storage-duckdb/src/turns.rs
+++ b/server/h-storage-duckdb/src/turns.rs
@@ -870,6 +870,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-storage-duckdb/src/util.rs
+++ b/server/h-storage-duckdb/src/util.rs
@@ -156,6 +156,7 @@ pub(crate) fn extract_full_text(
         tool_call_count: 0,
         tool_names: vec![],
         body_bytes_dropped: 0,
+        process: None,
     };
     let (req, resp) = parse_bodies(&call);
     let ctx = CallCtx::new(&call, req.as_ref(), resp.as_ref());
@@ -267,6 +268,7 @@ pub(crate) fn extract_full_text_batch(
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         };
         let (req, resp) = parse_bodies(&call);
         let ctx = CallCtx::new(&call, req.as_ref(), resp.as_ref());

--- a/server/h-storage-duckdb/tests/migrations.rs
+++ b/server/h-storage-duckdb/tests/migrations.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use duckdb::Connection;
 use tempfile::TempDir;
 
+use h_common::process::ProcessInfo;
 use h_llm::model::{ApiType, LlmCall};
 use h_storage::query::{DimensionFilter, TimeRange, TurnsQuery};
 use h_storage::StorageBackend;
@@ -70,6 +71,7 @@ fn sample_call(id: &str, tool_call_count: u32, body_bytes_dropped: u64) -> LlmCa
         tool_call_count,
         tool_names: vec![],
         body_bytes_dropped,
+        process: None,
     }
 }
 
@@ -148,6 +150,49 @@ CREATE TABLE llm_calls (
     agent_topology    VARCHAR,
     tool_call_count   UINTEGER NOT NULL DEFAULT 0,
     tool_names_json   VARCHAR
+);
+";
+
+/// Schema shape immediately before Phase 7 added the `process_*` attribution
+/// columns to `llm_calls` — the full post-Phase-6 layout (body-cap counter
+/// present) but without process pid/comm/exe. Drives the
+/// `phase7_adds_process_columns_*` test.
+const LEGACY_LLM_CALLS_PRE_PHASE7: &str = "
+CREATE TABLE llm_calls (
+    id                VARCHAR NOT NULL PRIMARY KEY,
+    source_id         VARCHAR NOT NULL DEFAULT '',
+    client_ip         VARCHAR NOT NULL,
+    client_port       USMALLINT NOT NULL,
+    server_ip         VARCHAR NOT NULL,
+    server_port       USMALLINT NOT NULL,
+    request_time      TIMESTAMP NOT NULL,
+    response_time     TIMESTAMP,
+    complete_time     TIMESTAMP,
+    wire_api          VARCHAR NOT NULL,
+    model             VARCHAR NOT NULL,
+    api_type          VARCHAR NOT NULL,
+    is_stream         BOOLEAN NOT NULL,
+    request_path      VARCHAR NOT NULL,
+    status_code       USMALLINT,
+    finish_reason     VARCHAR,
+    input_tokens      UINTEGER,
+    output_tokens     UINTEGER,
+    total_tokens      UINTEGER,
+    cache_read_input_tokens   UINTEGER,
+    cache_creation_input_tokens UINTEGER,
+    ttft_ms           DOUBLE,
+    e2e_latency_ms    DOUBLE,
+    request_body      VARCHAR,
+    response_body     VARCHAR,
+    response_id       VARCHAR,
+    request_headers   VARCHAR,
+    response_headers  VARCHAR,
+    is_agent_request  BOOLEAN  NOT NULL DEFAULT FALSE,
+    tool_surface      VARCHAR,
+    agent_topology    VARCHAR,
+    tool_call_count   UINTEGER NOT NULL DEFAULT 0,
+    tool_names_json   VARCHAR,
+    body_bytes_dropped UBIGINT NOT NULL DEFAULT 0
 );
 ";
 
@@ -353,6 +398,90 @@ async fn phase6_adds_body_bytes_dropped_and_appender_stays_aligned_on_legacy_db(
     assert_eq!(
         body_bytes_dropped, 4242,
         "body_bytes_dropped must round-trip into the migrated column (appender alignment)"
+    );
+}
+
+// Phase-7 migration: the `process_*` attribution columns must be added to a
+// legacy (pre-Phase-7) `llm_calls`, AND the positional appender must keep
+// writing the right columns afterward. Same alignment contract as Phase 6:
+// the three columns append at the table tail in both CREATE and ALTER, so a
+// fresh-vs-migrated DB share one column order. This writes a call carrying
+// real process attribution and reads pid/comm/exe back to prove the eBPF
+// attribution round-trips through the migrated columns intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn phase7_adds_process_columns_and_appender_stays_aligned_on_legacy_db() {
+    let tmp = TempDir::new().unwrap();
+    let path = synth_db(&tmp, &[LEGACY_LLM_CALLS_PRE_PHASE7]);
+
+    // Pre-condition: the process columns are absent on the legacy DB.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_calls");
+        assert!(
+            !cols.iter().any(|c| c == "process_pid"),
+            "synth pre-condition: process_pid must be absent in pre-Phase-7 DB, got: {cols:?}"
+        );
+    }
+
+    let backend = Arc::new(
+        DuckDbBackend::open_with_pool(path.to_str().unwrap(), 2).expect("open backend"),
+    );
+    backend.init().await.expect("init must reconcile legacy schema");
+
+    // Columns landed.
+    {
+        let conn = Connection::open(&path).unwrap();
+        let cols = column_names(&conn, "llm_calls");
+        for col in ["process_pid", "process_comm", "process_exe"] {
+            assert!(
+                cols.iter().any(|c| c == col),
+                "post-migration llm_calls must contain {col}, got: {cols:?}"
+            );
+        }
+    }
+
+    // Write a call carrying eBPF process attribution through the real appender
+    // into the just-migrated table. The trailing sentinel body_bytes_dropped
+    // (4242) plus the process columns catch a positional swap among tail cols.
+    let mut call = sample_call("call-phase7", 7, 4242);
+    call.process = Some(ProcessInfo {
+        pid: 31337,
+        comm: "python3".into(),
+        exe: Some("/usr/bin/python3.12".into()),
+    });
+    backend
+        .write_calls(vec![call])
+        .await
+        .expect("write_calls must succeed against a migrated table");
+
+    drop(backend);
+
+    let conn = Connection::open(&path).unwrap();
+    let (pid, comm, exe, body_bytes_dropped): (Option<u32>, Option<String>, Option<String>, u64) =
+        conn.query_row(
+            "SELECT process_pid, process_comm, process_exe, body_bytes_dropped \
+             FROM llm_calls WHERE id = 'call-phase7'",
+            [],
+            |r| {
+                Ok((
+                    r.get::<_, Option<u32>>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                    r.get::<_, u64>(3)?,
+                ))
+            },
+        )
+        .expect("row must be present after write_calls");
+    assert_eq!(pid, Some(31337), "process_pid must round-trip");
+    assert_eq!(comm.as_deref(), Some("python3"), "process_comm must round-trip");
+    assert_eq!(
+        exe.as_deref(),
+        Some("/usr/bin/python3.12"),
+        "process_exe must round-trip"
+    );
+    assert_eq!(
+        body_bytes_dropped, 4242,
+        "body_bytes_dropped must stay aligned after the process columns append"
     );
 }
 

--- a/server/h-storage/src/query.rs
+++ b/server/h-storage/src/query.rs
@@ -1,3 +1,4 @@
+use h_common::process::ProcessInfo;
 use serde::Serialize;
 
 #[derive(Debug, Clone)]
@@ -309,6 +310,9 @@ pub struct CallListItem {
     pub agent_topology: Option<String>,
     pub tool_call_count: u32,
     pub tool_names: Vec<String>,
+    /// Owning process (eBPF attribution), or `None` for passive-tap sources.
+    #[serde(default)]
+    pub process: Option<ProcessInfo>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -920,6 +924,9 @@ pub struct CallDetail {
     pub agent_topology: Option<String>,
     pub tool_call_count: u32,
     pub tool_names: Vec<String>,
+    /// Owning process (eBPF attribution), or `None` for passive-tap sources.
+    #[serde(default)]
+    pub process: Option<ProcessInfo>,
 }
 
 #[cfg(test)]

--- a/server/h-storage/src/sink.rs
+++ b/server/h-storage/src/sink.rs
@@ -497,6 +497,7 @@ mod tests {
             headers: vec![],
             body: Bytes::new(),
             timestamp_us: 0,
+            process: None,
         });
         let response = Arc::new(HttpResponseData {
             flow_key: request.flow_key.clone(),
@@ -508,6 +509,7 @@ mod tests {
             body: Bytes::from_static(b"ok"),
             first_byte_timestamp_us: 100,
             complete_timestamp_us: 200,
+            process: None,
         });
         HttpExchange {
             id: format!("x-{i}"),
@@ -557,6 +559,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-turn/src/stage.rs
+++ b/server/h-turn/src/stage.rs
@@ -215,6 +215,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-turn/src/test_support.rs
+++ b/server/h-turn/src/test_support.rs
@@ -80,6 +80,7 @@ pub fn make_call(
         tool_call_count,
         tool_names: tool_names.iter().map(|s| s.to_string()).collect(),
         body_bytes_dropped: 0,
+        process: None,
     };
     let agent = AgentCallInfo {
         agent_kind: "test",

--- a/server/h-turn/src/tracker.rs
+++ b/server/h-turn/src/tracker.rs
@@ -1087,6 +1087,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 
@@ -1136,6 +1137,7 @@ mod tests {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-turn/tests/integration.rs
+++ b/server/h-turn/tests/integration.rs
@@ -852,6 +852,7 @@ async fn generic_profile_anthropic_two_call_session() {
             tool_call_count: 0,
             tool_names: vec![],
             body_bytes_dropped: 0,
+            process: None,
         }
     }
 

--- a/server/h-turn/tests/reorder.rs
+++ b/server/h-turn/tests/reorder.rs
@@ -125,6 +125,7 @@ fn anthropic_call(
         tool_call_count: 0,
         tool_names: vec![],
         body_bytes_dropped: 0,
+        process: None,
     }
 }
 


### PR DESCRIPTION
## What

Adds a native **eBPF SSL-uprobe capture source** to Heron so it can observe
TLS-encrypted LLM API calls **on-host, with no proxy in the request path** —
plus **process attribution** (pid / comm / exe) that a passive packet tap
fundamentally cannot provide. A call surfaced in the console can now be traced
back to the agent process that made it (`claude`, `node`, `python3`, …).

Researched AgentSight (MIT) first; concluded **reimplement natively** rather
than integrate its frontend/OTLP/LLM-analysis (all overlap Heron's
console/storage/turn-tracker and are weaker / unpersisted). AgentSight's
BoringSSL byte-pattern technique informed Phase 3 below.

## How

The novel correctness surface is **frame synthesis**: eBPF hands us per-
connection plaintext chunks, which a `FlowSynthesizer` dresses as synthetic
Ethernet+IP+TCP `RawPacket`s. They feed Heron's existing dispatcher → TCP
reassembler → HTTP parser → joiner → LLM extractor **unchanged** — no new
ingress layer. The Rust eBPF stack is **aya** (pure Rust); the BPF program
builds for `bpfel-unknown-none` and is embedded via `include_bytes_aligned!`,
keeping Heron's single-static-binary model.

Process attribution lives in a new shared `h_common::process::ProcessInfo` and
is threaded `RawPacket → ParsedPacket → TcpFlow → Http{Request,Response,Sse}Data
→ LlmCall → DuckDB/ClickHouse → REST DTOs → console`.

## Phases in this PR

- **Phase 0** — `FlowSynthesizer` + integration tests driving synthesized
  frames through the full chain to a real `LlmCall`.
- **Phase 1** — config + cross-platform pump/clock + factory/doctor gating;
  aya loader + BPF program (`SSL_write` / `SSL_read` uretprobe / `SSL_shutdown`)
  attaching to dynamic libssl by symbol.
- **Phase 2** — process attribution (pid/comm/exe) end-to-end, incl. a DuckDB
  phased migration (tail-aligned for the positional appender), ClickHouse
  columns, REST DTOs, and a console Process column + detail rows.
- **Phase 3** — byte-signature offset uprobe attach for **statically-linked,
  symbol-stripped** TLS stacks (Claude Code's Bun/BoringSSL). `sigscan` scans an
  ELF's executable segments for a masked prologue signature and returns uprobe
  file offsets; the loader resolves a **unique** offset per function and attaches
  by offset. Signatures are version-specific data (config `write_sig`/`read_sig`,
  per-release), not code. See `docs/design/03-ebpf-static-targets.md`.

## Gating — CI stays green

The `ebpf` feature is **off by default**. macOS dev and the default Linux CI
never compile aya / the BPF toolchain. The BPF program crate is excluded from
the workspace (built out-of-band by `build.rs` only when the feature is on).
The `sigscan` matcher is pure/cross-platform and is built+unit-tested everywhere.

## Verification

- Full workspace test suite green on the default build; `cargo check
  --workspace --all-targets` clean; console `tsc -b` clean.
- New tests: pump attribution stamping, **full-chain pump → `LlmCall` pid/comm/
  exe assertion**, a **legacy-DB migration + positional-appender round-trip**,
  and **8 `sigscan` unit tests** (masked match + ELF segment scoping).
- `cargo check -p h-capture --features ebpf` compiles clean on a Linux 6.8 host.
  Live there:
  - Phase 1/2 dynamic libssl: real HTTPS attributed to its process —
    `curl(35012) /usr/bin/curl  GET / HTTP/1.1`,
    `.NET TP Worker(17817) /…/Runner.Listener  GET /message?…`.
  - Phase 3 offset-attach (vs real libssl, symbols = ground truth): a 48-byte
    signature maps to the exact `SSL_write`/`SSL_read` offset (16B→5 matches,
    32B→3, 48B→1 — the shared CET+frame+canary preamble is why short sigs are
    ambiguous), and the smoke in offset-only mode captured real HTTP/1.1
    plaintext, attributed — proving signature → scan → offset → attach → capture.

## De-risking (measured) and limitations

- **HTTP/2 — cleared for Bun.** Heron's parser is HTTP/1.x only. Measured on a
  Linux 6.8 host: **Bun's `fetch()` offers only `http/1.1`** in its ALPN (never
  h2), via a Node `ALPNCallback` dual-protocol server (bun→`[http/1.1]`; curl
  default→`[h2,http/1.1]`). So Claude Code → anthropic is HTTP/1.1 and parseable.
  (Other h2 clients remain invisible on the plaintext path, as today.)
- A validated **Bun/Claude Code signature is per-release data** — derive with the
  `sigscan_probe` example and wildcard the RIP-relative call displacements; no
  live Claude Code capture is demonstrated in this PR (needs that signature).
- MVP uses a **synthetic 5-tuple** + mid-stream sync; real-tuple recovery via a
  connect-kprobe is a follow-up.
- `TurnCallItem` DTO does not yet carry `process` (only `CallListItem` /
  `CallDetail`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
