### PR TITLE
fix(ebpf): correct large/multi-connection capture + form Claude Code agent-turns

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "criterion",
+ "flate2",
  "h-capture",
  "h-common",
  "httparse",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -60,6 +60,10 @@ httparse = "1"
 uuid = { version = "1", features = ["v7"] }
 bytemuck = { version = "1", features = ["derive"] }
 
+# Response-body decompression (Content-Encoding: gzip/deflate). Pure-Rust
+# backend (miniz_oxide) so the single static binary keeps building offline.
+flate2 = "1"
+
 # Benchmarking (dev-only; hot-path micro-benches — see h-protocol/benches/)
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -311,6 +311,37 @@ mod tests {
     }
 
     #[test]
+    fn chunked_write_events_emit_sequential_segments() {
+        // The BPF program splits a large SSL_write into several consecutive
+        // DATA events on the same conn+dir. The pump must turn each into its own
+        // TCP segment (one frame per event) so the TCP layer reassembles the
+        // full body — never merging or dropping a chunk.
+        let mut p = pump(vec![]);
+        p.on_event(SslEvent::Connect {
+            conn_id: 1,
+            pid: 100,
+            comm: "node".into(),
+            exe: None,
+            tuple: Some(tuple()),
+            ktime_ns: 1_000_000,
+        });
+        let mut segments = 0;
+        for (k, part) in [b"AAAA".as_slice(), b"BBBB", b"CCCC"].iter().enumerate() {
+            let frames = p.on_event(SslEvent::Data {
+                conn_id: 1,
+                pid: 100,
+                comm: "node".into(),
+                exe: None,
+                dir: StreamDir::ClientToServer,
+                data: Bytes::copy_from_slice(part),
+                ktime_ns: 1_100_000 + k as u64 * 1000,
+            });
+            segments += data_frame_count(&frames);
+        }
+        assert_eq!(segments, 3, "each chunk event yields one TCP segment");
+    }
+
+    #[test]
     fn close_event_emits_fins_and_forgets_conn() {
         let mut p = pump(vec![]);
         p.on_event(SslEvent::Connect {

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -78,6 +78,10 @@ pub enum SslEvent {
         exe: Option<String>,
         dir: StreamDir,
         data: Bytes,
+        /// Absolute byte offset of `data[0]` within this connection-direction
+        /// stream (BPF per-connection counter). Lets the synthesizer place a
+        /// chunk at its true sequence even after a dropped/reordered sibling.
+        seq_off: u64,
         ktime_ns: u64,
     },
     /// The connection was torn down (`SSL_shutdown` / `close`).
@@ -224,8 +228,12 @@ impl EbpfPump {
                 self.synth.open(conn_id, tuple, ts_us)
             }
             SslEvent::Data {
-                conn_id, dir, data, ..
-            } => self.synth.data(conn_id, dir, &data, ts_us),
+                conn_id,
+                dir,
+                data,
+                seq_off,
+                ..
+            } => self.synth.data(conn_id, dir, &data, seq_off, ts_us),
             SslEvent::Close { conn_id, .. } => self.synth.close(conn_id, ts_us),
         };
 
@@ -305,6 +313,7 @@ mod tests {
             exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"POST /v1/messages HTTP/1.1\r\n\r\n"),
+            seq_off: 0,
             ktime_ns: 1_100_000,
         });
         assert_eq!(data_frame_count(&frames), 1);
@@ -334,6 +343,8 @@ mod tests {
                 exe: None,
                 dir: StreamDir::ClientToServer,
                 data: Bytes::copy_from_slice(part),
+                // Each chunk carries its absolute stream offset (4 bytes each).
+                seq_off: (k * 4) as u64,
                 ktime_ns: 1_100_000 + k as u64 * 1000,
             });
             segments += data_frame_count(&frames);
@@ -414,6 +425,7 @@ mod tests {
             exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"GET / HTTP/1.1\r\n"),
+            seq_off: 0,
             ktime_ns: 1_000 * 1_000, // 1_000_000 ns = 1_000 µs
         });
         assert_eq!(f0.iter().filter(|p| p.is_heartbeat()).count(), 0);
@@ -428,6 +440,7 @@ mod tests {
             exe: None,
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"X"),
+            seq_off: 16,
             ktime_ns: later_ns,
         });
         assert_eq!(
@@ -455,6 +468,7 @@ mod tests {
             exe: Some("/usr/bin/python3.12".into()),
             dir: StreamDir::ClientToServer,
             data: Bytes::from_static(b"POST /v1/messages HTTP/1.1\r\n\r\n"),
+            seq_off: 0,
             ktime_ns: 1_100_000,
         });
         // The data segment carries the owning process; pid/comm/exe survive

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -113,7 +113,13 @@ impl CaptureSource for EbpfSource {
         // Load every BPF program once; a program is attached to many sites
         // (each libssl, each static target) but the kernel only accepts a
         // single `load()` per program.
-        for name in ["ssl_write", "ssl_read_enter", "ssl_read_exit", "ssl_shutdown"] {
+        for name in [
+            "ssl_write",
+            "ssl_read_enter",
+            "ssl_read_exit",
+            "ssl_shutdown",
+            "ssl_free",
+        ] {
             load_program(&mut ebpf, name)?;
         }
 
@@ -124,6 +130,13 @@ impl CaptureSource for EbpfSource {
             attach_sym(&mut ebpf, "ssl_read_enter", "SSL_read", &libs, false)?;
             attach_sym(&mut ebpf, "ssl_read_exit", "SSL_read", &libs, true)?;
             attach_sym(&mut ebpf, "ssl_shutdown", "SSL_shutdown", &libs, false)?;
+            // SSL_free is the reliable teardown for dynamic libssl (many clients
+            // never call SSL_shutdown). Best-effort: a libssl missing the symbol
+            // shouldn't fail the whole attach, so log-and-continue, unlike the
+            // load-bearing read/write probes above.
+            if let Err(e) = attach_sym(&mut ebpf, "ssl_free", "SSL_free", &libs, false) {
+                tracing::warn!("ebpf: SSL_free attach skipped: {e}");
+            }
         }
 
         // Static, symbol-stripped targets (Phase 3, e.g. Claude Code's Bun
@@ -271,6 +284,7 @@ fn decode_event(bytes: &[u8], exe_cache: &mut HashMap<u32, Option<String>>) -> O
                 exe: resolve_exe(raw.pid, exe_cache),
                 dir,
                 data: Bytes::copy_from_slice(&raw.data[..len]),
+                seq_off: raw.seq_off,
                 ktime_ns: raw.ktime_ns,
             })
         }

--- a/server/h-capture/src/synth.rs
+++ b/server/h-capture/src/synth.rs
@@ -118,34 +118,53 @@ impl SynthConfig {
     }
 }
 
-/// Per-connection synthesis state: the endpoints and the next sequence number
-/// to use in each direction.
+/// The TCP ISN both directions baseline on. With a synthesized handshake the SYN
+/// carries ISN 0 and consumes one sequence number, so data starts at 1; without
+/// a handshake the absolute base is irrelevant (the reassembler re-baselines
+/// mid-stream), and 1 keeps the two paths identical.
+const SYNTH_ISN: u32 = 1;
+
+/// Per-connection synthesis state: the endpoints and the high-water byte offset
+/// reached in each direction (used only to place the closing FIN past all data).
+///
+/// Segment sequence numbers are NOT derived from a running counter here — each
+/// [`data`](FlowSynthesizer::data) call carries the absolute stream offset
+/// (`seq_off`, from the BPF program's per-connection byte counter), so a chunk
+/// is always placed at `SYNTH_ISN + seq_off` regardless of whether an earlier
+/// chunk was dropped or arrived out of order.
 #[derive(Debug)]
 struct ConnState {
     tuple: ConnTuple,
-    /// Next sequence number for client→server segments.
-    seq_c2s: u32,
-    /// Next sequence number for server→client segments.
-    seq_s2c: u32,
+    /// Highest `seq_off + len` seen client→server (the next FIN's seq offset).
+    hi_off_c2s: u64,
+    /// Highest `seq_off + len` seen server→client.
+    hi_off_s2c: u64,
 }
 
 impl ConnState {
-    /// Initial sequence numbers. With a synthesized handshake the SYN carries
-    /// ISN 0 and consumes one sequence number, so data starts at 1; without a
-    /// handshake the absolute base is irrelevant (the reassembler re-baselines
-    /// mid-stream), and 1 keeps the two paths identical.
     fn new(tuple: ConnTuple) -> Self {
         Self {
             tuple,
-            seq_c2s: 1,
-            seq_s2c: 1,
+            hi_off_c2s: 0,
+            hi_off_s2c: 0,
         }
     }
 
-    fn seq_mut(&mut self, dir: StreamDir) -> &mut u32 {
+    fn hi_off(&self, dir: StreamDir) -> u64 {
         match dir {
-            StreamDir::ClientToServer => &mut self.seq_c2s,
-            StreamDir::ServerToClient => &mut self.seq_s2c,
+            StreamDir::ClientToServer => self.hi_off_c2s,
+            StreamDir::ServerToClient => self.hi_off_s2c,
+        }
+    }
+
+    /// Bump the direction's high-water offset to at least `end`.
+    fn observe(&mut self, dir: StreamDir, end: u64) {
+        let slot = match dir {
+            StreamDir::ClientToServer => &mut self.hi_off_c2s,
+            StreamDir::ServerToClient => &mut self.hi_off_s2c,
+        };
+        if end > *slot {
+            *slot = end;
         }
     }
 
@@ -172,6 +191,11 @@ impl ConnState {
 pub struct FlowSynthesizer {
     cfg: SynthConfig,
     conns: HashMap<u64, ConnState>,
+    /// Per-`conn_id` generation, bumped on [`close`](Self::close). Folded into
+    /// the synthetic tuple so a reused `SSL*` pointer (same `conn_id`) after a
+    /// close gets a DISTINCT [`FlowKey`] instead of overlapping the prior
+    /// connection's sequence space. Absent ⇒ generation 0.
+    generations: HashMap<u64, u32>,
 }
 
 impl FlowSynthesizer {
@@ -179,7 +203,13 @@ impl FlowSynthesizer {
         Self {
             cfg,
             conns: HashMap::new(),
+            generations: HashMap::new(),
         }
+    }
+
+    /// Current generation for `conn_id` (0 until its first close).
+    fn generation(&self, conn_id: u64) -> u32 {
+        self.generations.get(&conn_id).copied().unwrap_or(0)
     }
 
     /// True if `conn_id` has been opened and not yet closed.
@@ -210,90 +240,117 @@ impl FlowSynthesizer {
         out
     }
 
-    /// Emit TCP segments carrying `bytes` in direction `dir`. A chunk larger
-    /// than the configured segment size is split across multiple in-order
-    /// segments. An empty chunk emits nothing. Unknown connections are opened
-    /// lazily (synthetic tuple, no handshake).
+    /// Emit TCP segments carrying `bytes` in direction `dir`, with `seq_off` the
+    /// absolute byte offset of `bytes[0]` within this connection-direction
+    /// stream (from the BPF per-connection counter). The segment sequence is
+    /// `SYNTH_ISN + seq_off`, so a chunk lands at its true position even if an
+    /// earlier chunk was dropped or reordered. A chunk larger than the
+    /// configured segment size is split across multiple in-order segments. An
+    /// empty chunk emits nothing. Unknown connections are opened lazily
+    /// (generation-stamped synthetic tuple, no handshake).
     pub fn data(
         &mut self,
         conn_id: u64,
         dir: StreamDir,
         bytes: &[u8],
+        seq_off: u64,
         ts_us: i64,
     ) -> Vec<RawPacket> {
         if bytes.is_empty() {
             return Vec::new();
         }
         // Mid-stream attach (unknown conn): open lazily with a synthetic tuple
-        // and no handshake. The reassembler re-baselines on the first request
-        // line. Known connections keep their registered state untouched.
+        // for the current generation and no handshake. The reassembler
+        // re-baselines on the first request line. Known connections keep their
+        // registered state untouched.
+        let gen = self.generation(conn_id);
         self.conns
             .entry(conn_id)
-            .or_insert_with(|| ConnState::new(Self::synthetic_tuple(conn_id)));
+            .or_insert_with(|| ConnState::new(Self::synthetic_tuple_gen(conn_id, gen)));
 
         let seg = self.cfg.effective_segment();
         // Snapshot the routing inputs while we hold the connection borrow, then
         // drop it so `self.frame` can borrow `self` immutably per segment.
-        let (src, dst, mut seq) = {
+        let (src, dst) = {
             let state = self.conns.get(&conn_id).expect("just inserted");
-            let (src, dst) = state.endpoints(dir);
-            (src, dst, *self.peek_seq(conn_id, dir))
+            state.endpoints(dir)
         };
+        // Absolute sequence for the first byte of this chunk.
+        let seq0 = SYNTH_ISN.wrapping_add(seq_off as u32);
 
         let mut out = Vec::with_capacity(bytes.len().div_ceil(seg));
         let mut offset = 0;
         while offset < bytes.len() {
             let end = (offset + seg).min(bytes.len());
             let chunk = &bytes[offset..end];
+            let seq = seq0.wrapping_add(offset as u32);
             out.push(self.frame(src, dst, seq, 1, TCP_PSH | TCP_ACK, chunk, ts_us));
-            seq = seq.wrapping_add(chunk.len() as u32);
             offset = end;
         }
 
-        *self.conns.get_mut(&conn_id).expect("present").seq_mut(dir) = seq;
+        self.conns
+            .get_mut(&conn_id)
+            .expect("present")
+            .observe(dir, seq_off + bytes.len() as u64);
         out
     }
 
-    /// Emit FIN segments in both directions and forget the connection. The
-    /// reassembler finalizes any pending response on FIN, so a turn does not
-    /// have to wait out the 120 s idle sweep. A no-op for unknown connections.
+    /// Emit FIN segments in both directions and forget the connection, then bump
+    /// the connection's generation so a future `SSL*`-pointer reuse with the
+    /// same `conn_id` synthesizes a fresh, non-overlapping [`FlowKey`]. The
+    /// reassembler finalizes any pending response on FIN, so a turn does not have
+    /// to wait out the idle sweep. For an unknown connection the FIN frames are
+    /// skipped but the generation is still advanced (a close with no prior data
+    /// can still precede a reuse).
     pub fn close(&mut self, conn_id: u64, ts_us: i64) -> Vec<RawPacket> {
+        // Advance generation regardless: the next stream on this conn_id is a
+        // new connection and must not reuse this one's FlowKey.
+        *self.generations.entry(conn_id).or_insert(0) += 1;
+
         let Some(state) = self.conns.remove(&conn_id) else {
             return Vec::new();
         };
+        let c_seq = SYNTH_ISN.wrapping_add(state.hi_off(StreamDir::ClientToServer) as u32);
+        let s_seq = SYNTH_ISN.wrapping_add(state.hi_off(StreamDir::ServerToClient) as u32);
         let (csrc, cdst) = state.endpoints(StreamDir::ClientToServer);
         let (ssrc, sdst) = state.endpoints(StreamDir::ServerToClient);
         vec![
-            self.frame(csrc, cdst, state.seq_c2s, 1, TCP_FIN | TCP_ACK, &[], ts_us),
-            self.frame(ssrc, sdst, state.seq_s2c, 1, TCP_FIN | TCP_ACK, &[], ts_us),
+            self.frame(csrc, cdst, c_seq, 1, TCP_FIN | TCP_ACK, &[], ts_us),
+            self.frame(ssrc, sdst, s_seq, 1, TCP_FIN | TCP_ACK, &[], ts_us),
         ]
     }
 
     /// Deterministic placeholder 5-tuple for a connection whose real socket
-    /// addresses are unknown (uprobe gave `SSL*`/pid but no socket). Stable and
-    /// collision-resistant per `conn_id`, so both directions of one connection
-    /// share a `FlowKey`. The client side maps into `127.64.0.0/10` and the
-    /// server into a documentation address; wire-API detection keys on the HTTP
-    /// `Host`/path, not on these IPs, so they affect only the displayed tuple.
+    /// addresses are unknown (uprobe gave `SSL*`/pid but no socket). Generation 0
+    /// — the entry point for callers that don't track reuse (e.g. a Connect
+    /// event with a real tuple falling back). See [`synthetic_tuple_gen`].
     pub fn synthetic_tuple(conn_id: u64) -> ConnTuple {
+        Self::synthetic_tuple_gen(conn_id, 0)
+    }
+
+    /// Generation-aware [`synthetic_tuple`]. Stable and collision-resistant per
+    /// `(conn_id, generation)`, so both directions of one connection share a
+    /// `FlowKey` while a reused pointer (incremented generation) gets a distinct
+    /// one. The client side maps into `127.64.0.0/10` and the server into a
+    /// documentation address; wire-API detection keys on the HTTP `Host`/path,
+    /// not on these IPs, so they affect only the displayed tuple. The generation
+    /// perturbs the client port so successive connections on the same `conn_id`
+    /// never share a 4-tuple.
+    pub fn synthetic_tuple_gen(conn_id: u64, generation: u32) -> ConnTuple {
         let lo = conn_id as u32;
         let hi = (conn_id >> 32) as u32;
         // Client: 127.64.x.y to stay inside loopback's /8 but clear of 127.0.0.1.
         let client_ip = IpAddr::from([127, 64, (lo >> 8) as u8, lo as u8]);
-        let client_port = 1024u16.wrapping_add((lo >> 16) as u16);
+        // Fold the generation in (×40503, an odd spreader) so each reuse lands on
+        // a clearly different port rather than an adjacent one.
+        let client_port = 1024u16
+            .wrapping_add((lo >> 16) as u16)
+            .wrapping_add((generation as u16).wrapping_mul(40503));
         // Server: 192.0.2.0/24 (TEST-NET-1, RFC 5737) — never a real host.
         let server_ip = IpAddr::from([192, 0, 2, (hi & 0xFF) as u8]);
         ConnTuple {
             client: SocketAddr::new(client_ip, client_port.max(1024)),
             server: SocketAddr::new(server_ip, 443),
-        }
-    }
-
-    fn peek_seq(&self, conn_id: u64, dir: StreamDir) -> &u32 {
-        let state = self.conns.get(&conn_id).expect("present");
-        match dir {
-            StreamDir::ClientToServer => &state.seq_c2s,
-            StreamDir::ServerToClient => &state.seq_s2c,
         }
     }
 
@@ -420,6 +477,12 @@ mod tests {
         u16::from_be_bytes([pkt.data[12], pkt.data[13]])
     }
 
+    /// TCP source port (bytes 0..2 of the TCP header) of an IPv4 frame.
+    fn ipv4_src_port(pkt: &RawPacket) -> u16 {
+        let tcp = ETH_HDR_LEN + IPV4_HDR_LEN;
+        u16::from_be_bytes([pkt.data[tcp], pkt.data[tcp + 1]])
+    }
+
     /// Extract `(seq, flags, payload)` from an IPv4 frame for assertions.
     fn ipv4_tcp(pkt: &RawPacket) -> (u32, u8, &[u8]) {
         let ip = ETH_HDR_LEN;
@@ -465,7 +528,7 @@ mod tests {
         let mut s = FlowSynthesizer::new(SynthConfig::default());
         s.open(1, v4_tuple(), 0);
         let body = b"GET / HTTP/1.1\r\n\r\n";
-        let frames = s.data(1, StreamDir::ClientToServer, body, 10);
+        let frames = s.data(1, StreamDir::ClientToServer, body, 0, 10);
         assert_eq!(frames.len(), 1);
         let (seq, flags, payload) = ipv4_tcp(&frames[0]);
         assert_eq!(seq, 1, "first data seq follows SYN's ISN+1");
@@ -473,8 +536,8 @@ mod tests {
         assert_eq!(payload, body);
         assert_eq!(ethertype(&frames[0]), ETHERTYPE_IPV4);
 
-        // Next chunk continues from the advanced seq.
-        let more = s.data(1, StreamDir::ClientToServer, b"XYZ", 20);
+        // Next chunk carries its absolute stream offset.
+        let more = s.data(1, StreamDir::ClientToServer, b"XYZ", body.len() as u64, 20);
         let (seq2, _, _) = ipv4_tcp(&more[0]);
         assert_eq!(seq2, 1 + body.len() as u32);
     }
@@ -488,7 +551,7 @@ mod tests {
         let mut s = FlowSynthesizer::new(cfg);
         s.open(1, v4_tuple(), 0);
         let body = vec![b'A'; 2500];
-        let frames = s.data(1, StreamDir::ServerToClient, &body, 5);
+        let frames = s.data(1, StreamDir::ServerToClient, &body, 0, 5);
         assert_eq!(frames.len(), 3, "2500 / 1000 = 3 segments");
 
         let mut expected_seq = 1u32;
@@ -504,19 +567,71 @@ mod tests {
     }
 
     #[test]
+    fn chunk_placed_by_absolute_offset_not_running_counter() {
+        // Two chunks of one logical write where the MIDDLE chunk was dropped
+        // upstream (never delivered). The third chunk must still land at its
+        // true sequence (SYNTH_ISN + its seq_off), leaving a gap where the
+        // dropped chunk was — NOT shifted earlier to abut the first chunk (the
+        // old running-counter bug that spliced later bytes over earlier ones).
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        let a = s.data(9, StreamDir::ClientToServer, b"AAAA", 0, 0);
+        // (chunk at offset 4 dropped)
+        let c = s.data(9, StreamDir::ClientToServer, b"CCCC", 8, 0);
+        let (seq_a, _, _) = ipv4_tcp(&a[0]);
+        let (seq_c, _, _) = ipv4_tcp(&c[0]);
+        assert_eq!(seq_a, 1, "first chunk at ISN+0");
+        assert_eq!(seq_c, 1 + 8, "third chunk at ISN+8 (gap preserved), not ISN+4");
+    }
+
+    #[test]
     fn empty_chunk_emits_nothing() {
         let mut s = FlowSynthesizer::new(SynthConfig::default());
         s.open(1, v4_tuple(), 0);
-        assert!(s.data(1, StreamDir::ClientToServer, &[], 0).is_empty());
+        assert!(s.data(1, StreamDir::ClientToServer, &[], 0, 0).is_empty());
     }
 
     #[test]
     fn unknown_conn_opens_lazily_without_handshake() {
         let mut s = FlowSynthesizer::new(SynthConfig::default());
         // No open() first — data() must lazily register the connection.
-        let frames = s.data(7, StreamDir::ClientToServer, b"POST / HTTP/1.1\r\n", 0);
+        let frames = s.data(7, StreamDir::ClientToServer, b"POST / HTTP/1.1\r\n", 0, 0);
         assert_eq!(frames.len(), 1, "exactly the data segment, no handshake");
         assert!(s.is_open(7));
+    }
+
+    #[test]
+    fn close_bumps_generation_so_reused_conn_id_gets_distinct_tuple() {
+        // A reused SSL* pointer (same conn_id) after a close must synthesize a
+        // DISTINCT FlowKey, so the new connection's bytes never overlap the
+        // closed one's sequence space.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        let first = s.data(5, StreamDir::ClientToServer, b"POST /a HTTP/1.1\r\n", 0, 1);
+        let src1 = ipv4_src_port(&first[0]);
+        s.close(5, 2);
+        // After close, conn forgotten; reuse lazily re-opens at generation 1.
+        let second = s.data(5, StreamDir::ClientToServer, b"POST /b HTTP/1.1\r\n", 0, 3);
+        let src2 = ipv4_src_port(&second[0]);
+        assert_ne!(
+            src1, src2,
+            "reused conn_id after close must get a different synthetic client port"
+        );
+    }
+
+    #[test]
+    fn synthetic_tuple_generation_changes_flowkey() {
+        let g0 = FlowSynthesizer::synthetic_tuple_gen(123, 0);
+        let g1 = FlowSynthesizer::synthetic_tuple_gen(123, 1);
+        assert_eq!(g0.client.ip(), g1.client.ip(), "same conn_id → same client IP");
+        assert_ne!(
+            g0.client.port(),
+            g1.client.port(),
+            "generation must perturb the client port"
+        );
+        assert_eq!(
+            FlowSynthesizer::synthetic_tuple(123),
+            g0,
+            "synthetic_tuple == generation 0"
+        );
     }
 
     #[test]
@@ -543,7 +658,7 @@ mod tests {
             server: "[2606:4700::1]:443".parse().unwrap(),
         };
         s.open(1, tuple, 0);
-        let frames = s.data(1, StreamDir::ClientToServer, b"GET / HTTP/1.1\r\n", 0);
+        let frames = s.data(1, StreamDir::ClientToServer, b"GET / HTTP/1.1\r\n", 0, 0);
         assert_eq!(ethertype(&frames[0]), ETHERTYPE_IPV6);
         // Ethernet(14) + IPv6(40) + TCP(20) + payload.
         assert_eq!(frames[0].data.len(), ETH_HDR_LEN + IPV6_HDR_LEN + TCP_HDR_LEN + 16);
@@ -567,7 +682,7 @@ mod tests {
         let mut s = FlowSynthesizer::new(cfg);
         s.open(1, v4_tuple(), 0);
         let body = vec![b'Z'; DEFAULT_SEGMENT_SIZE + 1];
-        let frames = s.data(1, StreamDir::ClientToServer, &body, 0);
+        let frames = s.data(1, StreamDir::ClientToServer, &body, 0, 0);
         assert_eq!(frames.len(), 2, "default segment size still chunks");
     }
 }

--- a/server/h-ebpf-common/src/lib.rs
+++ b/server/h-ebpf-common/src/lib.rs
@@ -15,12 +15,24 @@
 /// Length of a process `comm` (kernel `TASK_COMM_LEN`).
 pub const COMM_LEN: usize = 16;
 
-/// Maximum plaintext bytes carried in a single event. A larger `SSL_read` /
-/// `SSL_write` is emitted as several consecutive same-direction events, which
-/// the userspace synthesizer concatenates by sequence number — so this cap
-/// never loses bytes, it only bounds per-event size (BPF stack/verifier
-/// limits make one giant copy impossible).
-pub const DATA_CAP: usize = 4096;
+/// Maximum plaintext bytes carried in a single event. A single `SSL_read` /
+/// `SSL_write` larger than this is currently **truncated** to `DATA_CAP` by the
+/// BPF program (`h-ebpf-prog::emit_data`) and its tail is lost — chunking a big
+/// write into several consecutive same-direction events that the userspace
+/// synthesizer reassembles is a TODO, not yet implemented.
+///
+/// Sized at 32 KiB so a real-world Claude Code `/v1/messages` request — sent by
+/// Node as ONE ~23 KiB `SSL_write` (request line + headers + JSON body) —
+/// arrives whole in a single event. At the previous 4 KiB the request was cut
+/// after its first 4 KiB, so `anthropic-version` / the JSON body were lost and
+/// the wire-API registry could not recognize the call (it went to
+/// `wires_ignored`), leaving every Claude Code call out of storage. The record
+/// is reserved from the 16 MiB ring buffer (not the 512-byte BPF stack), so a
+/// 32 KiB payload is fine, and the `bpf_probe_read_user` length stays clamped
+/// to `DATA_CAP`, so the verifier can still prove the copy in-bounds. Writes
+/// beyond 32 KiB (long conversations) still lose their tail until the chunking
+/// TODO lands.
+pub const DATA_CAP: usize = 32768;
 
 /// Event kind discriminants (`SslEvent::kind`).
 pub mod kind {

--- a/server/h-ebpf-common/src/lib.rs
+++ b/server/h-ebpf-common/src/lib.rs
@@ -16,10 +16,12 @@
 pub const COMM_LEN: usize = 16;
 
 /// Maximum plaintext bytes carried in a single event. A single `SSL_read` /
-/// `SSL_write` larger than this is currently **truncated** to `DATA_CAP` by the
-/// BPF program (`h-ebpf-prog::emit_data`) and its tail is lost — chunking a big
-/// write into several consecutive same-direction events that the userspace
-/// synthesizer reassembles is a TODO, not yet implemented.
+/// `SSL_write` larger than this is split by the BPF program
+/// (`h-ebpf-prog::emit_data`) into several consecutive same-direction events,
+/// each carrying its absolute position in the connection-direction stream via
+/// [`SslEvent::seq_off`], which the userspace synthesizer uses to place every
+/// chunk at the correct sequence number (so a dropped/reordered chunk leaves a
+/// detectable gap instead of shifting every later byte).
 ///
 /// Sized at 32 KiB so a real-world Claude Code `/v1/messages` request — sent by
 /// Node as ONE ~23 KiB `SSL_write` (request line + headers + JSON body) —
@@ -29,9 +31,7 @@ pub const COMM_LEN: usize = 16;
 /// `wires_ignored`), leaving every Claude Code call out of storage. The record
 /// is reserved from the 16 MiB ring buffer (not the 512-byte BPF stack), so a
 /// 32 KiB payload is fine, and the `bpf_probe_read_user` length stays clamped
-/// to `DATA_CAP`, so the verifier can still prove the copy in-bounds. Writes
-/// beyond 32 KiB (long conversations) still lose their tail until the chunking
-/// TODO lands.
+/// to `DATA_CAP`, so the verifier can still prove the copy in-bounds.
 pub const DATA_CAP: usize = 32768;
 
 /// Event kind discriminants (`SslEvent::kind`).
@@ -58,6 +58,16 @@ pub struct SslEvent {
     pub conn_id: u64,
     /// Kernel monotonic timestamp (`bpf_ktime_get_ns`).
     pub ktime_ns: u64,
+    /// Absolute byte offset of `data[0]` within this connection-direction
+    /// stream. The BPF program keeps a running per-`(conn_id, direction)`
+    /// counter so that a single large `SSL_*` call split across several events —
+    /// and successive calls on the same keep-alive connection — carry a
+    /// monotonic position. The userspace synthesizer maps this to a TCP sequence
+    /// number, so a silently dropped or reordered chunk leaves a gap at its true
+    /// position instead of shifting every later byte earlier (which previously
+    /// spliced the next request's bytes into the prior body). Always 0 for
+    /// `CLOSE`.
+    pub seq_off: u64,
     /// Valid bytes in `data` (0 for `CLOSE`).
     pub data_len: u32,
     /// Process name (`bpf_get_current_comm`), NUL-padded.

--- a/server/h-ebpf-prog/src/main.rs
+++ b/server/h-ebpf-prog/src/main.rs
@@ -1,13 +1,20 @@
 //! BPF program for eBPF SSL-uprobe capture.
 //!
-//! Attaches to OpenSSL / BoringSSL `SSL_write`, `SSL_read` and `SSL_shutdown`
-//! and streams the plaintext (and connection lifecycle) to userspace over a
-//! ring buffer as [`SslEvent`] records. The userspace loader (h-capture's
+//! Attaches to OpenSSL / BoringSSL `SSL_write`, `SSL_read`, `SSL_shutdown` and
+//! `SSL_free` and streams the plaintext (and connection lifecycle) to userspace
+//! over a ring buffer as [`SslEvent`] records. The userspace loader (h-capture's
 //! `EbpfSource`) turns those into synthetic TCP frames.
 //!
 //! Direction mapping: `SSL_write` ⇒ client→server (request), `SSL_read` ⇒
 //! server→client (response). `SSL_read` reads its buffer only on return, so we
-//! stash its args on entry and emit on the uretprobe using the real byte count.
+//! stash its args on entry and emit on the uretprobe using the real byte count;
+//! a return of 0 (peer close_notify) is treated as a connection close.
+//!
+//! Connection teardown comes from `SSL_shutdown`/`SSL_free` (dynamic libssl, by
+//! symbol) or the read-side EOF above (static BoringSSL SEA targets, which have
+//! no teardown symbol to attach). Each emits a CLOSE so the flow finalizes
+//! without waiting out the idle sweep, and resets the per-connection stream
+//! offsets so a reused `SSL*` pointer starts a fresh sequence.
 
 #![no_std]
 #![no_main]
@@ -32,11 +39,51 @@ static EVENTS: RingBuf = RingBuf::with_byte_size(16 * 1024 * 1024, 0);
 #[map]
 static READ_ARGS: HashMap<u32, ReadArgs> = HashMap::with_max_entries(10240, 0);
 
+/// Running client→server (`SSL_write`) byte offset per connection (`conn_id` →
+/// next absolute stream offset). Lets a large write split across several events,
+/// and successive writes on the same keep-alive connection, carry a monotonic
+/// position so userspace places every chunk at its true sequence number. Cleared
+/// on connection close so a reused `SSL*` pointer restarts at 0.
+#[map]
+static WRITE_OFF: HashMap<u64, u64> = HashMap::with_max_entries(10240, 0);
+
+/// Running server→client (`SSL_read`) byte offset per connection. Sibling of
+/// [`WRITE_OFF`] for the response direction.
+#[map]
+static READ_OFF: HashMap<u64, u64> = HashMap::with_max_entries(10240, 0);
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct ReadArgs {
     ssl: u64,
     buf: u64,
+}
+
+/// Current absolute stream offset for `conn_id` in the given direction (0 if
+/// unseen). `#[inline(always)]` to keep it straight-line in the caller — a
+/// non-inlined BPF-to-BPF call here trips the 5.15 verifier in the same way the
+/// chunk emitter does (see [`emit_chunk_at`]).
+#[inline(always)]
+fn stream_off(conn_id: u64, is_write: bool) -> u64 {
+    let slot = if is_write {
+        unsafe { WRITE_OFF.get(&conn_id) }
+    } else {
+        unsafe { READ_OFF.get(&conn_id) }
+    };
+    match slot {
+        Some(v) => *v,
+        None => 0,
+    }
+}
+
+/// Store the next absolute stream offset for `conn_id` in the given direction.
+#[inline(always)]
+fn set_stream_off(conn_id: u64, is_write: bool, next: u64) {
+    if is_write {
+        let _ = WRITE_OFF.insert(&conn_id, &next, 0);
+    } else {
+        let _ = READ_OFF.insert(&conn_id, &next, 0);
+    }
 }
 
 #[uprobe]
@@ -71,12 +118,30 @@ pub fn ssl_read_exit(ctx: RetProbeContext) -> u32 {
     let ret: i32 = ctx.ret().unwrap_or(0);
     if args.buf != 0 && ret > 0 {
         emit_data(kind::DATA_READ, args.ssl, args.buf, ret as u32);
+    } else if ret == 0 {
+        // `SSL_read` returning 0 = the peer sent close_notify: a clean
+        // connection teardown. (A non-blocking retry is ret<0 / WANT_READ, NOT
+        // 0, so this never fires spuriously.) Emit CLOSE so the flow finalizes
+        // promptly — the static (BoringSSL SEA) target has no SSL_shutdown /
+        // SSL_free uprobe, so this read-side EOF is its only teardown signal.
+        emit_close(args.ssl);
     }
     0
 }
 
 #[uprobe]
 pub fn ssl_shutdown(ctx: ProbeContext) -> u32 {
+    let ssl: u64 = ctx.arg(0).unwrap_or(0);
+    emit_close(ssl);
+    0
+}
+
+/// `SSL_free` destroys the `SSL` object; after it the `SSL*` pointer value can
+/// be handed to a brand-new connection. Emitting CLOSE here resets the flow so a
+/// reused pointer starts a fresh stream (userspace bumps the connection
+/// generation), rather than continuing the dead connection's sequence space.
+#[uprobe]
+pub fn ssl_free(ctx: ProbeContext) -> u32 {
     let ssl: u64 = ctx.arg(0).unwrap_or(0);
     emit_close(ssl);
     0
@@ -96,7 +161,7 @@ const MAX_CHUNKS: u32 = 8;
 /// body is straight-line code — the exact single-event pattern that already
 /// loaded — repeated `MAX_CHUNKS` times, which the verifier accepts.
 #[inline(always)]
-fn emit_chunk_at(ev_kind: u32, ssl: u64, buf: u64, start: u32, len: u32) {
+fn emit_chunk_at(ev_kind: u32, ssl: u64, buf: u64, start: u32, len: u32, base_off: u64) {
     if start >= len {
         return;
     }
@@ -116,6 +181,8 @@ fn emit_chunk_at(ev_kind: u32, ssl: u64, buf: u64, start: u32, len: u32) {
         (*ev).pid = (bpf_get_current_pid_tgid() >> 32) as u32;
         (*ev).conn_id = ssl;
         (*ev).ktime_ns = bpf_ktime_get_ns();
+        // Absolute position of this chunk's first byte in the conn+dir stream.
+        (*ev).seq_off = base_off + start as u64;
         (*ev).data_len = n;
         if let Ok(comm) = bpf_get_current_comm() {
             (*ev).comm = comm;
@@ -143,17 +210,30 @@ fn emit_chunk_at(ev_kind: u32, ssl: u64, buf: u64, start: u32, len: u32) {
 /// back-edge here. See [`emit_chunk_at`].
 fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
     let cap = DATA_CAP as u32;
-    emit_chunk_at(ev_kind, ssl, buf, 0, len);
-    emit_chunk_at(ev_kind, ssl, buf, cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 2 * cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 3 * cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 4 * cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 5 * cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 6 * cap, len);
-    emit_chunk_at(ev_kind, ssl, buf, 7 * cap, len);
+    let is_write = ev_kind == kind::DATA_WRITE;
+    // Base = where this whole SSL_* call sits in the conn+dir stream. Each chunk
+    // is stamped base+start so userspace places it absolutely; a dropped chunk
+    // then leaves a gap at its true offset instead of shifting the rest.
+    let base = stream_off(ssl, is_write);
+    emit_chunk_at(ev_kind, ssl, buf, 0, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 2 * cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 3 * cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 4 * cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 5 * cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 6 * cap, len, base);
+    emit_chunk_at(ev_kind, ssl, buf, 7 * cap, len, base);
+    // Advance the running offset past this call so the next one continues it.
+    set_stream_off(ssl, is_write, base + len as u64);
 }
 
 fn emit_close(ssl: u64) {
+    // Forget the per-connection stream offsets: a future SSL_* on this same
+    // pointer value belongs to a brand-new connection and must restart at 0
+    // (userspace bumps the flow generation so the fresh stream gets its own
+    // FlowKey rather than overlapping the closed one's sequence space).
+    let _ = WRITE_OFF.remove(&ssl);
+    let _ = READ_OFF.remove(&ssl);
     let mut entry = match EVENTS.reserve::<SslEvent>(0) {
         Some(e) => e,
         None => return,
@@ -164,6 +244,7 @@ fn emit_close(ssl: u64) {
         (*ev).pid = (bpf_get_current_pid_tgid() >> 32) as u32;
         (*ev).conn_id = ssl;
         (*ev).ktime_ns = bpf_ktime_get_ns();
+        (*ev).seq_off = 0;
         (*ev).data_len = 0;
         if let Ok(comm) = bpf_get_current_comm() {
             (*ev).comm = comm;

--- a/server/h-ebpf-prog/src/main.rs
+++ b/server/h-ebpf-prog/src/main.rs
@@ -83,9 +83,13 @@ pub fn ssl_shutdown(ctx: ProbeContext) -> u32 {
 }
 
 /// Reserve a ring-buffer record, fill the header, and copy up to [`DATA_CAP`]
-/// plaintext bytes from the userspace buffer. A larger call is truncated to
-/// `DATA_CAP` here; the userspace synthesizer treats each event as a contiguous
-/// segment, so consecutive events on the same connection reassemble in order.
+/// plaintext bytes from the userspace buffer.
+///
+/// A single call larger than `DATA_CAP` is **truncated** to `DATA_CAP` and its
+/// tail is dropped — we do NOT yet split a big write into several consecutive
+/// events for the userspace synthesizer to reassemble. `DATA_CAP` is sized
+/// (32 KiB) to hold a whole Claude Code `/v1/messages` request in one event;
+/// chunking arbitrarily large writes is a TODO.
 fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
     let n = if len as usize > DATA_CAP {
         DATA_CAP as u32

--- a/server/h-ebpf-prog/src/main.rs
+++ b/server/h-ebpf-prog/src/main.rs
@@ -82,19 +82,29 @@ pub fn ssl_shutdown(ctx: ProbeContext) -> u32 {
     0
 }
 
-/// Reserve a ring-buffer record, fill the header, and copy up to [`DATA_CAP`]
-/// plaintext bytes from the userspace buffer.
+/// Max `DATA_CAP`-sized chunks emitted for one `SSL_*` call. A write larger than
+/// `MAX_CHUNKS * DATA_CAP` (8 × 32 KiB = 256 KiB) loses its tail — rare, and the
+/// userspace parser tolerates a body shorter than Content-Length.
+const MAX_CHUNKS: u32 = 8;
+
+/// Emit ONE `DATA_CAP`-sized chunk of `buf[start..]` if `start < len`.
 ///
-/// A single call larger than `DATA_CAP` is **truncated** to `DATA_CAP` and its
-/// tail is dropped — we do NOT yet split a big write into several consecutive
-/// events for the userspace synthesizer to reassemble. `DATA_CAP` is sized
-/// (32 KiB) to hold a whole Claude Code `/v1/messages` request in one event;
-/// chunking arbitrarily large writes is a TODO.
-fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
-    let n = if len as usize > DATA_CAP {
+/// `#[inline(always)]` + invoked from an UNROLLED sequence (not a loop) in
+/// [`emit_data`] on purpose: a real loop's back-edge makes the 5.15 verifier
+/// reject the program ("R1 type=ctx expected=fp"), and a non-inlined helper
+/// makes it a BPF-to-BPF call the verifier also rejects. Inlined + unrolled, the
+/// body is straight-line code — the exact single-event pattern that already
+/// loaded — repeated `MAX_CHUNKS` times, which the verifier accepts.
+#[inline(always)]
+fn emit_chunk_at(ev_kind: u32, ssl: u64, buf: u64, start: u32, len: u32) {
+    if start >= len {
+        return;
+    }
+    let remaining = len - start;
+    let n = if remaining as usize > DATA_CAP {
         DATA_CAP as u32
     } else {
-        len
+        remaining
     };
     let mut entry = match EVENTS.reserve::<SslEvent>(0) {
         Some(e) => e,
@@ -111,9 +121,36 @@ fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
             (*ev).comm = comm;
         }
         let dst = core::ptr::addr_of_mut!((*ev).data) as *mut c_void;
-        let _ = bpf_probe_read_user(dst, n, buf as *const c_void);
+        let _ = bpf_probe_read_user(dst, n, (buf + start as u64) as *const c_void);
     }
     entry.submit(0);
+}
+
+/// Stream a full `SSL_read`/`SSL_write` buffer to userspace as up to
+/// [`MAX_CHUNKS`] consecutive `DATA_CAP`-sized events on the same `conn_id` +
+/// direction.
+///
+/// Previously a call larger than `DATA_CAP` was truncated to a single event.
+/// That broke HTTP framing on keep-alive connections: the request's
+/// `Content-Length` (read from the intact header prefix) exceeded the captured
+/// bytes, so the userspace parser kept reading the body PAST the truncated data
+/// and swallowed the next request on the connection — corrupting both. Emitting
+/// the WHOLE buffer in chunks lets the synthesizer turn each event into a
+/// sequential TCP segment that reassembles into the complete plaintext, so
+/// Content-Length matches and request boundaries stay correct.
+///
+/// Unrolled rather than looped: the 5.15 BPF verifier rejects the loop's
+/// back-edge here. See [`emit_chunk_at`].
+fn emit_data(ev_kind: u32, ssl: u64, buf: u64, len: u32) {
+    let cap = DATA_CAP as u32;
+    emit_chunk_at(ev_kind, ssl, buf, 0, len);
+    emit_chunk_at(ev_kind, ssl, buf, cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 2 * cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 3 * cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 4 * cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 5 * cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 6 * cap, len);
+    emit_chunk_at(ev_kind, ssl, buf, 7 * cap, len);
 }
 
 fn emit_close(ssl: u64) {

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -201,7 +201,17 @@ impl AgentProfile for ClaudeCliProfile {
         // extractor for text only; this one is the structural turn-start
         // predicate. Sub-agent filtering happens at the h-llm stage.
         let req = ctx.req?;
-        let last = req.get("messages")?.as_array()?.last()?;
+        // Skip trailing `role=system` messages: Claude Code's
+        // `mid-conversation-system` beta appends system notices (e.g. the
+        // ToolSearch "deferred tools are now available" block) AFTER the user's
+        // message, so the literal last element is often `system` even on a fresh
+        // user turn. The operative message is the last NON-system one.
+        let last = req
+            .get("messages")?
+            .as_array()?
+            .iter()
+            .rev()
+            .find(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))?;
         if last.get("role").and_then(|r| r.as_str()) != Some("user") {
             return Some(false);
         }
@@ -461,6 +471,43 @@ mod tests {
         let body = r#"{"messages":[{"role":"user","content":"hello"}]}"#;
         let c = call_with(wa::ANTHROPIC, vec![], Some(body));
         assert_eq!(ClaudeCliProfile.is_user_turn_start(&c.ctx()), Some(true));
+    }
+
+    #[test]
+    fn is_user_turn_start_skips_trailing_system_message() {
+        // Claude Code (mid-conversation-system beta) appends a trailing
+        // role=system notice (e.g. ToolSearch "deferred tools available") AFTER
+        // the user's prompt. The fresh user turn must still be recognized — the
+        // operative message is the last NON-system one. This is the exact shape
+        // that made eBPF-captured Claude Code conversations discard as
+        // `no_user_start` until the skip was added.
+        let body = r#"{
+            "messages":[
+                {"role":"user","content":[{"type":"text","text":"use the Bash tool"}]},
+                {"role":"system","content":"The following deferred tools are now available via ToolSearch."}
+            ],
+            "tools":[{"name":"Agent"},{"name":"Bash"}]
+        }"#;
+        let c = call_with(wa::ANTHROPIC, vec![], Some(body));
+        assert_eq!(ClaudeCliProfile.is_user_turn_start(&c.ctx()), Some(true));
+    }
+
+    #[test]
+    fn is_user_turn_start_false_for_tool_result_then_trailing_system() {
+        // A tool-roundtrip continuation whose last user message is a tool_result,
+        // even with a trailing system notice mixed in earlier, stays a
+        // continuation (the operative last non-system message is the tool_result).
+        let body = r#"{
+            "messages":[
+                {"role":"user","content":[{"type":"text","text":"start"}]},
+                {"role":"system","content":"deferred tools available"},
+                {"role":"assistant","content":[{"type":"tool_use","id":"t","name":"Bash","input":{}}]},
+                {"role":"user","content":[{"type":"tool_result","tool_use_id":"t","content":"ok"}]}
+            ],
+            "tools":[{"name":"Agent"},{"name":"Bash"}]
+        }"#;
+        let c = call_with(wa::ANTHROPIC, vec![], Some(body));
+        assert_eq!(ClaudeCliProfile.is_user_turn_start(&c.ctx()), Some(false));
     }
 
     #[test]

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -130,7 +130,13 @@ impl AgentProfile for ClaudeCliProfile {
     fn extract_user_input(&self, ctx: &CallCtx<'_>) -> Option<String> {
         let req = ctx.req?;
         let msgs = req.get("messages")?.as_array()?;
-        let last = msgs.last()?;
+        // Skip trailing role=system notices (mid-conversation-system beta) so the
+        // user prompt preview comes from the operative last user message, not an
+        // appended ToolSearch/system block. Mirrors `is_user_turn_start`.
+        let last = msgs
+            .iter()
+            .rev()
+            .find(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))?;
         if last.get("role")?.as_str()? != "user" {
             return None;
         }
@@ -684,6 +690,22 @@ mod tests {
         ]}]}"#;
         let c = call_with(wa::ANTHROPIC, vec![], Some(body));
         assert_eq!(ClaudeCliProfile.extract_user_input(&c.ctx()), None);
+    }
+
+    #[test]
+    fn extract_user_input_skips_trailing_system_message() {
+        // The user prompt preview must come from the operative user message even
+        // when Claude Code appends a trailing role=system notice after it (the
+        // shape that left agent-turn `user_input_preview` empty until fixed).
+        let body = r#"{"messages":[
+            {"role":"user","content":[{"type":"text","text":"the real prompt"}]},
+            {"role":"system","content":"deferred tools available via ToolSearch"}
+        ]}"#;
+        let c = call_with(wa::ANTHROPIC, vec![], Some(body));
+        assert_eq!(
+            ClaudeCliProfile.extract_user_input(&c.ctx()).as_deref(),
+            Some("the real prompt")
+        );
     }
 
     #[test]

--- a/server/h-llm/src/agents/claude_cli.rs
+++ b/server/h-llm/src/agents/claude_cli.rs
@@ -1,13 +1,37 @@
 use crate::agent_primitives::{AgentPrimitives, SystemPromptMarkers};
 use crate::model::LlmCall;
 use crate::profile::{AgentProfile, CallCtx, SessionIdExtraction};
-use crate::wire_apis as wa;
+use crate::wire_apis::{self as wa, AssistantSig};
 use serde_json::Value;
+
+use super::session_id::compose_session_id_tracked;
 
 pub struct ClaudeCliProfile;
 
 const SESSION_HEADER: &str = "x-claude-code-session-id";
 const UA_PREFIX: &str = "claude-cli/";
+
+/// Tool-call anchor for session synthesis when the legacy
+/// `x-claude-code-session-id` header is absent (Claude Code stopped sending it
+/// around v2.1). Mirrors `GenericProfile`'s anthropic branch: the first user
+/// text plus the first `tool_use` id (from the request history, else the
+/// response) form a stable per-session anchor. Returns `None` for text-only
+/// traffic with no tool anchor — such calls fall through to a later profile
+/// rather than being claimed-and-dropped.
+fn anthropic_tool_anchor(ctx: &CallCtx<'_>) -> Option<(String, AssistantSig)> {
+    let req = ctx.req?;
+    let user_text = wa::anthropic::first_user_text(req)?;
+    let sig = match wa::anthropic::first_assistant_sig_from_request(req) {
+        Some(s) => Some(s),
+        None => ctx
+            .resp
+            .and_then(wa::anthropic::first_assistant_sig_from_response_value),
+    }?;
+    if !matches!(sig, AssistantSig::ToolId(_)) {
+        return None;
+    }
+    Some((user_text, sig))
+}
 
 fn header<'a>(call: &'a LlmCall, key: &str) -> Option<&'a str> {
     call.request_headers
@@ -64,13 +88,14 @@ impl AgentProfile for ClaudeCliProfile {
     }
 
     fn matches(&self, ctx: &CallCtx<'_>) -> bool {
-        // Both UA prefix AND SESSION_HEADER must be present. UA alone isn't
-        // enough: the registry is first-match-wins (`profile.rs:181`), so
-        // claiming a call here when the session header is missing leaves the
-        // call with `extract_session_id() = None` and no fallback. By
-        // requiring the header up front, UA-spoofed / header-stripped /
-        // pre-session-header-version traffic falls through to GenericProfile,
-        // which can synthesize a session anchor from the body.
+        // Identify Claude Code by `User-Agent: claude-cli/*` on Anthropic wire,
+        // then require a usable session anchor so we never claim-and-drop a call
+        // (the registry is first-match-wins, profile.rs:181). The anchor is the
+        // legacy `x-claude-code-session-id` header when present, OR — for Claude
+        // Code v2.1+ which no longer sends that header — a synthesizable
+        // tool-call anchor in the body (same mechanism GenericProfile uses).
+        // UA-spoofed / header-stripped / anchorless text-only traffic still
+        // falls through to a later profile.
         if ctx.call.wire_api != wa::ANTHROPIC {
             return false;
         }
@@ -80,14 +105,25 @@ impl AgentProfile for ClaudeCliProfile {
         if !ua_ok {
             return false;
         }
-        header(ctx.call, SESSION_HEADER).is_some()
+        header(ctx.call, SESSION_HEADER).is_some() || anthropic_tool_anchor(ctx).is_some()
     }
 
     fn extract_session_id(&self, ctx: &CallCtx<'_>) -> Option<SessionIdExtraction> {
-        let session_id = header(ctx.call, SESSION_HEADER)?.to_string();
+        // Prefer the explicit session header when present (older Claude Code).
+        if let Some(h) = header(ctx.call, SESSION_HEADER) {
+            return Some(SessionIdExtraction {
+                session_id: h.to_string(),
+                tool_id_canonicalized: false,
+            });
+        }
+        // Fallback for header-less Claude Code: synthesize from the tool-call
+        // anchor exactly as GenericProfile does, so the same conversation maps
+        // to one stable session_id across its calls.
+        let (user_text, sig) = anthropic_tool_anchor(ctx)?;
+        let (session_id, tool_id_canonicalized) = compose_session_id_tracked(&user_text, sig);
         Some(SessionIdExtraction {
             session_id,
-            tool_id_canonicalized: false,
+            tool_id_canonicalized,
         })
     }
 
@@ -346,16 +382,37 @@ mod tests {
     }
 
     #[test]
-    fn does_not_match_when_session_header_missing() {
-        // UA alone is not enough — without `x-claude-code-session-id` we
-        // cannot extract a session_id, so the registry must let the call
-        // fall through to GenericProfile rather than claiming and dropping it.
+    fn does_not_match_when_session_header_missing_and_no_anchor() {
+        // UA + no session header + no body → no session anchor at all, so the
+        // call must fall through to a later profile rather than being
+        // claimed-and-dropped (registry is first-match-wins).
         let c = call_with(
             wa::ANTHROPIC,
             vec![("User-Agent", "claude-cli/2.1.98 (external, cli)")],
             None,
         );
         assert!(!ClaudeCliProfile.matches(&c.ctx()));
+    }
+
+    #[test]
+    fn matches_via_tool_anchor_when_session_header_absent() {
+        // Claude Code v2.1+ no longer sends x-claude-code-session-id. A
+        // tool-roundtrip request still carries a tool_use id in history, so the
+        // profile claims it (UA + synthesizable anchor) and labels it
+        // claude-cli instead of letting it fall through to generic.
+        let body = r#"{"messages":[
+            {"role":"user","content":[{"type":"text","text":"do the thing"}]},
+            {"role":"assistant","content":[{"type":"tool_use","id":"toolu_abc","name":"Bash","input":{}}]},
+            {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_abc","content":"ok"}]}
+        ]}"#;
+        let c = call_with(
+            wa::ANTHROPIC,
+            vec![("User-Agent", "claude-cli/2.1.75 (external, sdk-cli)")],
+            Some(body),
+        );
+        assert!(ClaudeCliProfile.matches(&c.ctx()));
+        let ids = ClaudeCliProfile.extract_session_id(&c.ctx()).unwrap();
+        assert!(!ids.session_id.is_empty());
     }
 
     #[test]

--- a/server/h-llm/src/agents/mod.rs
+++ b/server/h-llm/src/agents/mod.rs
@@ -197,18 +197,19 @@ mod priority_tests {
     }
 
     #[test]
-    fn generic_catches_claude_cli_ua_without_session_header() {
-        // UA-spoofing or header-stripping: looks like claude-cli but the
-        // session header is absent. ClaudeCliProfile must NOT claim it
-        // (otherwise extract_session_id would return None with no fallback) —
-        // GenericProfile picks it up when the body has a tool-call anchor.
+    fn claude_cli_claims_ua_with_tool_anchor_without_session_header() {
+        // Claude Code v2.1+ stopped sending x-claude-code-session-id. A
+        // claude-cli UA on Anthropic wire with a tool-anchored body is now
+        // claimed by ClaudeCliProfile (it synthesizes the session from the
+        // anchor, same as GenericProfile) so the turn is labeled claude-cli
+        // rather than generic.
         let reg = build_default_registry();
         let c = call_with_body(
             wa::ANTHROPIC,
             vec![("User-Agent", "claude-cli/2.1.98 (cli)")],
             Some(GENERIC_ANT_TOOL_HISTORY),
         );
-        assert_eq!(find_kind(&reg, &c), Some("generic"));
+        assert_eq!(find_kind(&reg, &c), Some("claude-cli"));
     }
 
     const CODEX_STUB_META: &str = r#"{"session_id":"deadbeef-0000-0000-0000-000000000000"}"#;

--- a/server/h-llm/src/wire_apis/anthropic.rs
+++ b/server/h-llm/src/wire_apis/anthropic.rs
@@ -635,7 +635,15 @@ pub fn extract_user_input(req: &Value) -> Option<String> {
 /// turn rather than a tool roundtrip continuation). Equivalent to
 /// `AgentProfile::is_user_turn_start` for Anthropic-shape bodies.
 pub fn is_user_turn_start(req: &Value) -> Option<bool> {
-    let last = req.get("messages")?.as_array()?.last()?;
+    // Skip trailing `role=system` messages (Claude Code's mid-conversation-system
+    // beta appends them after the user's turn), so a fresh user turn isn't masked
+    // by a trailing system notice. The operative message is the last non-system.
+    let last = req
+        .get("messages")?
+        .as_array()?
+        .iter()
+        .rev()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))?;
     if last.get("role").and_then(|r| r.as_str()) != Some("user") {
         return Some(false);
     }

--- a/server/h-llm/tests/synth_e2e.rs
+++ b/server/h-llm/tests/synth_e2e.rs
@@ -90,8 +90,8 @@ fn synthesized_anthropic_call_extracts_llmcall() {
     );
 
     let mut frames = s.open(1, tuple, 1_000);
-    frames.extend(s.data(1, StreamDir::ClientToServer, req.as_bytes(), 2_000));
-    frames.extend(s.data(1, StreamDir::ServerToClient, resp.as_bytes(), 3_000));
+    frames.extend(s.data(1, StreamDir::ClientToServer, req.as_bytes(), 0, 2_000));
+    frames.extend(s.data(1, StreamDir::ServerToClient, resp.as_bytes(), 0, 3_000));
     frames.extend(s.close(1, 4_000));
 
     let events = drive(frames);
@@ -151,6 +151,7 @@ fn synthesized_call_via_pump_carries_process_attribution() {
         exe: exe.clone(),
         dir: StreamDir::ClientToServer,
         data: Bytes::from(req.into_bytes()),
+        seq_off: 0,
         ktime_ns: 2_000_000,
     }));
     frames.extend(pump.on_event(SslEvent::Data {
@@ -160,6 +161,7 @@ fn synthesized_call_via_pump_carries_process_attribution() {
         exe: exe.clone(),
         dir: StreamDir::ServerToClient,
         data: Bytes::from(resp.into_bytes()),
+        seq_off: 0,
         ktime_ns: 3_000_000,
     }));
     frames.extend(pump.on_event(SslEvent::Close {

--- a/server/h-protocol/Cargo.toml
+++ b/server/h-protocol/Cargo.toml
@@ -10,6 +10,7 @@ h-common.workspace = true
 h-capture.workspace = true
 bytes.workspace = true
 httparse.workspace = true
+flate2.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true

--- a/server/h-protocol/src/http.rs
+++ b/server/h-protocol/src/http.rs
@@ -1,6 +1,8 @@
+use std::io::Write;
 use std::net::IpAddr;
 
 use bytes::{Bytes, BytesMut};
+use flate2::write::{GzDecoder, ZlibDecoder};
 
 use crate::model::{HttpParseEvent, HttpRequestData, HttpResponseData, SseEventData};
 use crate::net::FlowKey;
@@ -45,6 +47,66 @@ enum ReadResult {
     Error,
 }
 
+/// Streaming `Content-Encoding` decompressor for an HTTP body.
+///
+/// Compressed bytes are pushed in as they arrive (one de-chunked chunk at a
+/// time for SSE, or the whole body for Content-Length) and decompressed bytes
+/// come out incrementally, so the SSE parser keeps seeing plaintext. The real
+/// motivator: api.anthropic.com gzip-compresses its `text/event-stream`
+/// responses, and without this every Anthropic call lands with an empty
+/// response body (no tokens / tool_use / model). gzip + deflate are handled via
+/// flate2 (pure-Rust miniz_oxide); other encodings (`br`, …) are treated as
+/// unsupported and left to the caller as passthrough.
+///
+/// Best-effort: a malformed stream yields whatever decompressed so far rather
+/// than failing the parse — this is observability data, not a correctness gate.
+enum BodyDecompressor {
+    Gzip(GzDecoder<Vec<u8>>),
+    /// `Content-Encoding: deflate` per RFC 7230 is the zlib format (RFC 1950).
+    Zlib(ZlibDecoder<Vec<u8>>),
+}
+
+impl BodyDecompressor {
+    /// Build from a `Content-Encoding` value, or `None` for identity / an
+    /// encoding we don't decode (caller then treats the body as plaintext).
+    fn from_encoding(enc: &str) -> Option<Self> {
+        match enc.trim().to_ascii_lowercase().as_str() {
+            "gzip" | "x-gzip" => Some(Self::Gzip(GzDecoder::new(Vec::new()))),
+            "deflate" => Some(Self::Zlib(ZlibDecoder::new(Vec::new()))),
+            _ => None,
+        }
+    }
+
+    fn writer(&mut self) -> &mut dyn Write {
+        match self {
+            Self::Gzip(d) => d,
+            Self::Zlib(d) => d,
+        }
+    }
+
+    fn drain(&mut self) -> Vec<u8> {
+        match self {
+            Self::Gzip(d) => std::mem::take(d.get_mut()),
+            Self::Zlib(d) => std::mem::take(d.get_mut()),
+        }
+    }
+
+    /// Push compressed bytes; return whatever decompressed output is ready.
+    fn push(&mut self, data: &[u8]) -> Vec<u8> {
+        let _ = self.writer().write_all(data);
+        let _ = self.writer().flush();
+        self.drain()
+    }
+
+    /// Finish the stream, returning any trailing decompressed bytes.
+    fn finish(self) -> Vec<u8> {
+        match self {
+            Self::Gzip(d) => d.finish().unwrap_or_default(),
+            Self::Zlib(d) => d.finish().unwrap_or_default(),
+        }
+    }
+}
+
 /// Reads an HTTP message body according to its framing.
 struct BodyReader {
     framing: BodyFraming,
@@ -56,6 +118,9 @@ struct BodyReader {
     /// `finish`. Used for SSE responses whose raw body is never read by any
     /// downstream stage (LlmProcessor rebuilds response_body from SSE events).
     skip_accumulation: bool,
+    /// `Content-Encoding` decompressor. `None` for the common uncompressed case,
+    /// where the body passes through byte-for-byte unchanged.
+    decompressor: Option<BodyDecompressor>,
 }
 
 impl BodyReader {
@@ -64,6 +129,7 @@ impl BodyReader {
             framing: BodyFraming::NoBody,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            decompressor: None,
         }
     }
 
@@ -79,6 +145,9 @@ impl BodyReader {
             framing,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            // Request bodies are not decompressed (agent clients send plaintext
+            // JSON); only responses carry Content-Encoding in practice.
+            decompressor: None,
         }
     }
 
@@ -98,6 +167,28 @@ impl BodyReader {
             framing,
             decoded_body: BytesMut::new(),
             skip_accumulation: false,
+            decompressor: extract_content_encoding(headers)
+                .as_deref()
+                .and_then(BodyDecompressor::from_encoding),
+        }
+    }
+
+    /// Pass de-chunked body bytes through the `Content-Encoding` decompressor,
+    /// if any. With no decompressor (the common case) this is an identity copy,
+    /// so uncompressed traffic is byte-for-byte unchanged.
+    fn decode_payload(&mut self, data: &[u8]) -> Bytes {
+        match self.decompressor.as_mut() {
+            Some(d) => Bytes::from(d.push(data)),
+            None => Bytes::copy_from_slice(data),
+        }
+    }
+
+    /// Flush trailing decompressed bytes at end-of-body (terminal chunk / close).
+    /// Empty when there is no decompressor or nothing is buffered.
+    fn flush_decompressor(&mut self) -> Bytes {
+        match self.decompressor.take() {
+            Some(d) => Bytes::from(d.finish()),
+            None => Bytes::new(),
         }
     }
 
@@ -110,8 +201,16 @@ impl BodyReader {
             BodyFraming::NoBody => ReadResult::Complete(Bytes::new()),
             BodyFraming::ContentLength(len) => {
                 if buf.len() >= len {
-                    let body = Bytes::copy_from_slice(&buf[..len]);
-                    let _ = buf.split_to(len);
+                    let raw = buf.split_to(len);
+                    let body = self.decode_payload(&raw);
+                    let tail = self.flush_decompressor();
+                    let body = if tail.is_empty() {
+                        body
+                    } else {
+                        let mut v = body.to_vec();
+                        v.extend_from_slice(&tail);
+                        Bytes::from(v)
+                    };
                     ReadResult::Complete(body)
                 } else {
                     ReadResult::NeedMore
@@ -122,11 +221,12 @@ impl BodyReader {
                 if buf.is_empty() {
                     ReadResult::NeedMore
                 } else {
-                    let data = buf.split();
+                    let raw = buf.split();
+                    let data = self.decode_payload(&raw);
                     if !self.skip_accumulation {
                         self.decoded_body.extend_from_slice(&data);
                     }
-                    ReadResult::ChunkDecoded(data.freeze())
+                    ReadResult::ChunkDecoded(data)
                 }
             }
         }
@@ -162,6 +262,11 @@ impl BodyReader {
                             // Empty line — end of trailers.
                             let total = line_end + 2 + pos + 2;
                             let _ = buf.split_to(total);
+                            // Flush any decompressor remainder into the body.
+                            let tail = self.flush_decompressor();
+                            if !self.skip_accumulation && !tail.is_empty() {
+                                self.decoded_body.extend_from_slice(&tail);
+                            }
                             let body = if self.skip_accumulation {
                                 Bytes::new()
                             } else {
@@ -183,12 +288,13 @@ impl BodyReader {
         }
 
         let _ = buf.split_to(line_end + 2);
-        let chunk_data = buf.split_to(chunk_size);
+        let raw = buf.split_to(chunk_size);
         let _ = buf.split_to(2);
+        let chunk_data = self.decode_payload(&raw);
         if !self.skip_accumulation {
             self.decoded_body.extend_from_slice(&chunk_data);
         }
-        ReadResult::ChunkDecoded(chunk_data.freeze())
+        ReadResult::ChunkDecoded(chunk_data)
     }
 
     /// Flush remaining data as body on connection close.
@@ -196,11 +302,13 @@ impl BodyReader {
         match self.framing {
             BodyFraming::NoBody => Bytes::new(),
             BodyFraming::ContentLength(_) => {
-                let body = buf.split().freeze();
+                let raw = buf.split();
                 if self.skip_accumulation {
                     Bytes::new()
                 } else {
-                    body
+                    let mut body = self.decode_payload(&raw).to_vec();
+                    body.extend_from_slice(&self.flush_decompressor());
+                    Bytes::from(body)
                 }
             }
             BodyFraming::Chunked | BodyFraming::CloseDelimited => {
@@ -209,7 +317,13 @@ impl BodyReader {
                     Bytes::new()
                 } else {
                     if !buf.is_empty() {
-                        self.decoded_body.extend_from_slice(&buf.split());
+                        let raw = buf.split();
+                        let data = self.decode_payload(&raw);
+                        self.decoded_body.extend_from_slice(&data);
+                    }
+                    let tail = self.flush_decompressor();
+                    if !tail.is_empty() {
+                        self.decoded_body.extend_from_slice(&tail);
                     }
                     self.decoded_body.split().freeze()
                 }
@@ -705,6 +819,17 @@ fn extract_content_length(headers: &[(String, String)]) -> Option<usize> {
         .and_then(|(_, v)| v.trim().parse().ok())
 }
 
+/// Extract a decodable `Content-Encoding` from parsed headers, skipping
+/// `identity` / empty. Returns the raw token (e.g. `"gzip"`) for
+/// [`BodyDecompressor::from_encoding`].
+fn extract_content_encoding(headers: &[(String, String)]) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-encoding"))
+        .map(|(_, v)| v.trim().to_string())
+        .filter(|v| !v.is_empty() && !v.eq_ignore_ascii_case("identity"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -721,6 +846,62 @@ mod tests {
         let ca = ("127.0.0.1".parse().unwrap(), 1000);
         let sa = ("127.0.0.1".parse().unwrap(), 8080);
         (fk, ca, sa)
+    }
+
+    #[test]
+    fn body_reader_gunzips_content_length_gzip() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let plain = b"{\"model\":\"claude-opus-4-6\",\"usage\":{\"output_tokens\":7}}";
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(plain).unwrap();
+        let gz = enc.finish().unwrap();
+        let headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("Content-Encoding".to_string(), "gzip".to_string()),
+            ("Content-Length".to_string(), gz.len().to_string()),
+        ];
+        let mut br = BodyReader::new_for_response(200, "POST", &headers);
+        let mut buf = BytesMut::from(&gz[..]);
+        match br.read(&mut buf) {
+            ReadResult::Complete(body) => assert_eq!(&body[..], &plain[..]),
+            _ => panic!("expected Complete with decompressed body"),
+        }
+    }
+
+    #[test]
+    fn body_reader_gunzips_chunked_gzip_sse() {
+        // The real api.anthropic.com shape: text/event-stream + chunked +
+        // Content-Encoding: gzip. Before the fix the SSE parser saw gzip bytes
+        // and produced an empty body.
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let plain = b"event: message_start\r\ndata: {\"type\":\"message_start\"}\r\n\r\n";
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(plain).unwrap();
+        let gz = enc.finish().unwrap();
+        // Wrap the gzip stream as one HTTP chunk + terminal chunk.
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(format!("{:x}\r\n", gz.len()).as_bytes());
+        buf.extend_from_slice(&gz);
+        buf.extend_from_slice(b"\r\n0\r\n\r\n");
+        let headers = vec![
+            ("Content-Type".to_string(), "text/event-stream".to_string()),
+            ("Transfer-Encoding".to_string(), "chunked".to_string()),
+            ("Content-Encoding".to_string(), "gzip".to_string()),
+        ];
+        let mut br = BodyReader::new_for_response(200, "POST", &headers);
+        br.set_skip_accumulation(true); // SSE path: collect ChunkDecoded output
+        let mut out = Vec::new();
+        loop {
+            match br.read(&mut buf) {
+                ReadResult::ChunkDecoded(c) => out.extend_from_slice(&c),
+                ReadResult::Complete(_) => break,
+                ReadResult::NeedMore => panic!("unexpected NeedMore"),
+                ReadResult::Error => panic!("decode error"),
+            }
+        }
+        assert_eq!(out, plain);
     }
 
     #[test]

--- a/server/h-protocol/tests/synth_pipeline.rs
+++ b/server/h-protocol/tests/synth_pipeline.rs
@@ -107,12 +107,14 @@ fn synth_request_response_round_trips_through_reassembler() {
         1,
         StreamDir::ClientToServer,
         &http_request("/v1/messages", "api.anthropic.com", r#"{"model":"claude"}"#),
+        0,
         2_000,
     ));
     frames.extend(s.data(
         1,
         StreamDir::ServerToClient,
         &http_response(r#"{"id":"msg_1","role":"assistant"}"#),
+        0,
         3_000,
     ));
     frames.extend(s.close(1, 4_000));
@@ -151,18 +153,23 @@ fn synth_large_body_split_across_segments_reassembles() {
     let req = http_request("/v1/messages", "api.anthropic.com", &body);
 
     let mut frames = s.open(1, tuple(), 1_000);
-    frames.extend(s.data(1, StreamDir::ClientToServer, &req, 2_000));
+    frames.extend(s.data(1, StreamDir::ClientToServer, &req, 0, 2_000));
     frames.extend(s.data(
         1,
         StreamDir::ServerToClient,
         &http_response(r#"{"ok":true}"#),
+        0,
         3_000,
     ));
 
     // The request alone should span multiple segments (sanity on the harness).
-    let req_segments = s
-        .data(1, StreamDir::ClientToServer, &req, 9_000)
-        .len();
+    // Use a throwaway synthesizer so this probe doesn't perturb the live flow.
+    let req_segments = FlowSynthesizer::new(SynthConfig {
+        segment_size: 512,
+        ..Default::default()
+    })
+    .data(1, StreamDir::ClientToServer, &req, 0, 9_000)
+    .len();
     assert!(req_segments > 1, "request should be multi-segment");
 
     let events = run(&mut w, frames);
@@ -192,6 +199,7 @@ fn synth_sse_streaming_response_emits_sse_events() {
         1,
         StreamDir::ClientToServer,
         &http_request("/v1/messages", "api.anthropic.com", r#"{"stream":true}"#),
+        0,
         2_000,
     ));
     // Each SSE event arrives as its own server→client chunk, mimicking a real
@@ -201,7 +209,7 @@ fn synth_sse_streaming_response_emits_sse_events() {
         "event: content_block_delta\ndata: {\"delta\":\"Hello\"}\n\n",
         "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
     ]);
-    frames.extend(s.data(1, StreamDir::ServerToClient, &sse, 3_000));
+    frames.extend(s.data(1, StreamDir::ServerToClient, &sse, 0, 3_000));
     frames.extend(s.close(1, 4_000));
 
     let events = run(&mut w, frames);
@@ -233,12 +241,14 @@ fn synth_midstream_without_handshake_syncs_on_request() {
         1,
         StreamDir::ClientToServer,
         &http_request("/v1/chat/completions", "api.openai.com", r#"{"n":1}"#),
+        0,
         2_000,
     ));
     frames.extend(s.data(
         1,
         StreamDir::ServerToClient,
         &http_response(r#"{"choices":[]}"#),
+        0,
         3_000,
     ));
 
@@ -256,29 +266,28 @@ fn synth_two_keepalive_exchanges_pair_in_joiner() {
     let mut w = flow_worker();
     let mut j = joiner();
 
+    // Keep-alive: each direction's second message starts at the cumulative byte
+    // offset of the first (the BPF per-conn counter the synthesizer now honors).
+    let req1 = http_request("/v1/messages", "api.anthropic.com", r#"{"q":1}"#);
+    let req2 = http_request("/v1/messages", "api.anthropic.com", r#"{"q":2}"#);
+    let resp1 = http_response(r#"{"a":1}"#);
+    let resp2 = http_response(r#"{"a":2}"#);
+
     let mut frames = s.open(1, tuple(), 1_000);
+    frames.extend(s.data(1, StreamDir::ClientToServer, &req1, 0, 2_000));
+    frames.extend(s.data(1, StreamDir::ServerToClient, &resp1, 0, 3_000));
     frames.extend(s.data(
         1,
         StreamDir::ClientToServer,
-        &http_request("/v1/messages", "api.anthropic.com", r#"{"q":1}"#),
-        2_000,
-    ));
-    frames.extend(s.data(
-        1,
-        StreamDir::ServerToClient,
-        &http_response(r#"{"a":1}"#),
-        3_000,
-    ));
-    frames.extend(s.data(
-        1,
-        StreamDir::ClientToServer,
-        &http_request("/v1/messages", "api.anthropic.com", r#"{"q":2}"#),
+        &req2,
+        req1.len() as u64,
         4_000,
     ));
     frames.extend(s.data(
         1,
         StreamDir::ServerToClient,
-        &http_response(r#"{"a":2}"#),
+        &resp2,
+        resp1.len() as u64,
         5_000,
     ));
     frames.extend(s.close(1, 6_000));


### PR DESCRIPTION
## Summary

Makes the eBPF SSL-uprobe capture engine reconstruct **large and
multi-connection TLS traffic correctly**, and makes Claude Code conversations
form `claude-cli` agent-turns. Before this, real Claude Code sessions over TLS
were captured at the byte level but produced corrupted request bodies and never
became agent-turns.

This branch is the integration point for the eBPF Claude Code observability work:
it includes the changes under review in #153 (DATA_CAP) and #154 (gzip
decompression + header-less `claude-cli` classification), plus the chunking fix,
and adds the two capture-correctness fixes below. Recommend landing this as the
comprehensive change (or rebasing once #153/#154 merge).

## The bugs

1. **Corrupted large bodies / collapsed connections.** A big `SSL_*` buffer is
   split into several ring-buffer events, and the userspace synthesizer appended
   each at a running sequence counter. A silently-dropped chunk (a ring
   `reserve` failure, which isn't counted) or a reorder shifted *every later
   byte earlier*, so the next request's bytes were spliced into the previous
   request's body — invalid JSON, no LLM-call. Separately, the synthetic flow
   key was a pure function of the `SSL*` pointer, so a reused pointer collapsed
   two distinct connections onto one flow, and the static (stripped-BoringSSL)
   attach had no teardown probe at all, so connections never finalized.

2. **Agent turns never formed.** The Anthropic `mid-conversation-system` feature
   appends a trailing `role=system` notice (e.g. a deferred-tools message)
   *after* the user's prompt, so the messages array often ends with `system` on
   a fresh user turn. `is_user_turn_start` examined the literal last message,
   saw `system`, returned false, and the turn tracker discarded the partition as
   "no user start" — even once bodies were captured cleanly.

## The fixes

- **Absolute chunk placement.** The BPF program keeps a per-`(conn, direction)`
  byte counter and stamps each event with its absolute stream offset; the
  synthesizer places every chunk at `ISN + offset`. A dropped chunk now leaves a
  gap at its true position instead of shifting the rest.
- **Connection finalize + generation.** An `SSL_free` uprobe (dynamic libs) and
  an `SSL_read`-returns-0 EOF (static targets) emit a close; close bumps a
  per-connection generation folded into the synthetic tuple, so a reused pointer
  gets a fresh, non-overlapping flow key.
- **Trailing-system-message handling.** `is_user_turn_start` and
  `extract_user_input` skip trailing `role=system` messages and evaluate the
  last non-system message. Fresh turns are recognized again; tool-roundtrip
  continuations still aren't.

## Testing

- New/updated unit tests: absolute-offset placement, generation-on-reuse,
  keep-alive cumulative offsets through the real reassembler→parser→joiner
  pipeline, and the trailing-system cases for both `is_user_turn_start` and
  `extract_user_input`.
- `h-capture`, `h-protocol`, `h-llm`, `h-turn` suites green.
- The BPF program is accepted by the verifier on a 5.15 kernel (the new map
  lookups in the data path load fine).
- End-to-end: a controlled Claude Code conversation now yields a `claude-cli` /
  `anthropic` / `complete` agent-turn with both the user prompt preview and the
  final answer populated, and the corruption counters (out-of-order drops,
  retransmits-ignored) stay at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
