### PR TITLE
feat(ebpf): Settings enable/disable toggle + pipeline-health metrics

### DIFF
--- a/console/src/components/pipeline-health/all-metrics-table.tsx
+++ b/console/src/components/pipeline-health/all-metrics-table.tsx
@@ -20,6 +20,7 @@ type Props = {
 const GROUPS: Array<MetricGroup | "all"> = [
   "all",
   "capture",
+  "ebpf",
   "protocol",
   "llm",
   "turn",

--- a/console/src/components/settings/source-editor.tsx
+++ b/console/src/components/settings/source-editor.tsx
@@ -67,6 +67,7 @@ export function SourceEditorRow({
       {source.type === "pcap-file" && (
         <PcapFileForm source={source} onChange={onChange} />
       )}
+      {source.type === "ebpf" && <EbpfForm source={source} onChange={onChange} />}
     </li>
   )
 }
@@ -79,6 +80,8 @@ function rowHeading(type: CaptureSource["type"]): string {
       return "ZMQ receiver for remote probe stream"
     case "pcap-file":
       return "PCAP file replay"
+    case "ebpf":
+      return "eBPF SSL-uprobe capture (on-host TLS, Linux)"
   }
 }
 
@@ -97,6 +100,16 @@ export function defaultFor(type: CaptureSource["type"]): CaptureSource {
       type: "cloud-probe",
       endpoint: DEFAULT_CLOUD_PROBE_ENDPOINT,
       recv_hwm: DEFAULT_CLOUD_PROBE_HWM,
+    }
+  }
+  if (type === "ebpf") {
+    return {
+      type: "ebpf",
+      source_id: null,
+      ssl_libs: [],
+      targets: [],
+      pid_allowlist: [],
+      segment_size: 16384,
     }
   }
   return {
@@ -385,6 +398,99 @@ function CloudProbeForm({
             className="w-32 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
           />
         </Field>
+      </Disclosure>
+    </div>
+  )
+}
+
+// ============================================================================
+// EbpfForm — on-host eBPF SSL-uprobe capture (Linux)
+// ============================================================================
+
+function EbpfForm({
+  source,
+  onChange,
+}: {
+  source: Extract<CaptureSource, { type: "ebpf" }>
+  onChange: (next: CaptureSource) => void
+}) {
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-md border border-border/60 bg-muted/40 px-2.5 py-2 text-[11px] text-muted-foreground">
+        Reads TLS plaintext at the in-process <span className="font-mono">SSL_read</span> /{" "}
+        <span className="font-mono">SSL_write</span> boundary and attributes each call to its
+        owning process. Linux only; needs <span className="font-mono">CAP_BPF</span> + kernel BTF.
+      </div>
+      <Field
+        label="TLS libraries"
+        hint="Leave empty to auto-discover libssl via ldconfig (covers Python SDKs, curl). Or pin explicit paths, comma-separated."
+      >
+        <input
+          value={source.ssl_libs.join(", ")}
+          onChange={(e) =>
+            onChange({
+              ...source,
+              ssl_libs: e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            })
+          }
+          placeholder="auto-discover (leave empty)"
+          className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+        />
+      </Field>
+      <Disclosure
+        open={advancedOpen}
+        onToggle={() => setAdvancedOpen((v) => !v)}
+        label="Advanced"
+      >
+        <Field
+          label="PID allowlist"
+          hint="Restrict capture to these process IDs (comma-separated). Empty = all processes."
+        >
+          <input
+            value={source.pid_allowlist.join(", ")}
+            onChange={(e) =>
+              onChange({
+                ...source,
+                pid_allowlist: e.target.value
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean)
+                  .map(Number)
+                  .filter((n) => Number.isFinite(n) && n > 0),
+              })
+            }
+            placeholder="all processes (leave empty)"
+            className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </Field>
+        <Field
+          label="Segment size"
+          hint="Max plaintext bytes per synthetic TCP segment. Large SSL writes are split to stay under the IPv4 length limit."
+        >
+          <input
+            type="number"
+            min={1024}
+            value={source.segment_size}
+            onChange={(e) =>
+              onChange({ ...source, segment_size: Number(e.target.value) || 16384 })
+            }
+            className="w-32 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs"
+          />
+        </Field>
+        {source.targets.length > 0 && (
+          <Field
+            label="Static targets"
+            hint="Symbol-stripped binaries (e.g. Bun) — edit in the config file."
+          >
+            <div className="font-mono text-xs text-muted-foreground">
+              {source.targets.length} configured
+            </div>
+          </Field>
+        )}
       </Disclosure>
     </div>
   )

--- a/console/src/pages/settings.tsx
+++ b/console/src/pages/settings.tsx
@@ -122,6 +122,7 @@ export function SettingsPage() {
             onSave={(sources) => onSave(p.name, sources)}
             saveError={mutate.error}
             disabled={restartState !== "idle"}
+            ebpfAvailable={config.data.ebpf_available ?? false}
           />
         ))
       )}
@@ -207,6 +208,7 @@ function PipelineCard({
   onSave,
   saveError,
   disabled,
+  ebpfAvailable,
 }: {
   pipeline: PipelineShape
   metrics: Record<string, number>
@@ -216,6 +218,7 @@ function PipelineCard({
   onSave: (sources: CaptureSource[]) => Promise<void>
   saveError: unknown
   disabled: boolean
+  ebpfAvailable: boolean
 }) {
   return (
     <div className="rounded-lg border border-border/50 bg-card card-elevated">
@@ -265,6 +268,20 @@ function PipelineCard({
         )}
       </div>
 
+      {/* eBPF capture quick toggle */}
+      <EbpfCaptureToggle
+        enabled={pipeline.sources.some((s) => s.type === "ebpf")}
+        available={ebpfAvailable}
+        busy={disabled}
+        onToggle={(on) =>
+          onSave(
+            on
+              ? [...pipeline.sources, defaultFor("ebpf")]
+              : pipeline.sources.filter((s) => s.type !== "ebpf"),
+          )
+        }
+      />
+
       {/* Live counters */}
       <div className="border-b border-border px-4 py-3">
         <div className="mb-2 text-xs font-medium text-muted-foreground">
@@ -282,6 +299,60 @@ function PipelineCard({
           dumpErrors={metrics["dump_errors"]}
         />
       )}
+    </div>
+  )
+}
+
+// ============================================================================
+// EbpfCaptureToggle — one-click enable/disable for the on-host eBPF source
+// ============================================================================
+
+function EbpfCaptureToggle({
+  enabled,
+  available,
+  busy,
+  onToggle,
+}: {
+  enabled: boolean
+  available: boolean
+  busy: boolean
+  onToggle: (on: boolean) => Promise<void>
+}) {
+  return (
+    <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+      <div className="flex-1">
+        <div className="flex items-center gap-2 text-xs font-medium">
+          <span aria-hidden>🛰️</span>
+          <span>eBPF capture (on-host TLS)</span>
+          {!available && (
+            <span className="rounded-full border border-border px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground">
+              unavailable in this build
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 text-[11px] text-muted-foreground">
+          {available
+            ? "Read TLS plaintext at the SSL_read / SSL_write boundary with per-process attribution. Toggling rewrites the config and restarts capture (~2–3s)."
+            : "Requires a Linux build compiled with the `ebpf` feature (CAP_BPF + kernel BTF)."}
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled}
+        disabled={!available || busy}
+        onClick={() => onToggle(!enabled)}
+        title={enabled ? "Disable eBPF capture" : "Enable eBPF capture"}
+        className={`relative h-5 w-9 shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+          enabled ? "bg-primary" : "bg-muted"
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 size-4 rounded-full bg-background shadow-sm transition-transform ${
+            enabled ? "translate-x-4" : "translate-x-0.5"
+          }`}
+        />
+      </button>
     </div>
   )
 }
@@ -316,6 +387,13 @@ const TYPE_META: Record<
     addLabel: "Add file replay",
     emptyHint: "(none — replay packets from a saved .pcap file, for dev / forensic)",
   },
+  ebpf: {
+    icon: "🛰️",
+    title: "eBPF capture",
+    addLabel: "Add eBPF capture",
+    emptyHint:
+      "(none — read TLS plaintext on-host via SSL uprobes, with process attribution; Linux only)",
+  },
 }
 
 // ============================================================================
@@ -343,9 +421,10 @@ function SourcesByType({
     pcap: [],
     "cloud-probe": [],
     "pcap-file": [],
+    ebpf: [],
   }
   sources.forEach((s, i) => groups[s.type].push(i))
-  const order: SourceType[] = ["pcap", "cloud-probe", "pcap-file"]
+  const order: SourceType[] = ["pcap", "cloud-probe", "pcap-file", "ebpf"]
   return (
     <div className="flex flex-col gap-3">
       {order.map((type) => (
@@ -457,11 +536,26 @@ function SourceSummary({ source }: { source: CaptureSource }) {
       </li>
     )
   }
+  if (source.type === "pcap-file") {
+    return (
+      <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
+        <div className="break-all font-mono text-sm">{source.path}</div>
+        <div className="mt-1 text-muted-foreground">
+          {source.realtime ? "replay at original speed" : "replay as fast as possible"}
+        </div>
+      </li>
+    )
+  }
+  // eBPF SSL-uprobe source.
   return (
     <li className="rounded-md border border-border/60 bg-background px-3 py-2 text-xs">
-      <div className="break-all font-mono text-sm">{source.path}</div>
+      <div className="font-mono text-sm">
+        {source.ssl_libs.length > 0 ? source.ssl_libs.join(", ") : "auto-discover libssl"}
+      </div>
       <div className="mt-1 text-muted-foreground">
-        {source.realtime ? "replay at original speed" : "replay as fast as possible"}
+        on-host TLS uprobes · process attribution
+        {source.targets.length > 0 ? ` · ${source.targets.length} static target(s)` : ""}
+        {source.pid_allowlist.length > 0 ? ` · ${source.pid_allowlist.length} pid(s)` : ""}
       </div>
     </li>
   )

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -553,6 +553,7 @@ export interface SessionTurnsPage {
 
 export type MetricGroup =
   | "capture"
+  | "ebpf"
   | "protocol"
   | "llm"
   | "turn"

--- a/console/src/types/api.ts
+++ b/console/src/types/api.ts
@@ -615,6 +615,9 @@ export interface RuntimeConfigResponse {
   config_path: string
   /** Binary version (env!("CARGO_PKG_VERSION") at compile time). */
   version: string
+  /** Whether this binary can run an `ebpf` capture source (built with the
+   * `ebpf` feature on Linux). Gates the Settings eBPF toggle. */
+  ebpf_available: boolean
   /**
    * The live in-memory `AppConfig`. The narrow `AppConfigShape` typing is
    * used by Settings; the debug page still renders the whole thing as JSON
@@ -652,6 +655,26 @@ export type CaptureSource =
       endpoint: string
       recv_hwm: number
     }
+  | {
+      // On-host eBPF SSL-uprobe capture (Linux, experimental). Mirror of the
+      // Rust CaptureSourceConfig::Ebpf fields. Empty ssl_libs = auto-discover
+      // libssl; targets are static, symbol-stripped binaries (e.g. Bun).
+      type: "ebpf"
+      source_id: string | null
+      ssl_libs: string[]
+      targets: EbpfTarget[]
+      pid_allowlist: number[]
+      segment_size: number
+    }
+
+export interface EbpfTarget {
+  binary: string
+  flavor: string
+  write_sig: string | null
+  read_sig: string | null
+  write_offset: number | null
+  read_offset: number | null
+}
 
 export interface PcapDumpRetention {
   enabled: boolean

--- a/server/app/heron/src/main.rs
+++ b/server/app/heron/src/main.rs
@@ -446,6 +446,14 @@ async fn run_pipeline(cli: Cli) {
                                 Metric::CaptureReadErrors,
                                 Metric::CaptureDumpErrors,
                                 Metric::CaptureDumpLateMinutePackets,
+                                // eBPF source metrics (stay 0 for packet taps).
+                                Metric::EbpfEventsReceived,
+                                Metric::EbpfEventsDropped,
+                                Metric::EbpfBytesCaptured,
+                                Metric::EbpfFramesSynthesized,
+                                Metric::EbpfUprobesAttached,
+                                Metric::EbpfConnectionsActive,
+                                Metric::EbpfProcessCacheSize,
                             ],
                         )
                     })

--- a/server/h-api/src/routes/capture_sources.rs
+++ b/server/h-api/src/routes/capture_sources.rs
@@ -74,6 +74,15 @@ pub async fn update(
             h_capture::interfaces::validate_pcap_source(interface, bpf_filter.as_deref())
                 .map_err(|e| ApiError::InvalidParam(format!("invalid pcap source: {e}")))?;
         }
+        // Reject an eBPF source on a build that can't run it — fail fast at the
+        // API instead of writing a config the next process boot would error on.
+        if matches!(s, CaptureSourceConfig::Ebpf { .. }) && !h_capture::ebpf_available() {
+            return Err(ApiError::InvalidParam(
+                "eBPF capture is unavailable: this binary was not built with the \
+                 `ebpf` feature (Linux only). Deploy an eBPF-enabled build to enable it."
+                    .to_string(),
+            ));
+        }
     }
 
     // Write TOML

--- a/server/h-api/src/routes/runtime_config.rs
+++ b/server/h-api/src/routes/runtime_config.rs
@@ -15,6 +15,9 @@ struct RuntimeConfigResponse {
     loaded_at_ms: i64,
     config_path: String,
     version: &'static str,
+    /// Whether this binary can run an `ebpf` capture source (compiled with the
+    /// `ebpf` feature on Linux). Gates the Settings "enable eBPF capture" toggle.
+    ebpf_available: bool,
     config: AppConfig,
 }
 
@@ -23,6 +26,7 @@ pub async fn runtime_config(State(ctx): State<ApiRuntimeConfigContext>) -> impl 
         loaded_at_ms: ctx.loaded_at_ms,
         config_path: ctx.config_path,
         version: ctx.version,
+        ebpf_available: h_capture::ebpf_available(),
         config: (*ctx.config).clone(),
     })
 }

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -145,6 +145,12 @@ impl CaptureSource for EbpfSource {
                     .to_string(),
             ));
         }
+        // Attach-health gauge: count of binaries carrying SSL uprobes (dynamic
+        // libssl + resolved static targets). 0 would have errored above, so a
+        // healthy source reports ≥1.
+        metrics
+            .counter(Metric::EbpfUprobesAttached)
+            .set((libs.len() + attached_targets) as u64);
 
         let ring = RingBuf::try_from(
             ebpf.take_map("EVENTS")
@@ -197,7 +203,14 @@ impl CaptureSource for EbpfSource {
                     };
                     let ring = guard.get_inner_mut();
                     while let Some(item) = ring.next() {
-                        let Some(ev) = decode_event(&item, &mut exe_cache) else { continue };
+                        let Some(ev) = decode_event(&item, &mut exe_cache) else {
+                            metrics.counter(Metric::EbpfEventsDropped).inc();
+                            continue;
+                        };
+                        metrics.counter(Metric::EbpfEventsReceived).inc();
+                        if let SslEvent::Data { ref data, .. } = ev {
+                            metrics.counter(Metric::EbpfBytesCaptured).add(data.len() as u64);
+                        }
                         for pkt in pump.on_event(ev) {
                             let is_hb = pkt.is_heartbeat();
                             if tx.send(pkt).await.is_err() {
@@ -208,10 +221,18 @@ impl CaptureSource for EbpfSource {
                                 metrics.counter(Metric::CaptureHeartbeatsEmitted).inc();
                             } else {
                                 metrics.counter(Metric::CapturePacketsReceived).inc();
+                                metrics.counter(Metric::EbpfFramesSynthesized).inc();
                             }
                         }
                     }
                     guard.clear_ready();
+                    // Refresh live gauges after draining the ring batch.
+                    metrics
+                        .counter(Metric::EbpfConnectionsActive)
+                        .set(pump.conn_count() as u64);
+                    metrics
+                        .counter(Metric::EbpfProcessCacheSize)
+                        .set(exe_cache.len() as u64);
                 }
             }
         }

--- a/server/h-capture/src/lib.rs
+++ b/server/h-capture/src/lib.rs
@@ -40,6 +40,14 @@ pub use routing::RoutingSender;
 pub use source::CaptureSource;
 pub use synth::{ConnTuple, FlowSynthesizer, StreamDir, SynthConfig};
 
+/// Whether this binary was compiled with the on-host eBPF capture loader
+/// (`--features ebpf`, Linux only). The Settings UI gates its "enable eBPF
+/// capture" toggle on this, and the capture-sources API rejects an `ebpf`
+/// source on a build that can't run it (clearer than a deferred factory error).
+pub fn ebpf_available() -> bool {
+    cfg!(all(target_os = "linux", feature = "ebpf"))
+}
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/server/h-common/src/internal_metrics.rs
+++ b/server/h-common/src/internal_metrics.rs
@@ -29,6 +29,7 @@ pub enum MetricKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MetricGroup {
     Capture,
+    Ebpf,
     Protocol,
     Llm,
     Turn,
@@ -40,6 +41,7 @@ impl MetricGroup {
     /// Canonical output order for [`MonitorPoll::format_grouped`].
     pub const ORDER: &[MetricGroup] = &[
         MetricGroup::Capture,
+        MetricGroup::Ebpf,
         MetricGroup::Protocol,
         MetricGroup::Llm,
         MetricGroup::Turn,
@@ -50,6 +52,7 @@ impl MetricGroup {
     pub const fn as_str(self) -> &'static str {
         match self {
             MetricGroup::Capture => "capture",
+            MetricGroup::Ebpf => "ebpf",
             MetricGroup::Protocol => "protocol",
             MetricGroup::Llm => "llm",
             MetricGroup::Turn => "turn",
@@ -142,6 +145,18 @@ define_metrics! {
     CaptureDumpRetentionFilesDeleted => { kind: Counter, group: Capture, short: "dump_retention_files_deleted" },
     CaptureDumpRetentionBytesDeleted => { kind: Counter, group: Capture, short: "dump_retention_bytes_deleted" },
     CaptureDumpRetentionErrors       => { kind: Counter, group: Capture, short: "dump_retention_errors" },
+
+    // -- eBPF SSL-uprobe capture (Linux, `ebpf` feature) --
+    // Emitted only by the eBPF source; stay 0 for packet-tap sources. Together
+    // they tell the on-host TLS story: kernel events in → bytes → synthetic
+    // frames out, with attach health + live connection / process-cache gauges.
+    EbpfEventsReceived       => { kind: Counter, group: Ebpf, short: "ebpf_events_received"    },
+    EbpfEventsDropped        => { kind: Counter, group: Ebpf, short: "ebpf_events_dropped"     },
+    EbpfBytesCaptured        => { kind: Counter, group: Ebpf, short: "ebpf_bytes_captured"     },
+    EbpfFramesSynthesized    => { kind: Counter, group: Ebpf, short: "ebpf_frames_synthesized" },
+    EbpfUprobesAttached      => { kind: Gauge,   group: Ebpf, short: "ebpf_uprobes_attached"   },
+    EbpfConnectionsActive    => { kind: Gauge,   group: Ebpf, short: "ebpf_connections_active" },
+    EbpfProcessCacheSize     => { kind: Gauge,   group: Ebpf, short: "ebpf_process_cache_size" },
 
     // -- Protocol (dispatcher + flow workers) --
     // Heartbeat received/dropped are both attributed to the destination


### PR DESCRIPTION
The code layer for turning on the on-host eBPF capture source (merged in #141)
and observing it. **No deploy-pipeline changes here** — building the eBPF
binary in CI and the staging verification gate land in a follow-up PR.

### A · Settings enable/disable toggle
- One-click **"eBPF capture (on-host TLS)"** toggle per pipeline card. Toggling
  adds/removes an `ebpf` capture source and rides the existing config-write +
  self-restart flow.
- **Capability gate**: `h_capture::ebpf_available()` (`cfg!(linux + ebpf
  feature)`) is surfaced on `/api/runtime-config` as `ebpf_available`. On a
  build that can't run eBPF the toggle is disabled with a note, and the
  capture-sources API rejects an `ebpf` source (fail fast).
- `ebpf` is now a first-class source type in the source editor — `EbpfForm`
  (auto-discover libssl vs explicit `ssl_libs`, PID allowlist, segment size,
  static-target count), heading, default, per-type section.

### B · pipeline-health eBPF metrics
- New `ebpf` internal-metrics group with seven signals emitted by the source:
  `ebpf_events_received` / `_dropped`, `_bytes_captured`, `_frames_synthesized`,
  and the gauges `_uprobes_attached` (attach health — 0 = broken),
  `_connections_active`, `_process_cache_size`.
- Registered on the capture worker (stay 0 for packet-tap sources); the
  data-driven `/api/internal-metrics` endpoint and the console pipeline-health
  All-Metrics table surface them automatically (new `ebpf` group chip).

### Validation
- `cargo check` (h-common, h-api) ✓; console `tsc -b` ✓.
- **Full eBPF build** (`--features "console h-capture/ebpf"`) compiles on a
  6.8 kernel ✓; a live `ebpf_smoke` run captured real TLS plaintext with
  process attribution (`curl(<pid>) /usr/bin/curl GET / HTTP/1.1`).

Until the follow-up enables the eBPF build in CI, deployed binaries report
`ebpf_available=false` and the toggle stays disabled — the honest, safe default.