### PR TITLE
fix(ebpf): grant CAP_SYS_ADMIN to staging unit so SSL uprobes attach

### DIFF
--- a/scripts/staging/config.toml
+++ b/scripts/staging/config.toml
@@ -35,7 +35,8 @@ snaplen = 262144
 
 # eBPF SSL-uprobe source: captures the plaintext of TLS-encrypted LLM calls by
 # attaching SSL_read/SSL_write uprobes (Linux only, needs CAP_BPF + CAP_PERFMON
-# — see heron.service). Empty ssl_libs = autodetect libssl from /proc/*/maps.
+# + CAP_SYS_ADMIN — the uprobe perf_event_open is gated on CAP_SYS_ADMIN; see
+# heron.service). Empty ssl_libs = autodetect libssl from /proc/*/maps.
 # Requires a build with the `ebpf` feature; on a non-eBPF binary this source is
 # rejected at startup, so this config is paired with the ebpf-enabled staging
 # build (ci.yml). The ebpf-soak gate generates TLS traffic and asserts the

--- a/scripts/staging/heron.service
+++ b/scripts/staging/heron.service
@@ -13,11 +13,18 @@ WorkingDirectory=/opt/heron
 # so a `cargo` rebuild (which replaces the inode and drops file caps) can't
 # silently degrade capture to API-only — the unit re-grants them every start.
 #
-# CAP_BPF + CAP_PERFMON are for the `ebpf` source: loading BPF programs and
-# attaching SSL_read/SSL_write uprobes (kernel >= 5.8). Harmless to grant on a
-# build without the `ebpf` feature — the caps simply go unused.
-AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN CAP_BPF CAP_PERFMON
-CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_BPF CAP_PERFMON
+# The `ebpf` source needs CAP_BPF + CAP_PERFMON to load BPF programs, AND
+# CAP_SYS_ADMIN to attach the SSL_read/SSL_write uprobes: the kernel gates
+# uprobe `perf_event_open` (perf_uprobe_init) on CAP_SYS_ADMIN specifically —
+# CAP_BPF / CAP_PERFMON do NOT cover it and `perf_event_paranoid` does not relax
+# it. Verified on staging (6.8) and the prod host (5.15). Without CAP_SYS_ADMIN
+# the attach fails with `perf_event_open failed`, the ebpf source's run() errors
+# out, and the co-located pcap source keeps the process healthy — so the symptom
+# is a silent ebpf_uprobes_attached=0, not a crash. (deploy-prod.sh injects the
+# same three caps; keeping them in the committed unit makes that a no-op.)
+# Harmless to grant on a build without the `ebpf` feature — the caps go unused.
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN CAP_BPF CAP_PERFMON CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_BPF CAP_PERFMON CAP_SYS_ADMIN
 NoNewPrivileges=true
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Problem

The `ebpf-soak` gate has failed on **every** commit since it was introduced
(#148), which blocks releases (the prod-promotion + release gates both require a
passing `ebpf-soaked` status). The soak reported all eBPF metrics at zero:

```
ebpf_uprobes_attached   = 0
ebpf_events_received    = 0
ebpf_frames_synthesized = 0
ebpf_process_cache_size = 0
```

…while heron itself stayed healthy and `ebpf_available=true`.

## Root cause

The staging `heron.service` granted only `CAP_BPF` + `CAP_PERFMON`. But the
kernel gates uprobe `perf_event_open` (`perf_uprobe_init`) on **`CAP_SYS_ADMIN`
specifically** — `CAP_BPF`/`CAP_PERFMON` do not cover it and `perf_event_paranoid`
does not relax it. So the `SSL_write` uprobe attach failed:

```
WARN  ebpf: attach ssl_write to SSL_write in .../libssl.so.3 failed: `perf_event_open` failed
ERROR capture source [1] in pipeline 'local' error: could not attach ssl_write to SSL_write on any libssl
```

When the eBPF source's `run()` errors out it is **non-fatal** — the co-located
pcap source keeps the pipeline healthy — so the failure surfaced only as a
silent `ebpf_uprobes_attached=0` rather than a crash.

`deploy-prod.sh` already injects `CAP_SYS_ADMIN` at deploy time (documented there
as verified on the prod host), which is why prod was unaffected; the staging
deploy installs the committed unit as-is, so staging never got the cap.

## Fix

Bake `CAP_SYS_ADMIN` into the committed staging unit (Ambient + Bounding),
matching what prod injects — the prod injector is idempotent so it becomes a
no-op. Also corrects the now-misleading `CAP_BPF + CAP_PERFMON (kernel >= 5.8)`
comments in the unit and the staging capture config.

No code or Rust-behavior change; service-unit + config-comment only.

## Validation

On merge: `ci → deploy-staging → ebpf-soak` re-runs against the redeployed unit;
`ebpf-soak` is expected to go green (uprobe attaches → TLS traffic captured →
`LlmCall` persisted), clearing the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)