### PR TITLE
chore(olympus): align .olympus.json — current model + Greek-deity agent names

### DIFF
--- a/.olympus.json
+++ b/.olympus.json
@@ -36,5 +36,5 @@
       "expect": "true"
     }
   },
-  "model": "claude-3-5-sonnet-20241022"
+  "model": "claude-sonnet-4-6"
 }

--- a/.olympus.json
+++ b/.olympus.json
@@ -5,8 +5,8 @@
     "default_branch": "main"
   },
   "agents": {
-    "review_bot_login": "vivi",
-    "dev_agent_name": "wiwi"
+    "review_bot_login": "themis",
+    "dev_agent_name": "hephaestus"
   },
   "labels": {
     "assess": "agent:assess",
@@ -30,7 +30,7 @@
     "service_name": "heron",
     "health_url": "",
     "repo": "Netis/heron",
-    "labels": "mara,incident",
+    "labels": "argus,incident",
     "readiness": {
       "jq": ".data.pipelines[0].running",
       "expect": "true"


### PR DESCRIPTION
## Summary

Two corrections to the Olympus agent config (`.olympus.json`), both pure config — no workflow or code changes.

### 1. Model off a retired ID

`model` pinned `claude-3-5-sonnet-20241022`, **retired 2025-10-28** — requests carrying it would 404 once they reach the upstream provider through the LiteLLM-style gateway. Moved the dev/review agents to `claude-sonnet-4-6`, the documented drop-in for that retired ID (same Sonnet tier, current generation). Opus 4.8 is a one-line follow-up if we want higher implement/review quality.

### 2. Agent names → Greek-deity convention

Olympus names its roles after Greek deities (its own dogfood config uses `themis`/`hephaestus`/`argus`). heron carried over off-theme early names through the #167 migration (which only renamed + version-bumped). Aligned:

| Role | Field | Before | After |
|---|---|---|---|
| Review bot | `agents.review_bot_login` | `vivi` | `themis` |
| Dev agent | `agents.dev_agent_name` | `wiwi` | `hephaestus` |
| Observer | `observer.labels` | `mara,incident` | `argus,incident` |

**Why this is safe:** `review_bot_login` is a body-footer marker (reviews post as `github-actions` and are signed with this value; auto-merge/revise grep for it) — renaming the one config value keeps signing and matching consistent. `dev_agent_name` is the commit-author display name. The observer label is currently dormant (heron wires no `observe.yml`). Past PRs/issues keep their historical `wiwi`/`vivi` text; no functional impact going forward.

### Validation

- [x] `.olympus.json` is valid JSON
- [x] Validates against the Olympus v0.4.0 schema
- [x] `scripts/lint/check-olympus-migration.sh` — 0 failures