### PR TITLE
feat(prod): build the eBPF-enabled binary in deploy-prod

### DIFF
--- a/scripts/prod/Dockerfile.ebpf-build
+++ b/scripts/prod/Dockerfile.ebpf-build
@@ -1,0 +1,48 @@
+# Reproducible builder for an eBPF-enabled `heron` that runs on Ubuntu 22.04 /
+# glibc 2.35 (wuneng prod). The BPF toolchain (nightly + rust-src + bpf-linker)
+# lives ONLY in this image — never on the prod host. Output is a glibc-2.35
+# dynamically-linked `heron` built with the eBPF capture engine compiled in.
+#
+# Base MUST match the prod host's userland (Ubuntu 22.04) so the binary links
+# glibc 2.35 and runs there; building on a newer glibc (e.g. a 24.04 host)
+# yields `GLIBC_2.39 not found` at runtime.
+#
+# Rust artifacts come from the rsproxy.cn mirror — direct static.rust-lang.org
+# from this network crawls at ~45 KB/s (40 min for the stable toolchain alone),
+# rsproxy.cn runs at ~15 MB/s.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential pkg-config libpcap-dev \
+      git curl ca-certificates \
+      llvm clang \
+ && rm -rf /var/lib/apt/lists/*
+
+# rsproxy.cn mirror for rustup downloads (toolchains + components).
+ENV RUSTUP_DIST_SERVER=https://rsproxy.cn \
+    RUSTUP_UPDATE_ROOT=https://rsproxy.cn/rustup
+
+# Rust stable (host userspace build) + nightly with rust-src (the BPF program is
+# compiled with `-Z build-std=core` for the bpfel-unknown-none target).
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustup toolchain install nightly --component rust-src --profile minimal
+
+# rsproxy.cn mirror for crates.io (cargo install + the heron build both use it).
+RUN printf '%s\n' \
+  '[source.crates-io]' \
+  "replace-with = 'rsproxy-sparse'" \
+  '[source.rsproxy-sparse]' \
+  'registry = "sparse+https://rsproxy.cn/index/"' \
+  '[registries.rsproxy]' \
+  'index = "sparse+https://rsproxy.cn/index/"' \
+  '[net]' \
+  'git-fetch-with-cli = true' \
+  > /root/.cargo/config.toml
+
+# bpf-linker performs the final link of the embedded BPF program.
+RUN cargo install bpf-linker --locked
+
+WORKDIR /build

--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -4,8 +4,9 @@
 # Runs on the `prod-deploy` self-hosted runner ON the prod host, so the deploy
 # is LOCAL (build + systemctl restart) — no SSH/VM hop. It is pinned to a
 # specific commit (the one that passed staging-soak) so prod gets exactly the
-# validated source, and it builds in the PERSISTENT checkout (warm cargo cache
-# → incremental, fast) rather than a fresh runner workspace.
+# validated source. The release binary is built in an Ubuntu-22.04 container
+# (glibc-2.35-correct, with the BPF toolchain) so the prod host stays clean and
+# the on-host eBPF capture engine is compiled in.
 #
 # Safety:
 #   - builds BEFORE touching the running service, so a build failure leaves
@@ -22,8 +23,12 @@
 #   HERON_PROD_SERVICE   systemd unit             (default: heron.service)
 #   HERON_PROD_PORT      heron API port           (default: 4500)
 #   HEALTH_TIMEOUT_SECS  health-gate budget secs  (default: 120)
-#   CARGO_BIN            cargo path               (default: ~/.cargo/bin/cargo)
 #   BUN_BIN              bun path                 (default: bun on PATH)
+#
+# The release binary is built in an Ubuntu-22.04 container (docker required) so
+# the prod host carries no BPF toolchain; the binary ships the on-host eBPF
+# SSL-uprobe capture engine. deploy ALSO ensures the unit's uprobe caps and an
+# `ebpf` source in the config (idempotent), so a fresh host is fully set up.
 #
 # Exit: 0 = deployed + healthy; non-zero = failed (rolled back if possible).
 set -euo pipefail
@@ -33,7 +38,6 @@ REPO="${HERON_PROD_REPO_DIR:?set HERON_PROD_REPO_DIR (persistent heron checkout 
 SERVICE="${HERON_PROD_SERVICE:-heron.service}"
 PORT="${HERON_PROD_PORT:-4500}"
 HEALTH_TIMEOUT_SECS="${HEALTH_TIMEOUT_SECS:-120}"
-CARGO="${CARGO_BIN:-$HOME/.cargo/bin/cargo}"
 # bun: explicit override → PATH → bun's canonical install dir. A non-login
 # deploy shell often lacks ~/.bun/bin on PATH (same reason CARGO defaults to
 # ~/.cargo/bin above), so fall back to the official-installer location rather
@@ -42,7 +46,7 @@ BUN="${BUN_BIN:-$(command -v bun 2>/dev/null || true)}"
 [ -n "$BUN" ] || BUN="$HOME/.bun/bin/bun"
 
 [ -d "$REPO/.git" ] || { echo "::error::HERON_PROD_REPO_DIR not a git checkout: $REPO" >&2; exit 1; }
-[ -x "$CARGO" ] || { echo "::error::cargo not executable at $CARGO" >&2; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "::error::docker not found — the release build runs in an Ubuntu-22.04 container so the host needs no BPF toolchain (see scripts/prod/Dockerfile.ebpf-build)" >&2; exit 1; }
 [ -x "$BUN" ] || { echo "::error::bun not executable at '$BUN' — cannot rebuild the console bundle; set BUN_BIN or install bun; refusing to ship a stale embedded UI" >&2; exit 1; }
 cd "$REPO"
 
@@ -81,12 +85,80 @@ echo "==> build console bundle (bun) — embedded into the binary via --features
 # actually picks up the freshly-built bundle instead of cached embedded bytes.
 touch server/app/heron/src/main.rs
 
-echo "==> build (release + console, incremental — MUST pass --features console)"
-( cd server && "$CARGO" build --release --bin heron --features console )
-[ -x "$BIN" ] || { echo "::error::build produced no binary at $BIN" >&2; exit 1; }
+echo "==> build (release + console + eBPF) in an Ubuntu-22.04 container"
+# Build inside a throwaway ubuntu:22.04 container, NOT on the host: the prod box
+# then needs no BPF toolchain (nightly + rust-src + bpf-linker), and the binary
+# links glibc 2.35 (the prod userland — building on a newer glibc would yield
+# `GLIBC_2.xx not found` at runtime). The on-host SSL-uprobe capture engine is
+# compiled in via `h-capture/ebpf` (the dependency feature is referenced
+# directly, so this works whether or not the heron app exposes its own `ebpf`
+# forwarding feature). A plain `--features console` host build would ship a
+# binary that CANNOT run the `ebpf` source already in the prod config and would
+# fail to start. See scripts/prod/Dockerfile.ebpf-build.
+IMG="heron-ebpf-builder:22.04"
+OUTDIR="$REPO/server/target/ebpf-out"
+mkdir -p "$OUTDIR"
+docker build -t "$IMG" -f "$REPO/scripts/prod/Dockerfile.ebpf-build" "$REPO/scripts/prod"
+docker run --rm \
+  -v "$REPO":/src:ro \
+  -v "$OUTDIR":/out \
+  "$IMG" bash -euo pipefail -c '
+    git config --global --add safe.directory "*"
+    mkdir -p /build/heron
+    # Export the tracked tree at HEAD (= the pinned, soaked commit) via archive,
+    # NOT clone (--local hardlinks fail across the mount/overlay device). Graft
+    # in the host-built console bundle (gitignored, so not in the archive).
+    git -C /src archive HEAD | tar -x -C /build/heron
+    cp -r /src/console/dist /build/heron/console/dist
+    cd /build/heron/server
+    cargo build --release --bin heron --features "console h-capture/ebpf"
+    install -m0755 target/release/heron /out/heron
+  '
+[ -x "$OUTDIR/heron" ] || { echo "::error::container build produced no binary" >&2; exit 1; }
+install -m0755 "$OUTDIR/heron" "$BIN"
 
 echo "==> smoke: heron --version"
 "$BIN" --version || { echo "::error::freshly built binary does not run" >&2; exit 1; }
+
+echo "==> ensure on-host eBPF prerequisites (idempotent)"
+UNIT_PATH="/etc/systemd/system/$SERVICE"
+unit_changed=0
+if [ -f "$UNIT_PATH" ]; then
+  # uprobe attach needs these caps. On kernels older than ~5.16 with a hardened
+  # perf_event_paranoid, the uprobe perf_event_open is gated on CAP_SYS_ADMIN —
+  # CAP_BPF + CAP_PERFMON alone is rejected (verified on the 5.15 prod host).
+  for cap in CAP_BPF CAP_PERFMON CAP_SYS_ADMIN; do
+    if grep -q "AmbientCapabilities=" "$UNIT_PATH" && ! grep -qE "AmbientCapabilities=.*\b$cap\b" "$UNIT_PATH"; then
+      sudo sed -i -E "s/^(AmbientCapabilities=.*)$/\1 $cap/" "$UNIT_PATH"
+      sudo sed -i -E "s/^(CapabilityBoundingSet=.*)$/\1 $cap/" "$UNIT_PATH"
+      unit_changed=1
+    fi
+  done
+  # Ensure the config the unit runs with (parsed from its `-c` flag) has an ebpf
+  # source. heron's own startup is the authoritative TOML validator; the health
+  # gate below rolls back if the edit is malformed.
+  CONF_PATH="$(grep -oE -- '-c[= ]+[^ ]+' "$UNIT_PATH" | head -1 | sed -E 's/^-c[= ]+//')"
+  if [ -n "$CONF_PATH" ] && [ -f "$CONF_PATH" ] && ! grep -q 'type = "ebpf"' "$CONF_PATH"; then
+    python3 - "$CONF_PATH" <<'PY'
+import sys
+p = sys.argv[1]
+lines = open(p).read().splitlines(keepends=True)
+block = ("\n# eBPF SSL-uprobe source (added by deploy-prod). Empty ssl_libs =\n"
+         "# autodetect libssl. Needs CAP_BPF+CAP_PERFMON+CAP_SYS_ADMIN (see unit).\n"
+         '[[pipeline.sources]]\ntype = "ebpf"\nsource_id = "ebpf"\n\n')
+out, done = [], False
+for ln in lines:
+    if not done and ln.lstrip().startswith("[storage]"):
+        out.append(block); done = True
+    out.append(ln)
+if not done:
+    out.append(block)
+open(p, "w").write("".join(out))
+print("  added ebpf source to", p)
+PY
+  fi
+fi
+if [ "$unit_changed" = 1 ]; then echo "  unit caps updated → daemon-reload"; sudo systemctl daemon-reload; fi
 
 echo "==> restarting $SERVICE"
 sudo systemctl restart "$SERVICE"

--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -33,6 +33,12 @@
 # Exit: 0 = deployed + healthy; non-zero = failed (rolled back if possible).
 set -euo pipefail
 
+# Resolve the script's own dir BEFORE any cd. The Dockerfile must come from HERE
+# (the runner workspace, checked out at the workflow ref = latest main, which
+# carries it) — NOT from $REPO, which gets `git checkout $SHA`'d to the deploy
+# target and may predate this file.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 SHA="${1:-origin/main}"
 REPO="${HERON_PROD_REPO_DIR:?set HERON_PROD_REPO_DIR (persistent heron checkout on the prod host)}"
 SERVICE="${HERON_PROD_SERVICE:-heron.service}"
@@ -98,7 +104,7 @@ echo "==> build (release + console + eBPF) in an Ubuntu-22.04 container"
 IMG="heron-ebpf-builder:22.04"
 OUTDIR="$REPO/server/target/ebpf-out"
 mkdir -p "$OUTDIR"
-docker build -t "$IMG" -f "$REPO/scripts/prod/Dockerfile.ebpf-build" "$REPO/scripts/prod"
+docker build -t "$IMG" -f "$SCRIPT_DIR/Dockerfile.ebpf-build" "$SCRIPT_DIR"
 docker run --rm \
   -v "$REPO":/src:ro \
   -v "$OUTDIR":/out \


### PR DESCRIPTION
Makes prod's eBPF capture durable: every `deploy-prod` now builds a binary with
the on-host SSL-uprobe engine compiled in, instead of `--features console`
(which would clobber the manually-enabled eBPF prod and then fail to start,
since a non-eBPF binary rejects the `ebpf` source in the config).

## How

- **`scripts/prod/Dockerfile.ebpf-build`** — Ubuntu 22.04 + nightly + rust-src +
  bpf-linker, crates/toolchain via the **rsproxy.cn** mirror (direct
  static.rust-lang.org measured ~45 KB/s from this network → 40 min for the
  stable toolchain alone; rsproxy ~15 MB/s). 22.04 base ⇒ the binary links
  glibc 2.35 (the prod userland; a 24.04 build would `GLIBC_2.39 not found`).
- **`deploy-prod.sh`** — the release build moves into a throwaway container:
  `git archive HEAD | tar` the pinned tree, graft in the host-built
  `console/dist`, `cargo build --features "console h-capture/ebpf"`, install the
  binary. Host needs only `docker` + `bun`; no rust/cargo/BPF toolchain.
- deploy also **idempotently ensures** the unit's uprobe caps and an `ebpf`
  source in the config, so a fresh prod host is fully set up by one deploy.

## Why CAP_SYS_ADMIN

The prod kernel is 5.15 with a hardened `perf_event_paranoid=4`. The uprobe
`perf_event_open` there is gated on **CAP_SYS_ADMIN** — CAP_BPF + CAP_PERFMON
alone is rejected (verified live: attach failed with those two, succeeded once
CAP_SYS_ADMIN was added). Newer kernels (the staging VM is 6.8) accept the
narrower pair; the cap set is additive so both work.

## Status / testing

- eBPF capture is already **live and verified on prod** (enabled manually first;
  uprobes attached, real TLS LLM calls captured with process attribution). This
  PR makes that survive the next `deploy-prod` rebuild.
- The container build logic is the exact, proven path that produced the running
  prod binary. The **first end-to-end exercise of the new `deploy-prod.sh` is
  the next prod deploy** — `bash -n` + `shellcheck` clean, build logic
  validated by equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)