### PR TITLE
fix(prod): raise container fd limit for the eBPF build

### DIFF
--- a/scripts/prod/deploy-prod.sh
+++ b/scripts/prod/deploy-prod.sh
@@ -105,7 +105,11 @@ IMG="heron-ebpf-builder:22.04"
 OUTDIR="$REPO/server/target/ebpf-out"
 mkdir -p "$OUTDIR"
 docker build -t "$IMG" -f "$SCRIPT_DIR/Dockerfile.ebpf-build" "$SCRIPT_DIR"
+# Raise the container fd limit: parallel rustc across this host's many cores
+# exhausts the default soft nofile (1024) → `cargo build` dies with "Too many
+# open files (os error 24)". Cap at the host hard limit.
 docker run --rm \
+  --ulimit nofile=1048576:1048576 \
   -v "$REPO":/src:ro \
   -v "$OUTDIR":/out \
   "$IMG" bash -euo pipefail -c '


### PR DESCRIPTION
Follow-up to #150. The container build of the eBPF binary died with
`Too many open files (os error 24)` on the first real `deploy-prod` run: parallel
rustc across wuneng's many cores exhausts the container's default soft `nofile`
(1024). Set `--ulimit nofile` to the host hard limit (1048576).

Found by manually exercising the new deploy-prod.sh end-to-end on the prod host
(the build failed BEFORE the install step, so prod was untouched — still running
the working eBPF binary). Re-validated with this fix before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)