### PR TITLE
fix(storage): dialect-aware SQL literal escaping for the ClickHouse backend

### DIFF
--- a/server/h-storage-clickhouse/src/calls.rs
+++ b/server/h-storage-clickhouse/src/calls.rs
@@ -6,12 +6,11 @@ use serde::Deserialize;
 use h_common::error::Result;
 use h_llm::model::LlmCall;
 use h_storage::convert::{derive_tokens_estimated, parse_json_string_list};
-use h_storage::dialect::sql_in_list;
 use h_storage::query::*;
 
 use crate::client::{ch_err, insert_all};
 use crate::rows::CallRow;
-use crate::sql::{escape_str, time_where};
+use crate::sql::{escape_str, sql_in_list, time_where};
 use crate::ClickHouseBackend;
 
 const VALID_SORT_FIELDS: &[&str] = &[

--- a/server/h-storage-clickhouse/src/distincts.rs
+++ b/server/h-storage-clickhouse/src/distincts.rs
@@ -12,11 +12,10 @@ use clickhouse::Row;
 use serde::Deserialize;
 
 use h_common::error::Result;
-use h_storage::dialect::sql_in_list;
 use h_storage::query::{DistinctAgentKindsQuery, DistinctFinishReason};
 
 use crate::client::ch_err;
-use crate::sql::time_where;
+use crate::sql::{sql_in_list, time_where};
 use crate::ClickHouseBackend;
 
 /// Single-column `SELECT DISTINCT x AS v` row. `v` must match the SELECT alias;

--- a/server/h-storage-clickhouse/src/exchanges.rs
+++ b/server/h-storage-clickhouse/src/exchanges.rs
@@ -5,12 +5,11 @@ use serde::Deserialize;
 
 use h_common::error::Result;
 use h_protocol::HttpExchange;
-use h_storage::dialect::sql_in_list;
 use h_storage::query::*;
 
 use crate::client::insert_all;
 use crate::rows::ExchangeRow;
-use crate::sql::{escape_str, time_where};
+use crate::sql::{escape_str, sql_in_list, time_where};
 use crate::ClickHouseBackend;
 
 /// Valid `sort_by` fields for `query_http_exchanges`, mirroring the DuckDB

--- a/server/h-storage-clickhouse/src/metrics.rs
+++ b/server/h-storage-clickhouse/src/metrics.rs
@@ -12,11 +12,12 @@ use serde::Deserialize;
 
 use h_common::error::{AppError, Result};
 use h_metrics::model::{LlmFinishMetric, LlmMetric};
-use h_storage::dialect::{build_dimension_where, build_dimension_where_for_group, sql_in_list};
+use h_storage::dialect::{build_dimension_where, build_dimension_where_for_group, escape_clickhouse};
 use h_storage::query::*;
 
 use crate::client::{ch_err, insert_all};
 use crate::rows::{FinishMetricRow, MetricRow};
+use crate::sql::sql_in_list;
 use crate::ClickHouseBackend;
 
 /// All valid numeric metric field names accepted by `query_metrics_timeseries`.
@@ -269,7 +270,7 @@ impl ClickHouseBackend {
             if !matches!(group_by, "wire_api" | "model" | "server_ip") {
                 return Err(AppError::Storage(format!("invalid group_by: {group_by}")));
             }
-            let dim_where = build_dimension_where_for_group(&query.filter, group_by);
+            let dim_where = build_dimension_where_for_group(&query.filter, group_by, escape_clickhouse);
             let sql = format!(
                 "SELECT toInt64(toUnixTimestamp(timestamp)) AS ts, {group_by} AS grp, {vals} \
                  FROM llm_metrics \
@@ -292,7 +293,7 @@ impl ClickHouseBackend {
                 })
                 .collect())
         } else {
-            let dim_where = build_dimension_where(&query.filter);
+            let dim_where = build_dimension_where(&query.filter, escape_clickhouse);
             let sql = format!(
                 "SELECT toInt64(toUnixTimestamp(timestamp)) AS ts, {vals} \
                  FROM llm_metrics \
@@ -321,7 +322,7 @@ impl ClickHouseBackend {
         &self,
         query: &MetricsSummaryQuery,
     ) -> Result<MetricsSummaryRow> {
-        let dim_where = build_dimension_where(&query.filter);
+        let dim_where = build_dimension_where(&query.filter, escape_clickhouse);
         let ts_pred = ts_where(query.time_range.start_us, query.time_range.end_us);
         let sql = format!(
             "SELECT \
@@ -384,7 +385,7 @@ impl ClickHouseBackend {
         } else {
             "DESC"
         };
-        let dim_where = build_dimension_where_for_group(&query.filter, "wire_api");
+        let dim_where = build_dimension_where_for_group(&query.filter, "wire_api", escape_clickhouse);
         let ts_pred = ts_where(query.time_range.start_us, query.time_range.end_us);
         let sql = format!(
             "SELECT * FROM ( \

--- a/server/h-storage-clickhouse/src/services.rs
+++ b/server/h-storage-clickhouse/src/services.rs
@@ -518,7 +518,7 @@ impl ClickHouseBackend {
         let mut endpoint_by_id: HashMap<String, (String, u16, String)> = HashMap::new();
         if !wanted_ids.is_empty() {
             let id_list: Vec<String> = wanted_ids.into_iter().collect();
-            let in_list = h_storage::dialect::sql_in_list(&id_list);
+            let in_list = crate::sql::sql_in_list(&id_list);
             let calls_sql = format!(
                 "SELECT id, server_ip, server_port, client_ip \
                  FROM llm_calls WHERE id IN ({in_list})"

--- a/server/h-storage-clickhouse/src/sessions.rs
+++ b/server/h-storage-clickhouse/src/sessions.rs
@@ -23,11 +23,10 @@ use serde::Deserialize;
 
 use h_common::error::Result;
 use h_storage::convert::parse_json_string_list;
-use h_storage::dialect::sql_in_list;
 use h_storage::query::*;
 
 use crate::client::ch_err;
-use crate::sql::{escape_str, time_where};
+use crate::sql::{escape_str, sql_in_list, time_where};
 use crate::ClickHouseBackend;
 
 /// Step-1 row: one `(source_id, session_id)` key with its windowed

--- a/server/h-storage-clickhouse/src/sql.rs
+++ b/server/h-storage-clickhouse/src/sql.rs
@@ -3,13 +3,25 @@
 //! these helpers cover ClickHouse-specific concerns (DateTime64 time ranges,
 //! literal escaping).
 
-/// Escape a string for embedding inside a single-quoted ClickHouse literal by
-/// doubling single quotes (`''`), matching the DuckDB backend's `sql_in_list`
-/// convention (ClickHouse accepts both `''` and `\'`). Used for id / turn_id
-/// literals and `LIKE` substrings; `%` / `_` are intentionally NOT escaped so
-/// `LIKE '%x%'` keeps substring semantics, exactly as the DuckDB backend.
+/// Escape a string for embedding inside a single-quoted ClickHouse literal.
+///
+/// ClickHouse processes C-style backslash escapes inside `'...'` (it treats
+/// `\'` as an escaped quote in addition to the SQL-standard `''`), so quoting
+/// must escape backslashes as well as quotes — otherwise a value ending in `\`
+/// consumes the closing quote and breaks out of the literal (SQL injection).
+/// Delegates to the backend-neutral `escape_clickhouse` so the rule lives in
+/// one place. Used for id / turn_id literals and `LIKE` substrings; `%` / `_`
+/// are intentionally NOT escaped so `LIKE '%x%'` keeps substring semantics.
 pub(crate) fn escape_str(s: &str) -> String {
-    s.replace('\'', "''")
+    h_storage::dialect::escape_clickhouse(s)
+}
+
+/// ClickHouse IN-list builder. Mirrors `h_storage::dialect::sql_in_list` but
+/// uses ClickHouse's backslash-aware escaping. ClickHouse call sites MUST use
+/// this instead of the backend-neutral `sql_in_list`, whose quote-only
+/// escaping is correct for DuckDB/Postgres but injectable on ClickHouse.
+pub(crate) fn sql_in_list(values: &[String]) -> String {
+    h_storage::dialect::sql_in_list_with(values, h_storage::dialect::escape_clickhouse)
 }
 
 /// Half-open time-range predicate on a `DateTime64(6)` column, comparing against

--- a/server/h-storage-clickhouse/src/turns.rs
+++ b/server/h-storage-clickhouse/src/turns.rs
@@ -14,13 +14,12 @@ use serde::Deserialize;
 
 use h_common::error::{AppError, Result};
 use h_storage::convert::parse_json_string_list;
-use h_storage::dialect::sql_in_list;
 use h_storage::query::*;
 use h_turn::{AgentTurn, PairCandidate};
 
 use crate::client::{ch_err, insert_all};
 use crate::rows::TurnRow;
-use crate::sql::{escape_str, time_where};
+use crate::sql::{escape_str, sql_in_list, time_where};
 use crate::ClickHouseBackend;
 
 /// Full `agent_turns` column list in `TurnRow` field order, with the two

--- a/server/h-storage-duckdb/src/metrics.rs
+++ b/server/h-storage-duckdb/src/metrics.rs
@@ -8,8 +8,8 @@ use h_metrics::model::{LlmFinishMetric, LlmMetric};
 use h_storage::query::*;
 
 use crate::util::{
-    build_dimension_where, build_dimension_where_for_group, parse_json_string_list, sql_in_list,
-    us_to_timestamp,
+    build_dimension_where, build_dimension_where_for_group, escape_standard,
+    parse_json_string_list, sql_in_list, us_to_timestamp,
 };
 use crate::DuckDbBackend;
 
@@ -383,7 +383,7 @@ impl DuckDbBackend {
             let fields_sql = field_exprs.join(", ");
             let rows = if let Some(ref group_by) = query.group_by {
                 // Grouped query: aggregate across the group dimension plus source_id.
-                let dim_where = build_dimension_where_for_group(&query.filter, group_by);
+                let dim_where = build_dimension_where_for_group(&query.filter, group_by, escape_standard);
                 let sql = format!(
                     "SELECT epoch(timestamp) AS ts, {group_by}, {fields_sql} \
                      FROM llm_metrics \
@@ -431,7 +431,7 @@ impl DuckDbBackend {
                 // per-source aggregators emit one row per source per (ts,
                 // dim). Without the GROUP BY we'd return N overlapping rows
                 // at each timestamp (N = number of capture sources).
-                let dim_where = build_dimension_where(&query.filter);
+                let dim_where = build_dimension_where(&query.filter, escape_standard);
                 let sql = format!(
                     "SELECT epoch(timestamp) AS ts, {fields_sql} \
                      FROM llm_metrics \
@@ -490,7 +490,7 @@ impl DuckDbBackend {
             let start_ts = us_to_timestamp(query.time_range.start_us);
             let end_ts = us_to_timestamp(query.time_range.end_us);
 
-            let dim_where = build_dimension_where(&query.filter);
+            let dim_where = build_dimension_where(&query.filter, escape_standard);
             let sql = format!(
                 "
                 SELECT
@@ -581,7 +581,7 @@ impl DuckDbBackend {
             let limit = query.limit;
             // Per-(wire_api, model) breakdown shares the grouped-tier logic:
             // both dimensions are always specific, server_ip follows filter.
-            let dim_where = build_dimension_where_for_group(&query.filter, "wire_api");
+            let dim_where = build_dimension_where_for_group(&query.filter, "wire_api", escape_standard);
 
             let sql = format!(
                 "

--- a/server/h-storage-duckdb/src/util.rs
+++ b/server/h-storage-duckdb/src/util.rs
@@ -21,7 +21,7 @@ pub(crate) use h_storage::convert::{
     derive_tokens_estimated, headers_to_json, parse_json_string_list,
 };
 pub(crate) use h_storage::dialect::{
-    build_dimension_where, build_dimension_where_for_group, sql_in_list,
+    build_dimension_where, build_dimension_where_for_group, escape_standard, sql_in_list,
 };
 
 /// Convert microseconds since epoch to a string DuckDB can parse as TIMESTAMP.

--- a/server/h-storage/src/dialect.rs
+++ b/server/h-storage/src/dialect.rs
@@ -10,13 +10,48 @@
 
 use crate::query::DimensionFilter;
 
-/// Format a list of string values as a SQL IN list with single-quote escaping.
-pub fn sql_in_list(values: &[String]) -> String {
+/// A backend-specific SQL string-literal escaper.
+///
+/// String-literal escaping is NOT uniform across our backends: DuckDB and
+/// Postgres use standard-conforming strings where the only special character
+/// inside `'...'` is the single quote (doubled to `''`) and a backslash is an
+/// ordinary literal character. ClickHouse instead processes C-style backslash
+/// escapes inside single-quoted literals, so a backslash must itself be
+/// escaped — otherwise a value ending in `\` consumes the closing quote we
+/// emit and lets attacker-supplied input break out of the literal (SQL
+/// injection). Every builder here that interpolates user data takes the
+/// caller's escaper so each backend gets the correct semantics.
+pub type LiteralEscaper = fn(&str) -> String;
+
+/// Standard-conforming SQL literal escaping (DuckDB / Postgres): double single
+/// quotes; backslash is a literal character and is left untouched.
+pub fn escape_standard(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+/// ClickHouse literal escaping: escape backslashes *before* doubling single
+/// quotes, because ClickHouse treats `\'` as an escaped quote in addition to
+/// the SQL-standard `''`. Order matters — escaping quotes first would leave
+/// the freshly inserted backslashes unescaped.
+pub fn escape_clickhouse(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "''")
+}
+
+/// Format a list of string values as a SQL IN list, escaping each value with
+/// the supplied backend escaper.
+pub fn sql_in_list_with(values: &[String], escape: LiteralEscaper) -> String {
     values
         .iter()
-        .map(|s| format!("'{}'", s.replace('\'', "''")))
+        .map(|s| format!("'{}'", escape(s)))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// IN-list builder using standard (DuckDB / Postgres) escaping. ClickHouse
+/// call sites must NOT use this — they go through `crate::sql::sql_in_list`
+/// (backslash-aware) instead.
+pub fn sql_in_list(values: &[String]) -> String {
+    sql_in_list_with(values, escape_standard)
 }
 
 /// Build a WHERE clause segment for dimension filters on an ungrouped query.
@@ -34,7 +69,7 @@ pub fn sql_in_list(values: &[String]) -> String {
 /// and SUMs across the remaining rows. A filter on wire_api or model forces
 /// us below the `(*, *, ·)` tier; a filter on server_ip forces us off the
 /// `server_ip = '*'` coordinate.
-pub fn build_dimension_where(filter: &DimensionFilter) -> String {
+pub fn build_dimension_where(filter: &DimensionFilter, escape: LiteralEscaper) -> String {
     let has_wire = !filter.wire_apis.is_empty();
     let has_model = !filter.models.is_empty();
     let has_server = !filter.server_ips.is_empty();
@@ -45,12 +80,12 @@ pub fn build_dimension_where(filter: &DimensionFilter) -> String {
     } else {
         // Drop to (W, M, ·) tier — either IN-list or all specific values.
         let w = if has_wire {
-            format!("wire_api IN ({})", sql_in_list(&filter.wire_apis))
+            format!("wire_api IN ({})", sql_in_list_with(&filter.wire_apis, escape))
         } else {
             "wire_api != '*'".to_string()
         };
         let m = if has_model {
-            format!("model IN ({})", sql_in_list(&filter.models))
+            format!("model IN ({})", sql_in_list_with(&filter.models, escape))
         } else {
             "model != '*'".to_string()
         };
@@ -58,12 +93,12 @@ pub fn build_dimension_where(filter: &DimensionFilter) -> String {
     };
 
     let server_clause = if has_server {
-        format!("server_ip IN ({})", sql_in_list(&filter.server_ips))
+        format!("server_ip IN ({})", sql_in_list_with(&filter.server_ips, escape))
     } else {
         "server_ip = '*'".to_string()
     };
 
-    let surface_clause = build_tool_surface_clause(&filter.tool_surfaces);
+    let surface_clause = build_tool_surface_clause(&filter.tool_surfaces, escape);
     format!("{wire_clause} AND {model_clause} AND {server_clause}{surface_clause}")
 }
 
@@ -72,39 +107,43 @@ pub fn build_dimension_where(filter: &DimensionFilter) -> String {
 /// remaining dimensions follow the same filter/tier rules as
 /// [`build_dimension_where`]. Any non-recognized `group_by` falls through to
 /// the ungrouped builder.
-pub fn build_dimension_where_for_group(filter: &DimensionFilter, group_by: &str) -> String {
+pub fn build_dimension_where_for_group(
+    filter: &DimensionFilter,
+    group_by: &str,
+    escape: LiteralEscaper,
+) -> String {
     match group_by {
         "wire_api" | "model" => {
             let wire_clause = if !filter.wire_apis.is_empty() {
-                format!("wire_api IN ({})", sql_in_list(&filter.wire_apis))
+                format!("wire_api IN ({})", sql_in_list_with(&filter.wire_apis, escape))
             } else {
                 "wire_api != '*'".to_string()
             };
             let model_clause = if !filter.models.is_empty() {
-                format!("model IN ({})", sql_in_list(&filter.models))
+                format!("model IN ({})", sql_in_list_with(&filter.models, escape))
             } else {
                 "model != '*'".to_string()
             };
             let server_clause = if !filter.server_ips.is_empty() {
-                format!("server_ip IN ({})", sql_in_list(&filter.server_ips))
+                format!("server_ip IN ({})", sql_in_list_with(&filter.server_ips, escape))
             } else {
                 "server_ip = '*'".to_string()
             };
-            let surface_clause = build_tool_surface_clause(&filter.tool_surfaces);
+            let surface_clause = build_tool_surface_clause(&filter.tool_surfaces, escape);
             format!("{wire_clause} AND {model_clause} AND {server_clause}{surface_clause}")
         }
-        _ => build_dimension_where(filter),
+        _ => build_dimension_where(filter, escape),
     }
 }
 
 /// Optional `tool_surface IN (...)` segment, prefixed with ` AND ` when
 /// present. Returns an empty string when no filter is set so the query stays
 /// unchanged and rolls up across all surfaces (including NULL).
-fn build_tool_surface_clause(surfaces: &[String]) -> String {
+fn build_tool_surface_clause(surfaces: &[String], escape: LiteralEscaper) -> String {
     if surfaces.is_empty() {
         String::new()
     } else {
-        format!(" AND tool_surface IN ({})", sql_in_list(surfaces))
+        format!(" AND tool_surface IN ({})", sql_in_list_with(surfaces, escape))
     }
 }
 
@@ -116,7 +155,7 @@ mod build_dimension_where_tests {
     fn test_build_dimension_where_no_filter() {
         let f = DimensionFilter::default();
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api = '*' AND model = '*' AND server_ip = '*'"
         );
     }
@@ -128,7 +167,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api = '*' AND model = '*' AND server_ip IN ('10.0.0.1')"
         );
     }
@@ -140,7 +179,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api IN ('openai-chat') AND model != '*' AND server_ip = '*'"
         );
     }
@@ -152,7 +191,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api != '*' AND model IN ('gpt-4') AND server_ip = '*'"
         );
     }
@@ -165,7 +204,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api IN ('openai-chat') AND model IN ('gpt-4') AND server_ip = '*'"
         );
     }
@@ -178,7 +217,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api IN ('openai-chat') AND model != '*' AND server_ip IN ('10.0.0.1')"
         );
     }
@@ -191,7 +230,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api != '*' AND model IN ('gpt-4') AND server_ip IN ('10.0.0.1')"
         );
     }
@@ -205,7 +244,7 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where(&f),
+            build_dimension_where(&f, escape_standard),
             "wire_api IN ('openai-chat') AND model IN ('gpt-4') AND server_ip IN ('10.0.0.1')"
         );
     }
@@ -214,7 +253,7 @@ mod build_dimension_where_tests {
     fn test_build_dimension_where_for_group_wire_api_no_filter() {
         let f = DimensionFilter::default();
         assert_eq!(
-            build_dimension_where_for_group(&f, "wire_api"),
+            build_dimension_where_for_group(&f, "wire_api", escape_standard),
             "wire_api != '*' AND model != '*' AND server_ip = '*'"
         );
     }
@@ -226,12 +265,41 @@ mod build_dimension_where_tests {
             ..Default::default()
         };
         assert_eq!(
-            build_dimension_where_for_group(&f, "wire_api"),
+            build_dimension_where_for_group(&f, "wire_api", escape_standard),
             "wire_api != '*' AND model != '*' AND server_ip IN ('10.0.0.1')"
         );
         assert_eq!(
-            build_dimension_where_for_group(&f, "model"),
+            build_dimension_where_for_group(&f, "model", escape_standard),
             "wire_api != '*' AND model != '*' AND server_ip IN ('10.0.0.1')"
         );
+    }
+}
+
+#[cfg(test)]
+mod escaper_tests {
+    use super::*;
+
+    #[test]
+    fn escape_clickhouse_neutralizes_backslash_quote_breakout() {
+        // The ClickHouse SQL-injection payload: a trailing backslash before
+        // the closing quote. With quote-only escaping this yields `'\'')...`,
+        // where ClickHouse reads `\'` as an escaped quote and the literal
+        // terminates early, letting the rest parse as SQL. Backslash-aware
+        // escaping must double the backslash first.
+        let payload = r"\') OR 1=1 --";
+        assert_eq!(escape_clickhouse(payload), r"\\'') OR 1=1 --");
+        // Embedded in a literal: '\\'') OR 1=1 --' — ClickHouse decodes
+        // `\\` -> `\` and `''` -> `'`, so the literal content equals the input
+        // and the trailing quote stays the closing quote (no breakout).
+        let in_list = sql_in_list_with(&[payload.to_string()], escape_clickhouse);
+        assert_eq!(in_list, r"'\\'') OR 1=1 --'");
+    }
+
+    #[test]
+    fn escape_standard_leaves_backslash_untouched() {
+        // DuckDB / Postgres: backslash is an ordinary character; doubling it
+        // would corrupt the stored/compared value. Only the quote is doubled.
+        assert_eq!(escape_standard(r"a\b"), r"a\b");
+        assert_eq!(escape_standard("o'brien"), "o''brien");
     }
 }


### PR DESCRIPTION
Hardens ClickHouse read-path SQL literal escaping.

The read-path IN-list / literal quoting was shared with the DuckDB backend and only doubled single quotes. ClickHouse additionally honours backslash escapes inside single-quoted literals, so the shared quoting was not sufficient there. This introduces explicit per-dialect escapers (`escape_standard` / `escape_clickhouse`) and routes every ClickHouse read-path interpolation (escape_str, IN-lists, LIKE, dimension filters) through the backslash-aware variant. DuckDB output is byte-for-byte unchanged.

Adds regression tests covering both dialects.

Verified locally: cargo build (all storage crates) + cargo test -p h-storage (57 passed, incl. new escaper tests).

Security advisory: GHSA-pcfw-pjj8-94cf