### PR TITLE
fix(ci): gate self-hosted CI to same-repo PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ concurrency:
 
 jobs:
   test:
+    # Fork-PR safety gate. This job runs on a self-hosted runner, so it must
+    # never execute code from a forked pull request: a fork author could run
+    # arbitrary commands on the runner (and pivot from it) via build.rs,
+    # proc-macros, #[test] bodies, package lifecycle scripts, or the checked-out
+    # lint scripts. Restrict the pull_request trigger to same-repo branches;
+    # push/main runs are unaffected. Fork PRs intentionally get no CI here —
+    # review them from a trusted branch or on an ephemeral hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, ci-pool]
     # 25 was fine for test+lint, but the on-main artifact build adds a full
     # release compile (cargo build --release --features console) + the console


### PR DESCRIPTION
Restricts the self-hosted CI `test` job to same-repo pull requests.

The job runs on a self-hosted runner; without a same-repo guard a forked PR could execute code on it. Adds a job-level `if` so the pull_request path only runs for branches in this repo. push and main runs are unaffected; fork PRs intentionally get no CI on the self-hosted pool (review them from a trusted branch or a hosted runner).

Security advisory: GHSA-5hxc-fh4c-g94m