### PR TITLE
hera: Coverage tooling, just commands, CI report-only baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,93 @@ jobs:
           path: server/target/release/heron
           retention-days: 7
           if-no-files-found: error
+
+  # ────────────────────────────────────────────────────────────────────────
+  # coverage — report-only. Publishes line coverage for both stacks and
+  # uploads the reports as artifacts, but NEVER fails the PR solely because
+  # coverage ≤ the baseline. The run steps are `continue-on-error: true` and
+  # the consolidated threshold step runs under `shell: bash {0}` so the
+  # percentage always surfaces in the log even when it's below the baseline.
+  # The local gate (`just test coverage gate`) is the enforcing tier; CI is
+  # the visibility tier. Kept a separate job so a coverage hiccup can't block
+  # the merge-critical `test` job.
+  coverage:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, ci-pool]
+    timeout-minutes: 45
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Toolchain versions
+        run: |
+          cargo --version
+          rustc --version
+          bun --version
+          python3 --version
+
+      # cargo-llvm-cov + the llvm-tools-preview component are needed for the
+      # Rust stack. Idempotent on the pool host: the install is a fast no-op
+      # when already present.
+      - name: provision cargo-llvm-cov
+        run: |
+          rustup component add llvm-tools-preview
+          if ! cargo llvm-cov --version >/dev/null 2>&1; then
+            cargo install cargo-llvm-cov --locked
+          else
+            echo "cargo-llvm-cov already present: $(cargo llvm-cov --version)"
+          fi
+
+      # Report-only: continue-on-error so a tooling/runner hiccup or a
+      # below-baseline run never fails the job. The summary still prints the
+      # line %, per-crate summary, and worst-uncovered files to the log.
+      - name: rust coverage (cargo-llvm-cov, merged report)
+        continue-on-error: true
+        env:
+          CARGO_TERM_COLOR: always
+        run: bash scripts/coverage/run_coverage_rs.sh
+
+      - name: ts coverage (bun test --coverage)
+        continue-on-error: true
+        run: bash scripts/coverage/run_coverage_ts.sh
+
+      # Consolidated threshold step. `shell: bash {0}` makes the step always
+      # run and emit its output — the coverage percentage is printed here
+      # regardless of the run steps' exit codes, and the step itself exits 0,
+      # so a below-baseline number is visible in CI but never blocks the PR.
+      - name: coverage threshold (report-only — never fails)
+        shell: bash {0}
+        run: |
+          set +e
+          rs_log="server/target/llvm-cov/coverage.txt"
+          ts_log="console/coverage/coverage.txt"
+          extract_pct() {
+            # Matches the summarize.py "Overall line coverage:  NN.N%" line.
+            grep -m1 -oE 'Overall line coverage: +[0-9]+\.[0-9]+%' "$1" 2>/dev/null \
+              | grep -oE '[0-9]+\.[0-9]+%'
+          }
+          rs_pct="$(extract_pct "$rs_log" || echo n/a)"
+          ts_pct="$(extract_pct "$ts_log" || echo n/a)"
+          echo "::notice title=Coverage::rust=${rs_pct}%  ts=${ts_pct}%  (baseline=90%; CI is report-only, never fails)"
+          echo "rust coverage: ${rs_pct}%"
+          echo "ts   coverage: ${ts_pct}%"
+          echo "(CI coverage is report-only — a value ≤ 90% does not fail this job.)"
+          exit 0
+
+      # Publish the reports + raw JSON as short-lived artifacts so reviewers
+      # can read the per-crate/per-dir breakdown and gap lists without rerunning.
+      - name: upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            server/target/llvm-cov/coverage.json
+            server/target/llvm-cov/coverage.txt
+            console/coverage/*.json
+            console/coverage/coverage.txt
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Rust
 /server/target/
+# Coverage (cargo-llvm-cov merged report — `just test coverage rs`). Lives under
+# the target/ ignore above as server/target/llvm-cov/; never committed.
 **/*.rs.bk
 
 # Node / Bun (React frontend)

--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ just quality all     # rust fmt + clippy + ts lint + tsc
 just test all        # cargo test (all crates)
 ```
 
+Optional coverage report (`just test coverage` for the full menu):
+
+```bash
+just test coverage rs   # Rust (cargo-llvm-cov, merged incl. fault-injection)
+just test coverage ts   # Console (bun test --coverage)
+just test coverage gate # Hard-fail locally if either stack < 90%
+```
+
+CI publishes coverage numbers on every PR but never fails on the threshold
+alone — it's a visibility tier, not a gate. The local `gate` sub-command is the
+enforcing tier.
+
 Run `just help` for the full menu. Design docs under [docs/design/](docs/design/)
 describe the per-module contract — read the relevant one before changing anything
 load-bearing.

--- a/console/.gitignore
+++ b/console/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Coverage (bun test --coverage output — `just test coverage ts`).
+# The parser recomputes the denominator over src/** itself; never committed.
+coverage/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/justfile
+++ b/justfile
@@ -35,6 +35,7 @@ help:
     @echo "🧪 Testing"
     @echo "   just test all          Run cargo test (all crates)"
     @echo "   just test crate <name> Test a single workspace crate"
+    @echo "   just test coverage     Line coverage (rs + ts); 'just test coverage' for detail"
     @echo ""
     @echo "🌲 Worktrees"
     @echo "   just wt add <name>     Create worktree + feature branch"

--- a/scripts/coverage/coverage-gate.sh
+++ b/scripts/coverage/coverage-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Local coverage GATE — runs both stacks with HERON_COV_GATE=1 and fails the
+# shell if either is below HERON_COV_MIN (default 90).
+#
+# This is for local pre-push hygiene. CI does NOT use this: ci.yml's `coverage`
+# job is report-only (continue-on-error on the run steps + a threshold step
+# with `shell: bash {0}` so the percentage always surfaces even when below the
+# baseline). Keeping the local gate hard while CI stays soft means coverage
+# drops are *visible* in CI but never *block* a PR solely because % ≤ 90.
+#
+#   just test coverage gate            run the gate (rs + ts)
+#   HERON_COV_MIN=<pct> just test coverage gate   change threshold
+set -euo pipefail
+
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$PROJECT_ROOT" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+cd "$PROJECT_ROOT"
+
+export HERON_COV_MIN="${HERON_COV_MIN:-90}"
+export HERON_COV_GATE=1
+
+RC=0
+echo -e "${BOLD}${BLUE}🚪 coverage gate (threshold ${HERON_COV_MIN}%)${NC}"
+echo ""
+
+echo -e "${BLUE}━━━ Rust ━━━${NC}"
+if bash scripts/coverage/run_coverage_rs.sh; then
+    echo -e "${GREEN}✓ rs gate passed${NC}"
+else
+    echo -e "${RED}✗ rs gate failed${NC}" >&2
+    RC=1
+fi
+echo ""
+
+echo -e "${BLUE}━━━ TypeScript ━━━${NC}"
+if bash scripts/coverage/run_coverage_ts.sh; then
+    echo -e "${GREEN}✓ ts gate passed${NC}"
+else
+    echo -e "${RED}✗ ts gate failed${NC}" >&2
+    RC=1
+fi
+echo ""
+
+if [ "$RC" -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}✓ coverage gate passed (${HERON_COV_MIN}% on both stacks)${NC}"
+else
+    echo -e "${RED}${BOLD}✗ coverage gate failed (see above)${NC}" >&2
+fi
+exit "$RC"

--- a/scripts/coverage/lib/summarize_coverage.py
+++ b/scripts/coverage/lib/summarize_coverage.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Summarize coverage JSON into a stable, human-readable report.
+
+Heron has two coverage stacks, each emitting a *different* JSON shape:
+
+  Rust  — `cargo-llvm-cov` (`cargo llvm-cov report --json --summary-only`,
+           flat `{files, totals}`) and the underlying raw `llvm-cov export
+           -summary-only` (`{data:[{files, summary}]}`).
+  TS    — `bun test --coverage --coverage-reporter=json`
+           (`{coverage:{files:[…], summary:{…}}}`), whose field names drift
+           across Bun versions (`percent` | `coveredPercent` | `pct`,
+           `coveredLines` | `covered`, `totalLines` | `count` | `lineCount`).
+
+This parser is tolerant of all of the above. It deliberately **recomputes
+percentages from raw line counts** rather than trusting an aggregate
+`percent`/`totals` field, because those can fold in excluded files (Bun's
+totals include test files the gate must not count) or be rounded.
+
+For the TS stack the parser also **enforces the denominator itself**: it walks
+`console/src/**/*.{ts,tsx}` excluding `.test.`/`.spec.` files, `__fixtures__`/
+`fixtures`/`__mocks__` dirs, and `.d.ts` ambient files, and only counts files
+that appear in Bun's coverage report. A source file Bun never instrumented
+(think a leaf module with no tests touching it) contributes its *full* line
+count to the denominator with zero covered — the honest gap.
+
+Usage
+-----
+    summarize_coverage.py --kind rs|ts --json-file PATH [--text-log PATH]
+                          [--top N] [--min PCT] [--gap-list]
+
+Exit codes: 0 success · 1 coverage below --min (gate mode) · 2 bad invocation.
+
+The JSON shapes are referenced from the project memory note on Heron coverage
+tooling. Run the companion self-tests:
+    python3 scripts/coverage/lib/test_summarize_coverage.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Iterable
+
+# ──────────────────────────────────────────────────────────────────────────
+# JSON shape tolerance
+# ──────────────────────────────────────────────────────────────────────────
+
+# Exclude patterns for the TS denominator. Mirrors the rule in the project
+# memory: src/**/*.{ts,tsx} minus .test./.spec./__fixtures__//fixtures//__mocks__/.d.ts
+_TS_EXCLUDE_RE = re.compile(
+    r"(?:^|/)"            # dir boundary or start
+    r"(?:__fixtures__|fixtures|__mocks__|mocks)"  # fixture/mock dirs
+    r"(?:/|$)"
+)
+# A test/spec file, or a Bun-generated- ambient `.d.ts`. `.test.`/`.spec.`
+# anywhere in the basename counts (covers `foo.test.ts`, `foo.test.tsx`).
+_TS_TESTFILE_RE = re.compile(r"\.(?:test|spec)\.(?:ts|tsx)$")
+_TS_AMBIENT_RE = re.compile(r"\.d\.ts$")
+
+
+def _count_covered(node: Any) -> tuple[int | None, int | None]:
+    """Extract (total_lines, covered_lines) from one coverage node.
+
+    A node is either a per-file record or an aggregate (totals/summary).
+    Field families handled:
+
+      llvm-cov :  {lines: {count, covered, percent}}            (flat cargo)
+                  {summary: {lines: {count, covered}}}          (raw llvm)
+      bun      :  {lineCount, coveredLines, percent|pct|coveredPercent}
+                  {totalLines, coveredLines, …}
+                  {count, covered, …}                            (legacy)
+
+    `or` short-circuits on the first truthy hit; `0` lines is a real value so
+    None-guards (explicit `is not None`) are used where it matters — but here
+    a 0-count file contributes nothing to either side, so the truthy fallthrough
+    is fine and simpler.
+    """
+    if not isinstance(node, dict):
+        return None, None
+
+    # llvm-cov flat: {lines: {count, covered}}
+    lines = node.get("lines")
+    if isinstance(lines, dict):
+        return lines.get("count"), lines.get("covered")
+    # raw llvm-cov per-file: {summary: {lines: {count, covered}}}
+    summ = node.get("summary")
+    if isinstance(summ, dict) and isinstance(summ.get("lines"), dict):
+        return summ["lines"].get("count"), summ["lines"].get("covered")
+
+    # Bun family — try the explicit total-fields first so a 0-covered source
+    # file (all-missing) still reports its real total.
+    total = node.get("lineCount")
+    if total is None:
+        total = node.get("totalLines")
+    if total is None:
+        total = node.get("count")
+    cov = node.get("coveredLines")
+    if cov is None:
+        cov = node.get("covered")
+    if total is not None and cov is not None:
+        return total, cov
+    return None, None
+
+
+def _strip_noise(text: str) -> str:
+    """Slice the first {...} JSON object out of text, trimming leading and
+    trailing non-JSON noise (cargo banners, compiler warnings, blank lines).
+
+    `cargo llvm-cov` may print banners like
+        `     Finished test [unoptimized + debuginfo] target(s) in 0.12s`
+    before the JSON blob, and `llvm-cov export` occasionally emits a stray
+    blank line. `json.loads` chokes on any of it, so we find the first `{` and
+    match braces to recover the object. We do *not* use regex across the whole
+    string — JSON can contain `}` inside strings, which a naive regex miscounts.
+    """
+    s = text.strip()
+    start = s.find("{")
+    if start < 0:
+        raise ValueError("no JSON object found in coverage output")
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(s)):
+        ch = s[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return s[start : i + 1]
+    # Unbalanced — fall back to raw, let json.loads raise a clear error.
+    return s[start:]
+
+
+def _load_json(path: str) -> Any:
+    """Read a coverage JSON file, tolerant of leading/trailing non-JSON noise."""
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        raw = fh.read()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return json.loads(_strip_noise(raw))
+
+
+def _find_files_and_totals(doc: Any) -> tuple[list[dict], dict]:
+    """Locate the per-file list and the aggregate totals across shapes.
+
+      cargo-llvm-cov flat  : {files:[…], totals:{…}}
+      raw llvm-cov         : {data:[{files:[…], summary:{…}}], type, version}
+      bun                  : {coverage:{files:[…], summary:{…}}}
+    """
+    if isinstance(doc, dict):
+        data = doc.get("data")
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            rec = data[0]
+            return list(rec.get("files", [])), (rec.get("summary") or rec.get("totals") or {})
+        cov = doc.get("coverage")
+        if isinstance(cov, dict):
+            return list(cov.get("files", [])), (cov.get("summary") or {})
+        if "files" in doc or "totals" in doc or "summary" in doc:
+            return list(doc.get("files", [])), (doc.get("totals") or doc.get("summary") or {})
+    if isinstance(doc, list) and doc and isinstance(doc[0], dict):
+        # Some tooling wraps the report in a bare list.
+        rec = doc[0]
+        return list(rec.get("files", [])), (rec.get("summary") or rec.get("totals") or {})
+    return [], {}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Per-file normalization
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _file_path(rec: dict) -> str | None:
+    """The file's source path. llvm-cov uses `filename`, Bun uses `path`."""
+    return rec.get("filename") or rec.get("path") or rec.get("url")
+
+
+def _pct(total: int | None, covered: int | None) -> float:
+    """Recompute a percentage from counts (never trust a stored `percent`)."""
+    if not total:
+        return 0.0
+    if covered is None:
+        covered = 0
+    return (covered / total) * 100.0 if total else 0.0
+
+
+def _bucket_rust(path: str, server_root: str) -> str:
+    """Group a Rust source path under its crate name.
+
+    cargo-llvm-cov reports paths relative to the workspace, e.g.
+    `h-storage-duckdb/src/exchanges.rs`. The crate is the first path segment.
+    Files outside any `h-*`/`app/*` crate (generated, build scripts) bucket as
+    `<other>`.
+    """
+    p = path.replace("\\", "/")
+    # Strip a leading absolute or `server/` prefix so the first segment is the crate.
+    if p.startswith(server_root):
+        p = p[len(server_root):].lstrip("/")
+    parts = p.split("/")
+    if parts and (parts[0].startswith("h-") or parts[0] in ("app",)):
+        return parts[0]
+    if len(parts) >= 2 and parts[1].startswith("h-"):
+        return parts[1]
+    return "<other>"
+
+
+def _ts_denominator_entries(src_root: str) -> list[str]:
+    """Walk console/src/**/*.{ts,tsx} and return the files that belong in the
+    TS denominator — i.e. excluding tests, fixtures/mocks, and ambient `.d.ts`.
+
+    Returns repo-root-relative POSIX paths (`src/lib/foo.ts`). This is the
+    SSOT list the gate trusts; Bun's own aggregate totals are *not* used as
+    the denominator (they include the very test files we exclude here).
+    """
+    entries: list[str] = []
+    if not os.path.isdir(src_root):
+        return entries
+    for dirpath, dirnames, filenames in os.walk(src_root):
+        # Prune fixture/mock dirs in-place so os.walk doesn't descend.
+        dirnames[:] = [d for d in dirnames if d not in ("__fixtures__", "fixtures", "__mocks__", "mocks")]
+        for fn in filenames:
+            if not (fn.endswith(".ts") or fn.endswith(".tsx")):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, fn), src_root)
+            posix = rel.replace("\\", "/")
+            full = os.path.join(dirpath, fn)
+            if _TS_TESTFILE_RE.search(posix):
+                continue
+            if _TS_AMBIENT_RE.search(posix):
+                continue
+            if _TS_EXCLUDE_RE.search(posix):
+                continue
+            entries.append(full)
+    return entries
+
+
+def _ts_line_count(path: str) -> int:
+    """A cheap source-only line count for a TS file Bun never instrumented.
+
+    We only ever call this for files *missing* from Bun's report (the gap), so
+    it runs rarely. Counts non-blank lines; an exact count isn't critical —
+    these files contribute to the denominator as "0 covered" regardless, and we
+    only need a defensible total so the percentage is honest.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return sum(1 for ln in fh if ln.strip())
+    except OSError:
+        return 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Report assembly
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class CoverageReport:
+    """Aggregate of per-file (total, covered) tuples grouped by bucket."""
+
+    def __init__(self) -> None:
+        self.buckets: dict[str, list[tuple[str, int, int]]] = {}
+
+    def add(self, bucket: str, path: str, total: int, covered: int) -> None:
+        self.buckets.setdefault(bucket, []).append((path, total, covered))
+
+    @property
+    def total_lines(self) -> int:
+        return sum(t for rows in self.buckets.values() for _, t, _ in rows)
+
+    @property
+    def covered_lines(self) -> int:
+        return sum(c for rows in self.buckets.values() for _, _, c in rows)
+
+    @property
+    def pct(self) -> float:
+        return _pct(self.total_lines, self.covered_lines)
+
+    def bucket_summary(self) -> list[tuple[str, int, int, float]]:
+        rows = []
+        for bucket, items in self.buckets.items():
+            t = sum(x for _, x, _ in items)
+            c = sum(x for _, _, x in items)
+            rows.append((bucket, t, c, _pct(t, c)))
+        rows.sort(key=lambda r: (-r[1], r[0]))  # most lines first
+        return rows
+
+    def worst_uncovered(self, n: int) -> list[tuple[str, int, int, float]]:
+        """The N files with the largest *uncovered* line count (gap), breaking
+        ties by lowest percentage then by path. These are the gap list."""
+        flat = [(p, t, c) for items in self.buckets.values() for p, t, c in items]
+        flat.sort(key=lambda r: (-(r[1] - r[2]), r[3] if False else -_pct(r[1], r[2]), r[0]))
+        return [(p, t, c, _pct(t, c)) for p, t, c in flat[:n]]
+
+
+def build_rs_report(doc: Any, server_root: str) -> CoverageReport:
+    files, _totals = _find_files_and_totals(doc)
+    rep = CoverageReport()
+    for rec in files:
+        path = _file_path(rec)
+        if path is None:
+            continue
+        total, covered = _count_covered(rec)
+        if total is None:
+            continue
+        rep.add(_bucket_rust(path, server_root), path, total or 0, covered or 0)
+    return rep
+
+
+def build_ts_report(doc: Any, console_src: str, console_root: str) -> CoverageReport:
+    files, _totals = _find_files_and_totals(doc)
+    # Index Bun's per-file records by basename+relative path so we can match
+    # against the denominator walk. Bun paths are console-relative (`src/…`),
+    # but also tolerate bare basenames or absolute paths.
+    by_key: dict[str, dict] = {}
+    for rec in files:
+        p = _file_path(rec)
+        if p is None:
+            continue
+        key = p.replace("\\", "/")
+        # Normalize: strip any leading console/ or absolute prefix down to src/….
+        idx = key.find("src/")
+        if idx >= 0:
+            key = key[idx:]
+        by_key[key] = rec
+        by_key[os.path.basename(p)] = rec  # basename fallback
+
+    rep = CoverageReport()
+    # First, every file Bun *did* report (and that passes the denominator filter).
+    used = set()
+    for rec in files:
+        p = _file_path(rec)
+        if p is None:
+            continue
+        norm = p.replace("\\", "/")
+        idx = norm.find("src/")
+        rel = norm[idx:] if idx >= 0 else norm
+        posix = rel
+        if _TS_TESTFILE_RE.search(posix) or _TS_AMBIENT_RE.search(posix) or _TS_EXCLUDE_RE.search(posix):
+            continue  # excluded from denominator — don't count coverage either
+        total, covered = _count_covered(rec)
+        if total is None:
+            continue
+        bucket = posix.split("/")[1] if posix.startswith("src/") and "/" in posix[4:] else posix.split("/")[0]
+        rep.add(bucket, posix, total or 0, covered or 0)
+        used.add(posix)
+    # Then, denominator files Bun never reported → all-uncovered (the honest gap).
+    for full in _ts_denominator_entries(console_src):
+        rel = os.path.relpath(full, console_root).replace("\\", "/")
+        posix = rel
+        if posix in used:
+            continue
+        total = _ts_line_count(full)
+        if total == 0:
+            continue
+        bucket = posix.split("/")[1] if posix.startswith("src/") and "/" in posix[4:] else posix.split("/")[0]
+        rep.add(bucket, posix, total, 0)
+    return rep
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Rendering
+# ──────────────────────────────────────────────────────────────────────────
+
+BLUE = "\033[0;34m"
+GREEN = "\033[0;32m"
+YELLOW = "\033[0;33m"
+RED = "\033[0;31m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+
+def _color_for(pct: float, min_pct: float) -> str:
+    if pct >= min_pct:
+        return GREEN
+    if pct >= min_pct - 10:
+        return YELLOW
+    return RED
+
+
+def _fmt_pct(pct: float) -> str:
+    return f"{pct:5.1f}%"
+
+
+def render(
+    rep: CoverageReport,
+    *,
+    kind: str,
+    top: int,
+    min_pct: float,
+    gap_list: bool,
+    text_log: str | None,
+) -> str:
+    out: list[str] = []
+    overall = rep.pct
+    color = _color_for(overall, min_pct)
+    out.append("")
+    out.append(f"{BOLD}{BLUE}📊 Coverage — {kind.upper()}{NC}")
+    out.append("━" * 52)
+    out.append(
+        f"  Overall line coverage: {color}{BOLD}{_fmt_pct(overall)}{NC}"
+        f"  {DIM}({rep.covered_lines}/{rep.total_lines} lines){NC}"
+        f"  {DIM}gate: {min_pct:.0f}%{NC}"
+    )
+    out.append("")
+
+    # Per-bucket summary.
+    out.append(f"{BOLD}  Per-{'crate' if kind == 'rs' else 'dir'} summary{NC}")
+    out.append(f"  {'bucket':<28} {'lines':>8} {'covered':>9} {'pct':>7}")
+    out.append(f"  {'-' * 28} {'-' * 8} {'-' * 9} {'-' * 7}")
+    for bucket, t, c, p in rep.bucket_summary():
+        bc = _color_for(p, min_pct)
+        out.append(f"  {bucket:<28} {t:>8} {c:>9} {bc}{_fmt_pct(p)}{NC}")
+    out.append("")
+
+    # Worst uncovered files (the gap list).
+    if gap_list or top > 0:
+        n = top if top > 0 else 10
+        worst = rep.worst_uncovered(n)
+        out.append(f"{BOLD}  Worst uncovered files{NC} {DIM}(top {n} by gap){NC}")
+        out.append(f"  {'file':<54} {'gap':>5} {'pct':>7}")
+        out.append(f"  {'-' * 54} {'-' * 5} {'-' * 7}")
+        for path, t, c, p in worst:
+            gap = t - c
+            disp = path if len(path) <= 54 else "…" + path[-(53):]
+            pc = _color_for(p, min_pct)
+            out.append(f"  {disp:<54} {gap:>5} {pc}{_fmt_pct(p)}{NC}")
+        if not worst:
+            out.append(f"  {DIM}(no uncovered lines){NC}")
+        out.append("")
+
+    text = "\n".join(out) + "\n"
+    # Persist the text log (without ANSI colors) for CI artifacts.
+    if text_log:
+        plain = _strip_ansi(text)
+        try:
+            os.makedirs(os.path.dirname(text_log), exist_ok=True)
+        except OSError:
+            pass
+        with open(text_log, "w", encoding="utf-8") as fh:
+            fh.write(plain)
+    return text
+
+
+_ANSI_RE = re.compile("\033\\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Summarize Heron coverage JSON.")
+    p.add_argument("--kind", required=True, choices=["rs", "ts"], help="coverage stack")
+    p.add_argument("--json-file", required=True, help="coverage JSON report to parse")
+    p.add_argument("--text-log", help="also write a plain-text summary here (no ANSI)")
+    p.add_argument("--top", type=int, default=15, help="worst-uncovered files to list (0 to hide)")
+    p.add_argument("--min", type=float, default=90.0, help="gate threshold pct (default 90)")
+    p.add_argument("--gate", action="store_true", help="exit 1 when overall pct < --min")
+    p.add_argument(
+        "--gap-list", action="store_true", default=True,
+        help="print the worst-uncovered gap list (default on)",
+    )
+    p.add_argument("--no-gap-list", dest="gap_list", action="store_false")
+    p.add_argument("--server-root", default="server", help="Rust workspace dir (for --kind rs)")
+    p.add_argument("--console-root", default="console", help="console dir (for --kind ts)")
+    args = p.parse_args(argv)
+
+    doc = _load_json(args.json_file)
+
+    if args.kind == "rs":
+        rep = build_rs_report(doc, args.server_root)
+    else:
+        console_src = os.path.join(args.console_root, "src")
+        rep = build_ts_report(doc, console_src, args.console_root)
+
+    text = render(
+        rep,
+        kind=args.kind,
+        top=args.top,
+        min_pct=args.min,
+        gap_list=args.gap_list,
+        text_log=args.text_log,
+    )
+    sys.stdout.write(text)
+
+    if args.gate:
+        if rep.pct < args.min:
+            print(f"{RED}✗ coverage {rep.pct:.1f}% < gate {args.min:.0f}%{NC}", file=sys.stderr)
+            return 1
+        print(f"{GREEN}✓ coverage {rep.pct:.1f}% ≥ gate {args.min:.0f}%{NC}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/coverage/lib/test_summarize_coverage.py
+++ b/scripts/coverage/lib/test_summarize_coverage.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Self-tests for scripts/coverage/lib/summarize_coverage.py.
+
+Run:  python3 scripts/coverage/lib/test_summarize_coverage.py
+
+No third-party deps — plain `unittest` against the module under test. The
+env worktree has no cargo/bun, so the *coverage runs themselves* can't be
+exercised here; these tests lock down the parser's tolerance of the three
+JSON shapes (cargo-llvm-cov flat, raw llvm-cov, bun) plus the TS-denominator
+enforcement and report ordering, which is where regressions would hide.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import summarize_coverage as sc  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────────
+
+CARGO_FLAT = {
+    "files": [
+        {"filename": "h-common/src/lib.rs", "summary": {"lines": {"count": 100, "covered": 90, "percent": 0.9}}},
+        {"filename": "h-llm/src/x.rs", "summary": {"lines": {"count": 50, "covered": 20, "percent": 0.4}}},
+        {"filename": "h-storage-duckdb/src/concurrent_tests.rs",
+         "summary": {"lines": {"count": 60, "covered": 60, "percent": 1.0}}},
+    ],
+    "totals": {"lines": {"count": 210, "covered": 170, "percent": 0.8095}},
+}
+
+RAW_LLVM = {
+    "data": [{
+        "files": [
+            {"filename": "h-api/src/main.rs", "summary": {"lines": {"count": 30, "covered": 15}}},
+            {"filename": "app/heron/src/main.rs", "summary": {"lines": {"count": 12, "covered": 12}}},
+        ],
+        "summary": {"lines": {"count": 42, "covered": 27}},
+    }],
+    "type": "coverage.report.summary",
+    "version": "0.1.0",
+}
+
+# Bun variants across versions: percent|pct|coveredPercent, coveredLines|covered, lineCount|totalLines
+BUN_REPORT = {
+    "coverage": {
+        "files": [
+            {"path": "src/lib/foo.ts", "lineCount": 40, "coveredLines": 30, "percent": 0.75},
+            {"path": "src/lib/bar.test.ts", "lineCount": 20, "coveredLines": 20, "pct": 1.0},
+            {"path": "src/lib/baz.tsx", "lineCount": 10, "covered": 9, "totalLines": 10, "coveredPercent": 0.9},
+        ],
+        "summary": {"percent": 0.9, "coveredLines": 59, "totalLines": 70},
+    }
+}
+
+CARGO_NOISE = """     Finished test [unoptimized + debuginfo] target(s) in 0.12s
+   Compiling foo
+{"files":[{"filename":"h-common/src/lib.rs","summary":{"lines":{"count":10,"covered":8}}}],"totals":{"lines":{"count":10,"covered":8}}}
+"""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestShapeTolerance(unittest.TestCase):
+    def test_cargo_flat_extracts_per_file(self):
+        t, c = sc._count_covered(CARGO_FLAT["files"][0])
+        self.assertEqual((t, c), (100, 90))
+
+    def test_raw_llvm_per_file_nests_under_summary(self):
+        t, c = sc._count_covered(RAW_LLVM["data"][0]["files"][0])
+        self.assertEqual((t, c), (30, 15))
+
+    def test_bun_lineCount_coveredLines_variant(self):
+        t, c = sc._count_covered(BUN_REPORT["coverage"]["files"][0])
+        self.assertEqual((t, c), (40, 30))
+
+    def test_bun_covered_totalLines_variant(self):
+        t, c = sc._count_covered(BUN_REPORT["coverage"]["files"][2])
+        self.assertEqual((t, c), (10, 9))
+
+    def test_find_files_cargo_flat(self):
+        files, totals = sc._find_files_and_totals(CARGO_FLAT)
+        self.assertEqual(len(files), 3)
+        self.assertEqual(totals["lines"]["count"], 210)
+
+    def test_find_files_raw_llvm_unwraps_data(self):
+        files, totals = sc._find_files_and_totals(RAW_LLVM)
+        self.assertEqual(len(files), 2)
+        self.assertEqual(totals["lines"]["covered"], 27)
+
+    def test_find_files_bun_unwraps_coverage(self):
+        files, totals = sc._find_files_and_totals(BUN_REPORT)
+        self.assertEqual(len(files), 3)
+        self.assertEqual(totals["coveredLines"], 59)
+
+    def test_strip_noise_slices_leading_banner(self):
+        obj = json.loads(sc._strip_noise(CARGO_NOISE))
+        self.assertEqual(obj["files"][0]["filename"], "h-common/src/lib.rs")
+
+    def test_strip_noise_handles_strings_with_braces(self):
+        raw = 'noise {"a":"} tricky","b":{"c":1}} trailer'
+        obj = json.loads(sc._strip_noise(raw))
+        self.assertEqual(obj["a"], "} tricky")
+
+
+    def test_find_files_bun_flat_no_wrapper(self):
+        # Newer Bun can emit {summary, files} without a `coverage` wrapper.
+        doc = {"summary": {"percent": 0.9, "coveredLines": 9, "totalLines": 10},
+               "files": [{"path": "src/lib/foo.ts", "lineCount": 10, "coveredLines": 9}]}
+        files, totals = sc._find_files_and_totals(doc)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(totals["coveredLines"], 9)
+
+
+class TestPercentRecompute(unittest.TestCase):
+    def test_pct_from_counts(self):
+        self.assertAlmostEqual(sc._pct(100, 90), 90.0)
+        self.assertAlmostEqual(sc._pct(0, 0), 0.0)
+        self.assertAlmostEqual(sc._pct(7, 3), (3 / 7) * 100)
+
+    def test_rs_report_recomputes_overall_not_trusting_stored(self):
+        rep = sc.build_rs_report(CARGO_FLAT, "server")
+        # Counts: 90+20+60=170 / 100+50+60=210 → 80.952%, not the stored 80.95
+        self.assertEqual(rep.total_lines, 210)
+        self.assertEqual(rep.covered_lines, 170)
+        self.assertAlmostEqual(rep.pct, (170 / 210) * 100, places=2)
+
+
+class TestRustBuckets(unittest.TestCase):
+    def test_crate_bucket_from_path(self):
+        self.assertEqual(sc._bucket_rust("h-storage-duckdb/src/exchanges.rs", "server"), "h-storage-duckdb")
+        self.assertEqual(sc._bucket_rust("h-common/src/lib.rs", "server"), "h-common")
+
+    def test_app_crate_bucket(self):
+        self.assertEqual(sc._bucket_rust("app/heron/src/main.rs", "server"), "app")
+
+    def test_other_bucket_for_non_crate(self):
+        self.assertEqual(sc._bucket_rust("target/whatever.rs", "server"), "<other>")
+
+    def test_report_groups_by_crate(self):
+        rep = sc.build_rs_report(CARGO_FLAT, "server")
+        self.assertIn("h-common", rep.buckets)
+        self.assertIn("h-llm", rep.buckets)
+        self.assertIn("h-storage-duckdb", rep.buckets)
+
+
+class TestTSDenominator(unittest.TestCase):
+    def _write_tree(self, tree: dict[str, str]) -> str:
+        d = tempfile.mkdtemp(prefix="cov_test_")
+        for rel, content in tree.items():
+            full = os.path.join(d, rel)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w") as fh:
+                fh.write(content)
+        return d
+
+    def test_excludes_test_spec_files(self):
+        d = self._write_tree({
+            "src/lib/foo.ts": "a\nb\n",
+            "src/lib/foo.test.ts": "c\nd\n",
+            "src/lib/bar.spec.tsx": "e\nf\n",
+        })
+        entries = sc._ts_denominator_entries(os.path.join(d, "src"))
+        names = sorted(os.path.basename(e) for e in entries)
+        self.assertEqual(names, ["foo.ts"])
+
+    def test_excludes_fixture_and_mock_dirs(self):
+        d = self._write_tree({
+            "src/lib/real.ts": "a\n",
+            "src/lib/__fixtures__/sample.ts": "b\n",
+            "src/lib/wire-apis/openai-chat/__fixtures__/case.ts": "c\n",
+            "src/lib/__mocks__/thing.ts": "d\n",
+        })
+        entries = sc._ts_denominator_entries(os.path.join(d, "src"))
+        names = sorted(os.path.relpath(e, os.path.join(d, "src")) for e in entries)
+        self.assertEqual(names, ["lib/real.ts"])
+
+    def test_excludes_ambient_dts(self):
+        d = self._write_tree({
+            "src/vite-env.d.ts": "declare {}\n",
+            "src/types.ts": "x\n",
+        })
+        entries = sc._ts_denominator_entries(os.path.join(d, "src"))
+        names = [os.path.basename(e) for e in entries]
+        self.assertEqual(names, ["types.ts"])
+
+    def test_uninstrumented_file_counts_as_gap(self):
+        # Bun reports foo.ts but never touches bar.ts → bar.ts must enter the
+        # denominator with its real line count and 0 covered.
+        bun = {"coverage": {"files": [
+            {"path": "src/lib/foo.ts", "lineCount": 4, "coveredLines": 4},
+        ], "summary": {}}}
+        d = self._write_tree({
+            "src/lib/foo.ts": "a\nb\nc\nd\n",
+            "src/lib/bar.ts": "x\ny\nz\n",  # 3 lines, never reported
+        })
+        rep = sc.build_ts_report(bun, os.path.join(d, "src"), d)
+        # foo: 4/4, bar: 0/3 → 4/7 ≈ 57.1%
+        self.assertEqual(rep.total_lines, 7)
+        self.assertEqual(rep.covered_lines, 4)
+        self.assertAlmostEqual(rep.pct, (4 / 7) * 100, places=1)
+
+    def test_bun_report_excludes_test_files_from_denominator(self):
+        # The test file Bun *did* report must NOT contribute to either side.
+        rep = sc.build_ts_report(BUN_REPORT, "<nonexistent>", "<nonexistent>")
+        # foo.ts 40/30 + baz.tsx 10/9 = 50/50 covered; bar.test.ts excluded.
+        self.assertEqual(rep.total_lines, 50)
+        self.assertEqual(rep.covered_lines, 39)
+
+
+class TestWorstUncovered(unittest.TestCase):
+    def test_orders_by_gap_then_pct(self):
+        rep = sc.CoverageReport()
+        rep.add("c", "a.rs", 100, 50)   # gap 50, 50%
+        rep.add("c", "b.rs", 60, 0)     # gap 60, 0%
+        rep.add("c", "c.rs", 10, 0)     # gap 10, 0%
+        worst = rep.worst_uncovered(2)
+        self.assertEqual([w[0] for w in worst], ["b.rs", "a.rs"])
+
+    def test_worst_uncovered_handles_fully_covered(self):
+        rep = sc.CoverageReport()
+        rep.add("c", "full.rs", 10, 10)  # gap 0
+        rep.add("c", "half.rs", 10, 5)   # gap 5
+        worst = rep.worst_uncovered(5)
+        self.assertEqual(worst[0][0], "half.rs")
+        self.assertEqual(worst[0][3], 50.0)
+
+
+class TestCLI(unittest.TestCase):
+    def test_gate_exit_zero_when_above_min(self):
+        # 90/100 = 90% ≥ 90 gate
+        doc = {"files": [{"filename": "h-common/src/lib.rs",
+                          "summary": {"lines": {"count": 100, "covered": 90}}}], "totals": {}}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(doc, f)
+            path = f.name
+        rc = sc.main(["--kind", "rs", "--json-file", path, "--gate", "--min", "90", "--no-gap-list"])
+        os.unlink(path)
+        self.assertEqual(rc, 0)
+
+    def test_gate_exit_one_when_below_min(self):
+        doc = {"files": [{"filename": "h-common/src/lib.rs",
+                          "summary": {"lines": {"count": 100, "covered": 80}}}], "totals": {}}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(doc, f)
+            path = f.name
+        rc = sc.main(["--kind", "rs", "--json-file", path, "--gate", "--min", "90", "--no-gap-list"])
+        os.unlink(path)
+        self.assertEqual(rc, 1)
+
+    def test_text_log_written_without_ansi(self):
+        doc = {"files": [{"filename": "h-common/src/lib.rs",
+                          "summary": {"lines": {"count": 100, "covered": 90}}}], "totals": {}}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(doc, f)
+            path = f.name
+        log = path + ".txt"
+        rc = sc.main(["--kind", "rs", "--json-file", path, "--text-log", log, "--no-gap-list"])
+        self.assertEqual(rc, 0)
+        with open(log) as fh:
+            content = fh.read()
+        self.assertNotIn("\033[", content)
+        self.assertIn("Coverage", content)
+        os.unlink(path)
+        os.unlink(log)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/coverage/run_coverage_rs.sh
+++ b/scripts/coverage/run_coverage_rs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Rust workspace coverage via cargo-llvm-cov — a MERGED report.
+#
+# Two instrumented runs feed one merged report (so the `fault-injection`-gated
+# concurrent_tests in h-storage-duckdb contribute without forcing that
+# feature on for every crate):
+#
+#   1. `cargo llvm-cov test --workspace --no-report`           (default features)
+#   2. `cargo llvm-cov test -p h-storage-duckdb \
+#          --features fault-injection --no-report`              (gated suite)
+#
+# `--no-report` accumulates profraw into server/target/llvm-cov/ without
+# printing a report; `cargo llvm-cov merge` folds both profraw sets together;
+# `cargo llvm-cov report --json --summary-only` emits the merged numbers.
+# `cargo-llvm-cov` must be installed (`cargo install cargo-llvm-cov --locked`).
+#
+# Outputs live under gitignored server/target/llvm-cov/ (never committed).
+# The merged JSON is piped through summarize_coverage.py for the line-% +
+# per-crate + worst-uncovered summary.
+set -euo pipefail
+
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+RED='\033[0;31m'
+DIM='\033[2m'
+NC='\033[0m'
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$PROJECT_ROOT" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+cd "$PROJECT_ROOT"
+
+SERVER_DIR="server"
+OUT_DIR="$SERVER_DIR/target/llvm-cov"
+JSON_OUT="$OUT_DIR/coverage.json"
+TEXT_LOG="$OUT_DIR/coverage.txt"
+SUMMARY_PY="$PROJECT_ROOT/scripts/coverage/lib/summarize_coverage.py"
+HERON_COV_MIN="${HERON_COV_MIN:-90}"
+GATE="${HERON_COV_GATE:-0}"
+
+usage() {
+    echo ""
+    echo "🧪 just test coverage rs   Rust workspace coverage (cargo-llvm-cov, merged)"
+    echo ""
+    echo "   Env:"
+    echo "     HERON_COV_MIN=<pct>   gate threshold (default 90)"
+    echo "     HERON_COV_GATE=1      exit 1 if coverage < threshold (default: report-only)"
+    echo ""
+}
+
+# ── preflight ──────────────────────────────────────────────────────────────
+if ! command -v cargo >/dev/null 2>&1; then
+    echo -e "${RED}✗ cargo not found on PATH${NC}" >&2
+    exit 1
+fi
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
+    echo -e "${RED}✗ cargo-llvm-cov not installed.${NC}" >&2
+    echo -e "  Install with:  cargo install cargo-llvm-cov --locked" >&2
+    echo -e "  (also needs the llvm-tools-preview rustup component)" >&2
+    exit 1
+fi
+rustup component add llvm-tools-preview >/dev/null 2>&1 || true
+
+mkdir -p "$OUT_DIR"
+
+# ── run 1: workspace, default features ─────────────────────────────────────
+echo -e "${BLUE}[rs] cargo llvm-cov test --workspace (default features)${NC}"
+(
+    cd "$SERVER_DIR"
+    cargo llvm-cov test --workspace --no-report --quiet
+)
+
+# ── run 2: fault-injection suite (the gated concurrent_tests) ─────────────
+# The fault-injection code is #[cfg(feature = "fault-injection")] so only THIS
+# run instruments it; the merge below folds both profraw sets into one report.
+echo -e "${BLUE}[rs] cargo llvm-cov test -p h-storage-duckdb --features fault-injection${NC}"
+(
+    cd "$SERVER_DIR"
+    cargo llvm-cov test -p h-storage-duckdb --features fault-injection --no-report --quiet
+)
+
+# ── merge the two profraw runs, then emit the merged report ─────────────────
+# `merge --no-report` folds both runs' profraw into one profdata; `--ignore-run-version`
+# tolerates the recompile the fault-injection feature forces on h-storage-duckdb.
+echo -e "${BLUE}[rs] cargo llvm-cov merge → report${NC}"
+(
+    cd "$SERVER_DIR"
+    cargo llvm-cov merge --no-report --ignore-run-version >/dev/null
+    cargo llvm-cov report --json --summary-only >"$PROJECT_ROOT/$JSON_OUT"
+)
+
+# Also write a human text report (raw llvm-cov text view) alongside the JSON.
+(
+    cd "$SERVER_DIR"
+    cargo llvm-cov report --text 2>/dev/null >"$OUT_DIR/coverage-raw.txt" || true
+)
+
+# ── summarize ──────────────────────────────────────────────────────────────
+GATE_FLAG=""
+if [ "$GATE" = "1" ]; then
+    GATE_FLAG="--gate"
+fi
+
+python3 "$SUMMARY_PY" \
+    --kind rs \
+    --json-file "$JSON_OUT" \
+    --text-log "$TEXT_LOG" \
+    --min "$HERON_COV_MIN" \
+    --top 20 \
+    $GATE_FLAG
+
+echo -e "${DIM}artifacts: $JSON_OUT${NC}"
+echo -e "${DIM}          $TEXT_LOG${NC}"

--- a/scripts/coverage/run_coverage_ts.sh
+++ b/scripts/coverage/run_coverage_ts.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Console (frontend) coverage via `bun test --coverage`.
+#
+# Bun emits two reporters: `text` (to stdout, for the developer) and `json`
+# (to a file under --coverage-dir). Bun's own aggregate totals include the
+# very test/fixture files the gate must NOT count, so this script does NOT
+# trust them — it pipes the JSON through summarize_coverage.py, which walks
+# console/src/**/*.{ts,tsx} itself (excluding .test./.spec./__fixtures__/
+# fixtures/__mocks__/.d.ts) and recomputes the denominator from raw counts.
+#
+# A source file Bun never instrumented (a leaf module no test touches) enters
+# the denominator with its real line count and zero covered — the honest gap.
+#
+# Outputs live under gitignored console/coverage/ (never committed).
+set -euo pipefail
+
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+RED='\033[0;31m'
+DIM='\033[2m'
+NC='\033[0m'
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$PROJECT_ROOT" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+cd "$PROJECT_ROOT"
+
+CONSOLE_DIR="console"
+COV_DIR="$CONSOLE_DIR/coverage"
+TEXT_LOG="$COV_DIR/coverage.txt"
+SUMMARY_PY="$PROJECT_ROOT/scripts/coverage/lib/summarize_coverage.py"
+HERON_COV_MIN="${HERON_COV_MIN:-90}"
+GATE="${HERON_COV_GATE:-0}"
+
+usage() {
+    echo ""
+    echo "🧪 just test coverage ts   Console coverage (bun test --coverage)"
+    echo ""
+    echo "   Env:"
+    echo "     HERON_COV_MIN=<pct>   gate threshold (default 90)"
+    echo "     HERON_COV_GATE=1      exit 1 if coverage < threshold (default: report-only)"
+    echo ""
+}
+
+# ── preflight ──────────────────────────────────────────────────────────────
+if ! command -v bun >/dev/null 2>&1; then
+    echo -e "${RED}✗ bun not found on PATH${NC}" >&2
+    exit 1
+fi
+mkdir -p "$COV_DIR"
+
+# ── run ─────────────────────────────────────────────────────────────────────
+# Both reporters: json → file (parsed below), text → stdout (live view).
+echo -e "${BLUE}[ts] bun test --coverage${NC}"
+(
+    cd "$CONSOLE_DIR"
+    bun test --coverage \
+        --coverage-reporter=text \
+        --coverage-reporter=json \
+        --coverage-dir="$PROJECT_ROOT/$COV_DIR"
+)
+
+# ── locate the JSON report Bun wrote ───────────────────────────────────────
+# Bun's JSON filename has varied across versions (bun-coverage.json /
+# coverage.json). Pick the newest .json in the coverage dir.
+JSON_OUT=""
+JSON_OUT="$(find "$COV_DIR" -maxdepth 2 -name '*.json' -type f -printf '%T@ %p\n' 2>/dev/null \
+    | sort -rn | head -1 | cut -d' ' -f2-)"
+if [ -z "$JSON_OUT" ]; then
+    echo -e "${RED}✗ no coverage JSON found under $COV_DIR${NC}" >&2
+    echo -e "  (did bun write the json reporter to a different path?)" >&2
+    exit 1
+fi
+
+# ── summarize (summarizer enforces the denominator itself) ──────────────────
+GATE_FLAG=""
+if [ "$GATE" = "1" ]; then
+    GATE_FLAG="--gate"
+fi
+
+python3 "$SUMMARY_PY" \
+    --kind ts \
+    --json-file "$JSON_OUT" \
+    --text-log "$TEXT_LOG" \
+    --console-root "$CONSOLE_DIR" \
+    --min "$HERON_COV_MIN" \
+    --top 20 \
+    $GATE_FLAG
+
+echo -e "${DIM}artifacts: $JSON_OUT${NC}"
+echo -e "${DIM}          $TEXT_LOG${NC}"

--- a/scripts/routers/shared/test.sh
+++ b/scripts/routers/shared/test.sh
@@ -18,6 +18,12 @@ show_help() {
     echo "   just test rs [filter]     cargo test (optional filter)"
     echo "   just test ts              bun test in console/"
     echo "   just test crate <name>    Test a single workspace crate"
+    echo ""
+    echo "📊 Coverage (cargo-llvm-cov + bun test --coverage)"
+    echo "   just test coverage         Both stacks, report-only (no gate)"
+    echo "   just test coverage rs       Rust only (merged report incl. fault-injection)"
+    echo "   just test coverage ts       Console only (denominator over src/**)"
+    echo "   just test coverage gate     Hard-fail if either < HERON_COV_MIN (default 90)"
 }
 
 run_rs() {
@@ -38,6 +44,37 @@ run_crate() {
     (cd server && cargo test -p "$name" "$@")
 }
 
+# Coverage (cargo-llvm-cov for Rust, bun test --coverage for TS).
+# `just test coverage [rs|ts|gate]` — the gate hard-fails locally below
+# HERON_COV_MIN (default 90); plain `coverage`/`rs`/`ts` are report-only.
+run_coverage() {
+    local sub="${1:-all}"
+    case "$sub" in
+        all|"")
+            # Both stacks, report-only (no gate). The gate script is only used
+            # for the explicit `gate` sub-command so it can hard-fail.
+            bash scripts/coverage/run_coverage_rs.sh
+            bash scripts/coverage/run_coverage_ts.sh
+            ;;
+        rs|rust)
+            shift 2>/dev/null || true
+            bash scripts/coverage/run_coverage_rs.sh "$@"
+            ;;
+        ts|typescript)
+            shift 2>/dev/null || true
+            bash scripts/coverage/run_coverage_ts.sh "$@"
+            ;;
+        gate)
+            bash scripts/coverage/coverage-gate.sh
+            ;;
+        *)
+            echo "Unknown coverage sub-command: $sub" >&2
+            echo "Run 'just test coverage' for help." >&2
+            exit 1
+            ;;
+    esac
+}
+
 ACTION="${1:-help}"
 shift 2>/dev/null || true
 
@@ -46,6 +83,7 @@ case "$ACTION" in
     rs|rust|server) run_rs "$@" ;;
     ts|typescript|console) run_ts "$@" ;;
     crate|pkg|p) run_crate "$@" ;;
+    coverage|cov) run_coverage "$@" ;;
     help|--help|-h) show_help ;;
     *) echo "Unknown: $ACTION. Run 'just test' for help."; exit 1 ;;
 esac


### PR DESCRIPTION
Automated pull request for Hera task `3dde5fa1-2c43-4d9f-98d9-ec632320adb9`.

INPUT: approved design §2/§7; existing `scripts/routers/shared/test.sh` + `ci.yml`.
WORK: Add `cargo-llvm-cov` workflow for the `server/` workspace (merged report including at least default workspace tests + `h-storage-duckdb --features fault-injection`); add `bun test --coverage` for `console/` with denominator over `src/**/*.{ts,tsx}` excluding tests/fixtures; extend `just test coverage|coverage rs|coverage ts|coverage gate` (gate may hard-fail locally but CI stays report-only); write outputs under ignored paths; print overall line %, per-crate/per-dir summary, and worst uncovered files; document commands in just help (and a short README note if needed); add CI coverage job/steps that publish numbers without failing on threshold.