### PR TITLE
fix(ebpf): raise SSL-uprobe DATA_CAP 4 KiB → 32 KiB so large LLM requests are recognized

### DIFF
--- a/server/h-ebpf-common/src/lib.rs
+++ b/server/h-ebpf-common/src/lib.rs
@@ -15,12 +15,24 @@
 /// Length of a process `comm` (kernel `TASK_COMM_LEN`).
 pub const COMM_LEN: usize = 16;
 
-/// Maximum plaintext bytes carried in a single event. A larger `SSL_read` /
-/// `SSL_write` is emitted as several consecutive same-direction events, which
-/// the userspace synthesizer concatenates by sequence number — so this cap
-/// never loses bytes, it only bounds per-event size (BPF stack/verifier
-/// limits make one giant copy impossible).
-pub const DATA_CAP: usize = 4096;
+/// Maximum plaintext bytes carried in a single event. A single `SSL_read` /
+/// `SSL_write` larger than this is currently **truncated** to `DATA_CAP` by the
+/// BPF program (`h-ebpf-prog::emit_data`) and its tail is lost — chunking a big
+/// write into several consecutive same-direction events that the userspace
+/// synthesizer reassembles is a TODO, not yet implemented.
+///
+/// Sized at 32 KiB so a real-world Claude Code `/v1/messages` request — sent by
+/// Node as ONE ~23 KiB `SSL_write` (request line + headers + JSON body) —
+/// arrives whole in a single event. At the previous 4 KiB the request was cut
+/// after its first 4 KiB, so `anthropic-version` / the JSON body were lost and
+/// the wire-API registry could not recognize the call (it went to
+/// `wires_ignored`), leaving every Claude Code call out of storage. The record
+/// is reserved from the 16 MiB ring buffer (not the 512-byte BPF stack), so a
+/// 32 KiB payload is fine, and the `bpf_probe_read_user` length stays clamped
+/// to `DATA_CAP`, so the verifier can still prove the copy in-bounds. Writes
+/// beyond 32 KiB (long conversations) still lose their tail until the chunking
+/// TODO lands.
+pub const DATA_CAP: usize = 32768;
 
 /// Event kind discriminants (`SslEvent::kind`).
 pub mod kind {

--- a/server/h-ebpf-prog/src/main.rs
+++ b/server/h-ebpf-prog/src/main.rs
@@ -83,9 +83,13 @@ pub fn ssl_shutdown(ctx: ProbeContext) -> u32 {
 }
 
 /// Reserve a ring-buffer record, fill the header, and copy up to [`DATA_CAP`]
-/// plaintext bytes from the userspace buffer. A larger call is truncated to
-/// `DATA_CAP` here; the userspace synthesizer treats each event as a contiguous
-/// segment, so consecutive events on the same connection reassemble in order.
+/// plaintext bytes from the userspace buffer.
+///
+/// A single call larger than `DATA_CAP` is **truncated** to `DATA_CAP` and its
+/// tail is dropped — we do NOT yet split a big write into several consecutive
+/// events for the userspace synthesizer to reassemble. `DATA_CAP` is sized
+/// (32 KiB) to hold a whole Claude Code `/v1/messages` request in one event;
+/// chunking arbitrarily large writes is a TODO.
 fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
     let n = if len as usize > DATA_CAP {
         DATA_CAP as u32


### PR DESCRIPTION
## Problem

The eBPF SSL-uprobe capture path drops LLM calls whose HTTP request is larger
than 4 KiB. The BPF program (`h-ebpf-prog::emit_data`) copies at most `DATA_CAP`
(= 4096) bytes from each `SSL_write` / `SSL_read` into a single ring-buffer
event and **truncates** anything beyond that — it does not chunk a big write
into several events (the old doc comments claimed consecutive-event reassembly,
but that was aspirational and never implemented).

Modern agent clients send the whole request — request line + headers + a large
JSON body (system prompt + tools + conversation) — in one big `SSL_write`. A
real Claude Code (Node) `/v1/messages` request measured ~23 KiB in a single
write. At `DATA_CAP = 4096` heron saw only the first 4 KiB, so the wire-API
registry could not find `anthropic-version` / parse the body, the request went
to `wires_ignored` instead of `wires_detected`, and the call never became a
queryable `llm_calls` row — invisible in the console even though uprobes were
attached and bytes were being captured. Small requests (< 4 KiB) were
unaffected, which masked the bug.

## Fix

Raise `DATA_CAP` 4096 → 32768 in `h-ebpf-common` so a whole real-world request
arrives in one event and is recognized, persisted, and process-attributed.

- The record is reserved from the 16 MiB ring buffer, **not** the 512-byte BPF
  stack, so a 32 KiB payload is fine.
- `bpf_probe_read_user`'s length stays clamped to `DATA_CAP`, so the verifier
  can still prove the copy in-bounds.
- Misleading comments in `lib.rs` and `main.rs` are corrected to state that an
  over-cap write is truncated (not chunked).

## Verification

- The BPF object compiles and **loads on a 5.15 kernel** (the verifier accepts
  the 32 KiB clamped read); uprobes attach and capture starts.
- A real agent request that previously hit `wires_ignored` is now recognized as
  an Anthropic call, persisted, and attributed to the originating process
  (`comm` / pid / exe).
- Ring-buffer drops stay at zero under normal load with the larger record size.

## Known limitation / follow-up

Writes larger than 32 KiB (very long conversations) still lose their body tail —
headers and call recognition are unaffected, but the captured prompt body is
truncated. The complete fix is to chunk large writes into multiple `DATA_CAP`
events in the BPF program and reassemble them by connection + direction in the
userspace synthesizer before HTTP parsing; that is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)