### PR TITLE
ci: repoint agent-loop wrappers to Netis/olympus (agent-ops renamed)

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   guard:
-    uses: Netis/agent-ops/.github/workflows/guard.yml@v0.2.0
+    uses: Netis/olympus/.github/workflows/guard.yml@v0.2.0
     with:
       agent_ops_ref: v0.2.0
       run_secret_checks: false

--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   implement:
     if: ${{ github.event.label.name == 'agent:try' }}
-    uses: Netis/agent-ops/.github/workflows/implement.yml@v0.2.0
+    uses: Netis/olympus/.github/workflows/implement.yml@v0.2.0
     with:
       agent_ops_ref: v0.2.0
       runner_labels: '["self-hosted","heron"]'

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   triage:
-    uses: Netis/agent-ops/.github/workflows/triage.yml@v0.2.0
+    uses: Netis/olympus/.github/workflows/triage.yml@v0.2.0
     with:
       agent_ops_ref: v0.2.0
       runner_labels: '["self-hosted","heron"]'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   review:
-    uses: Netis/agent-ops/.github/workflows/review.yml@v0.3.1
+    uses: Netis/olympus/.github/workflows/review.yml@v0.3.1
     with:
       agent_ops_ref: v0.3.1
       runner_labels: '["self-hosted","heron"]'

--- a/.github/workflows/pr-revise.yml
+++ b/.github/workflows/pr-revise.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   revise:
-    uses: Netis/agent-ops/.github/workflows/revise.yml@v0.2.0
+    uses: Netis/olympus/.github/workflows/revise.yml@v0.2.0
     with:
       pr_number: ${{ inputs.pr_number }}
       agent_ops_ref: v0.2.0


### PR DESCRIPTION
Fixes the breakage from renaming the shared mechanism repo **`Netis/agent-ops` → `Netis/olympus`**.

## Why

GitHub Actions does **not** follow repository renames when resolving `uses:` — per GitHub's docs the run fails with `repository not found`. (git/web/API *do* redirect, which is why the reusable workflow's own inner `actions/checkout` still works — but the outer `uses:` resolution does not.) So our five wrappers broke the moment the rename happened.

## Change — owner segment only

| File | `uses:` now points to |
|---|---|
| `guard.yml` | `Netis/olympus/.github/workflows/guard.yml@v0.2.0` |
| `issue-implement.yml` | `Netis/olympus/.github/workflows/implement.yml@v0.2.0` |
| `issue-triage.yml` | `Netis/olympus/.github/workflows/triage.yml@v0.2.0` |
| `pr-revise.yml` | `Netis/olympus/.github/workflows/revise.yml@v0.2.0` |
| `pr-review.yml` | `Netis/olympus/.github/workflows/review.yml@v0.3.1` |

**Unchanged on purpose** (these tags predate the Olympus rebrand and their frozen code expects the old names): the `@v0.2.0`/`@v0.3.1` pins, the `agent_ops_ref:` inputs, and `.agent-ops.json`. Renaming those is a separate, larger upgrade (bump to a post-rename Olympus tag, e.g. `v0.4.0`, which reads `.olympus.json` + takes `olympus_ref`).

## Verification

`guard.yml` runs on `pull_request`, so this PR's own guard check uses the fixed wrapper — a green (resolving) run is the live proof the repoint works.

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)