### PR TITLE
fix: decompress gzip responses + classify header-less Claude Code as claude-cli

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "criterion",
+ "flate2",
  "h-capture",
  "h-common",
  "httparse",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -60,6 +60,10 @@ httparse = "1"
 uuid = { version = "1", features = ["v7"] }
 bytemuck = { version = "1", features = ["derive"] }
 
+# Response-body decompression (Content-Encoding: gzip/deflate). Pure-Rust
+# backend (miniz_oxide) so the single static binary keeps building offline.
+flate2 = "1"
+
 # Benchmarking (dev-only; hot-path micro-benches — see h-protocol/benches/)
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -1,13 +1,37 @@
 use crate::agent_primitives::{AgentPrimitives, SystemPromptMarkers};
 use crate::model::LlmCall;
 use crate::profile::{AgentProfile, CallCtx, SessionIdExtraction};
-use crate::wire_apis as wa;
+use crate::wire_apis::{self as wa, AssistantSig};
 use serde_json::Value;
+
+use super::session_id::compose_session_id_tracked;
 
 pub struct ClaudeCliProfile;
 
 const SESSION_HEADER: &str = "x-claude-code-session-id";
 const UA_PREFIX: &str = "claude-cli/";
+
+/// Tool-call anchor for session synthesis when the legacy
+/// `x-claude-code-session-id` header is absent (Claude Code stopped sending it
+/// around v2.1). Mirrors `GenericProfile`'s anthropic branch: the first user
+/// text plus the first `tool_use` id (from the request history, else the
+/// response) form a stable per-session anchor. Returns `None` for text-only
+/// traffic with no tool anchor — such calls fall through to a later profile
+/// rather than being claimed-and-dropped.
+fn anthropic_tool_anchor(ctx: &CallCtx<'_>) -> Option<(String, AssistantSig)> {
+    let req = ctx.req?;
+    let user_text = wa::anthropic::first_user_text(req)?;
+    let sig = match wa::anthropic::first_assistant_sig_from_request(req) {
+        Some(s) => Some(s),
+        None => ctx
+            .resp
+            .and_then(wa::anthropic::first_assistant_sig_from_response_value),
+    }?;
+    if !matches!(sig, AssistantSig::ToolId(_)) {
+        return None;
+    }
+    Some((user_text, sig))
+}
 
 fn header<'a>(call: &'a LlmCall, key: &str) -> Option<&'a str> {
     call.request_headers
@@ -64,13 +88,14 @@ impl AgentProfile for ClaudeCliProfile {
     }
 
     fn matches(&self, ctx: &CallCtx<'_>) -> bool {
-        // Both UA prefix AND SESSION_HEADER must be present. UA alone isn't
-        // enough: the registry is first-match-wins (`profile.rs:181`), so
-        // claiming a call here when the session header is missing leaves the
-        // call with `extract_session_id() = None` and no fallback. By
-        // requiring the header up front, UA-spoofed / header-stripped /
-        // pre-session-header-version traffic falls through to GenericProfile,
-        // which can synthesize a session anchor from the body.
+        // Identify Claude Code by `User-Agent: claude-cli/*` on Anthropic wire,
+        // then require a usable session anchor so we never claim-and-drop a call
+        // (the registry is first-match-wins, profile.rs:181). The anchor is the
+        // legacy `x-claude-code-session-id` header when present, OR — for Claude
+        // Code v2.1+ which no longer sends that header — a synthesizable
+        // tool-call anchor in the body (same mechanism GenericProfile uses).
+        // UA-spoofed / header-stripped / anchorless text-only traffic still
+        // falls through to a later profile.
         if ctx.call.wire_api != wa::ANTHROPIC {
             return false;
         }
@@ -80,14 +105,25 @@ impl AgentProfile for ClaudeCliProfile {
         if !ua_ok {
             return false;
         }
-        header(ctx.call, SESSION_HEADER).is_some()
+        header(ctx.call, SESSION_HEADER).is_some() || anthropic_tool_anchor(ctx).is_some()
     }
 
     fn extract_session_id(&self, ctx: &CallCtx<'_>) -> Option<SessionIdExtraction> {
-        let session_id = header(ctx.call, SESSION_HEADER)?.to_string();
+        // Prefer the explicit session header when present (older Claude Code).
+        if let Some(h) = header(ctx.call, SESSION_HEADER) {
+            return Some(SessionIdExtraction {
+                session_id: h.to_string(),
+                tool_id_canonicalized: false,
+            });
+        }
+        // Fallback for header-less Claude Code: synthesize from the tool-call
+        // anchor exactly as GenericProfile does, so the same conversation maps
+        // to one stable session_id across its calls.
+        let (user_text, sig) = anthropic_tool_anchor(ctx)?;
+        let (session_id, tool_id_canonicalized) = compose_session_id_tracked(&user_text, sig);
         Some(SessionIdExtraction {
             session_id,
-            tool_id_canonicalized: false,
+            tool_id_canonicalized,
         })
     }
 
@@ -346,16 +382,37 @@ mod tests {
     }
 
     #[test]
-    fn does_not_match_when_session_header_missing() {
-        // UA alone is not enough — without `x-claude-code-session-id` we
-        // cannot extract a session_id, so the registry must let the call
-        // fall through to GenericProfile rather than claiming and dropping it.
+    fn does_not_match_when_session_header_missing_and_no_anchor() {
+        // UA + no session header + no body → no session anchor at all, so the
+        // call must fall through to a later profile rather than being
+        // claimed-and-dropped (registry is first-match-wins).
         let c = call_with(
             wa::ANTHROPIC,
             vec![("User-Agent", "claude-cli/2.1.98 (external, cli)")],
             None,
         );
         assert!(!ClaudeCliProfile.matches(&c.ctx()));
+    }
+
+    #[test]
+    fn matches_via_tool_anchor_when_session_header_absent() {
+        // Claude Code v2.1+ no longer sends x-claude-code-session-id. A
+        // tool-roundtrip request still carries a tool_use id in history, so the
+        // profile claims it (UA + synthesizable anchor) and labels it
+        // claude-cli instead of letting it fall through to generic.
+        let body = r#"{"messages":[
+            {"role":"user","content":[{"type":"text","text":"do the thing"}]},
+            {"role":"assistant","content":[{"type":"tool_use","id":"toolu_abc","name":"Bash","input":{}}]},
+            {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_abc","content":"ok"}]}
+        ]}"#;
+        let c = call_with(
+            wa::ANTHROPIC,
+            vec![("User-Agent", "claude-cli/2.1.75 (external, sdk-cli)")],
+            Some(body),
+        );
+        assert!(ClaudeCliProfile.matches(&c.ctx()));
+        let ids = ClaudeCliProfile.extract_session_id(&c.ctx()).unwrap();
+        assert!(!ids.session_id.is_empty());
     }
 
     #[test]

--- a/server/h-llm/src/agents/mod.rs
+++ b/server/h-llm/src/agents/mod.rs
@@ -197,18 +197,19 @@ mod priority_tests {
     }
 
     #[test]
-    fn generic_catches_claude_cli_ua_without_session_header() {
-        // UA-spoofing or header-stripping: looks like claude-cli but the
-        // session header is absent. ClaudeCliProfile must NOT claim it
-        // (otherwise extract_session_id would return None with no fallback) —
-        // GenericProfile picks it up when the body has a tool-call anchor.
+    fn claude_cli_claims_ua_with_tool_anchor_without_session_header() {
+        // Claude Code v2.1+ stopped sending x-claude-code-session-id. A
+        // claude-cli UA on Anthropic wire with a tool-anchored body is now
+        // claimed by ClaudeCliProfile (it synthesizes the session from the
+        // anchor, same as GenericProfile) so the turn is labeled claude-cli
+        // rather than generic.
         let reg = build_default_registry();
         let c = call_with_body(
             wa::ANTHROPIC,
             vec![("User-Agent", "claude-cli/2.1.98 (cli)")],
             Some(GENERIC_ANT_TOOL_HISTORY),
         );
-        assert_eq!(find_kind(&reg, &c), Some("generic"));
+        assert_eq!(find_kind(&reg, &c), Some("claude-cli"));
     }
 
     const CODEX_STUB_META: &str = r#"{"session_id":"deadbeef-0000-0000-0000-000000000000"}"#;

--- a/server/h-protocol/Cargo.toml
+++ b/server/h-protocol/Cargo.toml
@@ -10,6 +10,7 @@ h-common.workspace = true
 h-capture.workspace = true
 bytes.workspace = true
 httparse.workspace = true
+flate2.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/server/h-protocol/src/http.rs
+++ b/server/h-protocol/src/http.rs
@@ -1,6 +1,8 @@
+use std::io::Write;
 use std::net::IpAddr;
 
 use bytes::{Bytes, BytesMut};
+use flate2::write::{GzDecoder, ZlibDecoder};
 
 use crate::model::{HttpParseEvent, HttpRequestData, HttpResponseData, SseEventData};
 use crate::net::FlowKey;
@@ -45,6 +47,66 @@ enum ReadResult {
     Error,
 }
 
+/// Streaming `Content-Encoding` decompressor for an HTTP body.
+///
+/// Compressed bytes are pushed in as they arrive (one de-chunked chunk at a
+/// time for SSE, or the whole body for Content-Length) and decompressed bytes
+/// come out incrementally, so the SSE parser keeps seeing plaintext. The real
+/// motivator: api.anthropic.com gzip-compresses its `text/event-stream`
+/// responses, and without this every Anthropic call lands with an empty
+/// response body (no tokens / tool_use / model). gzip + deflate are handled via
+/// flate2 (pure-Rust miniz_oxide); other encodings (`br`, …) are treated as
+/// unsupported and left to the caller as passthrough.
+///
+/// Best-effort: a malformed stream yields whatever decompressed so far rather
+/// than failing the parse — this is observability data, not a correctness gate.
+enum BodyDecompressor {
+    Gzip(GzDecoder<Vec<u8>>),
+    /// `Content-Encoding: deflate` per RFC 7230 is the zlib format (RFC 1950).
+    Zlib(ZlibDecoder<Vec<u8>>),
+}
+
+impl BodyDecompressor {
+    /// Build from a `Content-Encoding` value, or `None` for identity / an
+    /// encoding we don't decode (caller then treats the body as plaintext).
+    fn from_encoding(enc: &str) -> Option<Self> {
+        match enc.trim().to_ascii_lowercase().as_str() {
+            "gzip" | "x-gzip" => Some(Self::Gzip(GzDecoder::new(Vec::new()))),
+            "deflate" => Some(Self::Zlib(ZlibDecoder::new(Vec::new()))),
+            _ => None,
+        }
+    }
+
+    fn writer(&mut self) -> &mut dyn Write {
+        match self {
+            Self::Gzip(d) => d,
+            Self::Zlib(d) => d,
+        }
+    }
+
+    fn drain(&mut self) -> Vec<u8> {
+        match self {
+            Self::Gzip(d) => std::mem::take(d.get_mut()),
+            Self::Zlib(d) => std::mem::take(d.get_mut()),
+        }
+    }
+
+    /// Push compressed bytes; return whatever decompressed output is ready.
+    fn push(&mut self, data: &[u8]) -> Vec<u8> {
+        let _ = self.writer().write_all(data);
+        let _ = self.writer().flush();
+        self.drain()
+    }
+
+    /// Finish the stream, returning any trailing decompressed bytes.
+    fn finish(self) -> Vec<u8> {
+        match self {
+            Self::Gzip(d) => d.finish().unwrap_or_default(),
+            Self::Zlib(d) => d.finish().unwrap_or_default(),
+        }
+    }
+}
+
 /// Reads an HTTP message body according to its framing.
 struct BodyReader {
     framing: BodyFraming,
@@ -56,6 +118,9 @@ struct BodyReader {
     /// `finish`. Used for SSE responses whose raw body is never read by any
     /// downstream stage (LlmProcessor rebuilds response_body from SSE events).
     skip_accumulation: bool,
+    /// `Content-Encoding` decompressor. `None` for the common uncompressed case,
+    /// where the body passes through byte-for-byte unchanged.
+    decompressor: Option<BodyDecompressor>,
 }
 
 impl BodyReader {
@@ -64,6 +129,7 @@ impl BodyReader {
             framing: BodyFraming::NoBody,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            decompressor: None,
         }
     }
 
@@ -79,6 +145,9 @@ impl BodyReader {
             framing,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            // Request bodies are not decompressed (agent clients send plaintext
+            // JSON); only responses carry Content-Encoding in practice.
+            decompressor: None,
         }
     }
 
@@ -98,6 +167,28 @@ impl BodyReader {
             framing,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            decompressor: extract_content_encoding(headers)
+                .as_deref()
+                .and_then(BodyDecompressor::from_encoding),
+        }
+    }
+
+    /// Pass de-chunked body bytes through the `Content-Encoding` decompressor,
+    /// if any. With no decompressor (the common case) this is an identity copy,
+    /// so uncompressed traffic is byte-for-byte unchanged.
+    fn decode_payload(&mut self, data: &[u8]) -> Bytes {
+        match self.decompressor.as_mut() {
+            Some(d) => Bytes::from(d.push(data)),
+            None => Bytes::copy_from_slice(data),
+        }
+    }
+
+    /// Flush trailing decompressed bytes at end-of-body (terminal chunk / close).
+    /// Empty when there is no decompressor or nothing is buffered.
+    fn flush_decompressor(&mut self) -> Bytes {
+        match self.decompressor.take() {
+            Some(d) => Bytes::from(d.finish()),
+            None => Bytes::new(),
         }
     }
 
@@ -110,8 +201,16 @@ impl BodyReader {
             BodyFraming::NoBody => ReadResult::Complete(Bytes::new()),
             BodyFraming::ContentLength(len) => {
                 if buf.len() >= len {
-                    let body = Bytes::copy_from_slice(&buf[..len]);
-                    let _ = buf.split_to(len);
+                    let raw = buf.split_to(len);
+                    let body = self.decode_payload(&raw);
+                    let tail = self.flush_decompressor();
+                    let body = if tail.is_empty() {
+                        body
+                    } else {
+                        let mut v = body.to_vec();
+                        v.extend_from_slice(&tail);
+                        Bytes::from(v)
+                    };
                     ReadResult::Complete(body)
                 } else {
                     ReadResult::NeedMore
@@ -122,11 +221,12 @@ impl BodyReader {
                 if buf.is_empty() {
                     ReadResult::NeedMore
                 } else {
-                    let data = buf.split();
+                    let raw = buf.split();
+                    let data = self.decode_payload(&raw);
                     if !self.skip_accumulation {
                         self.decoded_body.extend_from_slice(&data);
                     }
-                    ReadResult::ChunkDecoded(data.freeze())
+                    ReadResult::ChunkDecoded(data)
                 }
             }
         }
@@ -162,6 +262,11 @@ impl BodyReader {
                             // Empty line — end of trailers.
                             let total = line_end + 2 + pos + 2;
                             let _ = buf.split_to(total);
+                            // Flush any decompressor remainder into the body.
+                            let tail = self.flush_decompressor();
+                            if !self.skip_accumulation && !tail.is_empty() {
+                                self.decoded_body.extend_from_slice(&tail);
+                            }
                             let body = if self.skip_accumulation {
                                 Bytes::new()
                             } else {
@@ -183,12 +288,13 @@ impl BodyReader {
         }
 
         let _ = buf.split_to(line_end + 2);
-        let chunk_data = buf.split_to(chunk_size);
+        let raw = buf.split_to(chunk_size);
         let _ = buf.split_to(2);
+        let chunk_data = self.decode_payload(&raw);
         if !self.skip_accumulation {
             self.decoded_body.extend_from_slice(&chunk_data);
         }
-        ReadResult::ChunkDecoded(chunk_data.freeze())
+        ReadResult::ChunkDecoded(chunk_data)
     }
 
     /// Flush remaining data as body on connection close.
@@ -196,11 +302,13 @@ impl BodyReader {
         match self.framing {
             BodyFraming::NoBody => Bytes::new(),
             BodyFraming::ContentLength(_) => {
-                let body = buf.split().freeze();
+                let raw = buf.split();
                 if self.skip_accumulation {
                     Bytes::new()
                 } else {
-                    body
+                    let mut body = self.decode_payload(&raw).to_vec();
+                    body.extend_from_slice(&self.flush_decompressor());
+                    Bytes::from(body)
                 }
             }
             BodyFraming::Chunked | BodyFraming::CloseDelimited => {
@@ -209,7 +317,13 @@ impl BodyReader {
                     Bytes::new()
                 } else {
                     if !buf.is_empty() {
-                        self.decoded_body.extend_from_slice(&buf.split());
+                        let raw = buf.split();
+                        let data = self.decode_payload(&raw);
+                        self.decoded_body.extend_from_slice(&data);
+                    }
+                    let tail = self.flush_decompressor();
+                    if !tail.is_empty() {
+                        self.decoded_body.extend_from_slice(&tail);
                     }
                     self.decoded_body.split().freeze()
                 }
@@ -705,6 +819,17 @@ fn extract_content_length(headers: &[(String, String)]) -> Option<usize> {
         .and_then(|(_, v)| v.trim().parse().ok())
 }
 
+/// Extract a decodable `Content-Encoding` from parsed headers, skipping
+/// `identity` / empty. Returns the raw token (e.g. `"gzip"`) for
+/// [`BodyDecompressor::from_encoding`].
+fn extract_content_encoding(headers: &[(String, String)]) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-encoding"))
+        .map(|(_, v)| v.trim().to_string())
+        .filter(|v| !v.is_empty() && !v.eq_ignore_ascii_case("identity"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -721,6 +846,62 @@ mod tests {
         let ca = ("127.0.0.1".parse().unwrap(), 1000);
         let sa = ("127.0.0.1".parse().unwrap(), 8080);
         (fk, ca, sa)
+    }
+
+    #[test]
+    fn body_reader_gunzips_content_length_gzip() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let plain = b"{\"model\":\"claude-opus-4-6\",\"usage\":{\"output_tokens\":7}}";
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(plain).unwrap();
+        let gz = enc.finish().unwrap();
+        let headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("Content-Encoding".to_string(), "gzip".to_string()),
+            ("Content-Length".to_string(), gz.len().to_string()),
+        ];
+        let mut br = BodyReader::new_for_response(200, "POST", &headers);
+        let mut buf = BytesMut::from(&gz[..]);
+        match br.read(&mut buf) {
+            ReadResult::Complete(body) => assert_eq!(&body[..], &plain[..]),
+            _ => panic!("expected Complete with decompressed body"),
+        }
+    }
+
+    #[test]
+    fn body_reader_gunzips_chunked_gzip_sse() {
+        // The real api.anthropic.com shape: text/event-stream + chunked +
+        // Content-Encoding: gzip. Before the fix the SSE parser saw gzip bytes
+        // and produced an empty body.
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let plain = b"event: message_start\r\ndata: {\"type\":\"message_start\"}\r\n\r\n";
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(plain).unwrap();
+        let gz = enc.finish().unwrap();
+        // Wrap the gzip stream as one HTTP chunk + terminal chunk.
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(format!("{:x}\r\n", gz.len()).as_bytes());
+        buf.extend_from_slice(&gz);
+        buf.extend_from_slice(b"\r\n0\r\n\r\n");
+        let headers = vec![
+            ("Content-Type".to_string(), "text/event-stream".to_string()),
+            ("Transfer-Encoding".to_string(), "chunked".to_string()),
+            ("Content-Encoding".to_string(), "gzip".to_string()),
+        ];
+        let mut br = BodyReader::new_for_response(200, "POST", &headers);
+        br.set_skip_accumulation(true); // SSE path: collect ChunkDecoded output
+        let mut out = Vec::new();
+        loop {
+            match br.read(&mut buf) {
+                ReadResult::ChunkDecoded(c) => out.extend_from_slice(&c),
+                ReadResult::Complete(_) => break,
+                ReadResult::NeedMore => panic!("unexpected NeedMore"),
+                ReadResult::Error => panic!("decode error"),
+            }
+        }
+        assert_eq!(out, plain);
     }
 
     #[test]


### PR DESCRIPTION
Two fixes that make captured Claude Code (and other agent) traffic usable, on top of the DATA_CAP bump in #153.

## 1. Decompress gzip/deflate response bodies (`h-protocol`)

api.anthropic.com gzip-compresses its streaming responses
(`Content-Type: text/event-stream` + `Transfer-Encoding: chunked` +
`Content-Encoding: gzip`). heron never decompressed response bodies, so the SSE
parser received gzip bytes and produced an **empty** response — no tokens, no
finish_reason, no tool_use. Uncompressed upstreams were unaffected, which masked
the gap.

`BodyReader` now runs a streaming `Content-Encoding` decompressor (gzip + deflate
via flate2's pure-Rust backend) over de-chunked bytes before they reach the SSE
parser and before accumulation/storage. It engages **only** when a response
carries `Content-Encoding`, so uncompressed traffic is byte-for-byte unchanged.
Covers chunked, Content-Length and close-delimited framings. Unsupported
encodings (`br`, …) pass through unchanged for now. Two unit tests cover
Content-Length gzip and the chunked+gzip+SSE shape.

Verified live: real streaming calls that previously stored an empty body now
land with input/output tokens and finish_reason populated.

## 2. Classify header-less Claude Code as `claude-cli`, not `generic` (`h-llm`)

Recent Claude Code stopped sending the `x-claude-code-session-id` header, which
`ClaudeCliProfile` hard-required to match — so every Claude Code turn fell
through to `GenericProfile` and was labelled `generic`.

`ClaudeCliProfile::matches` now claims a call on `User-Agent: claude-cli/*` +
Anthropic wire when EITHER the legacy session header is present OR a tool-call
anchor is synthesizable from the body (the same anchor `GenericProfile` already
uses). `extract_session_id` prefers the header and falls back to the synthesized
anchor, so a conversation maps to one stable session id and is never
claimed-and-dropped; anchorless text-only traffic still falls through. Registry
order already places claude-cli ahead of generic, so this only reclaims
previously-mislabelled traffic.

## Tests
Full `h-protocol` (129) and `h-llm` (394) suites green, including updated
priority coverage and new tests for both paths.

## Known follow-up
The agent **turn** label is taken from its first call. A turn's opening request
has no tool-call in its own history, so its anchor depends on the reconstructed
streaming response — that path still needs work for the first call to be claimed
as claude-cli (tool-roundtrip calls within the turn already classify correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)