### PR TITLE
hera: eBPF common tests, prog inventory, userspace coverage merge

### DIFF
--- a/docs/design/02-capture.md
+++ b/docs/design/02-capture.md
@@ -131,6 +131,36 @@ sources leave it `None`.
   tuple plus mid-stream sync, which the wire-API identification (method / URI /
   Host, not IP) is unaffected by.
 
+### Testability split (what's host-tested vs. what isn't)
+
+The eBPF path is split along a hard line — the kernel BPF verifier — so each
+piece is tested where it can be:
+
+- **Host unit-tested on every platform** (no BPF toolchain, no `CAP_BPF`):
+  - `h-ebpf-common` — the shared `#[repr(C)]` `SslEvent` layout / constants /
+    sizes (the contract the BPF program and userspace agree on).
+  - `h-capture` `ebpf/{decode,offsets,sigscan,synth}` — the ring-buffer decoder,
+    the static-target byte-signature offset resolver, the ELF scanner, and the
+    plaintext→TCP-frame synthesizer. These are pure over their inputs; they were
+    hoisted out of the Linux/aya-gated loader precisely so they build and run
+    on macOS dev and the Linux CI alike.
+- **Kernel-only, end-to-end soak-validated** (`ebpf-soak` workflow on staging):
+  - `h-ebpf-prog` — the BPF program itself. Its emit helpers
+    (`emit_chunk_at`, the unrolled `emit_data`, `stream_off`/`set_stream_off`)
+    are `#[inline(always)]` / unrolled because the 5.15 BPF verifier rejects a
+    loop back-edge and a BPF-to-BPF call. That makes them **not
+    verifier-safe** to extract to a callable, host-testable function — so the
+    whole program is the residual BPF-only surface. See
+    [`h-ebpf-prog/README.md`](../../server/h-ebpf-prog/README.md) for the full
+    probe/map/emit-path inventory and the residual-line list.
+
+The `--features ebpf` host-test coverage run (see
+[`scripts/coverage/run_coverage_rs.sh`](../../scripts/coverage/run_coverage_rs.sh))
+instruments whatever userspace unit tests remain behind the feature on a Linux
+host with the BPF toolchain; the aya loader (`ebpf/source.rs`) is excluded from
+that report as an environment-gated integration surface (it needs `CAP_BPF`).
+
+
 Config lives under a `type = "ebpf"` source — see
 [Configure → eBPF source](../configure.md#ebpf--on-host-tls-capture-linux-experimental).
 

--- a/scripts/coverage/run_coverage_rs.sh
+++ b/scripts/coverage/run_coverage_rs.sh
@@ -1,16 +1,35 @@
 #!/usr/bin/env bash
 # Rust workspace coverage via cargo-llvm-cov — a MERGED report.
 #
-# Two instrumented runs feed one merged report (so the `fault-injection`-gated
-# concurrent_tests in h-storage-duckdb contribute without forcing that
-# feature on for every crate):
+# Up to three instrumented runs feed one merged report, so a feature-gated
+# suite can contribute without forcing that feature on for every crate:
 #
 #   1. `cargo llvm-cov test --workspace --no-report`           (default features)
 #   2. `cargo llvm-cov test -p h-storage-duckdb \
 #          --features fault-injection --no-report`              (gated suite)
+#   3. `cargo llvm-cov test -p h-capture \
+#          --features ebpf --no-report`                          (eBPF userspace)
+#
+# Run 3 is Linux-only and best-effort: building h-capture with `--features ebpf`
+# compiles the BPF program out-of-band (build.rs → `rustup run nightly …
+# bpfel-unknown-none` + `bpf-linker`), so it only runs when the nightly BPF
+# toolchain is installed. Its host unit tests are the eBPF *userspace* contract
+# (the pure decoder/offset/synth helpers live in always-compiled modules that
+# run 1 already instruments; run 3 catches anything that lands behind the
+# feature later). It is merged only when it actually builds — otherwise it is
+# skipped with a one-line notice (the "when they add measurable lines" gate).
+#
+# eBPF measurement exception: the aya loader (`h-capture/src/ebpf/source.rs`)
+# is environment-gated integration code — it needs `CAP_BPF` + the BPF toolchain
+# to even build and has no host unit tests — so it is EXCLUDED from the report
+# (`--ignore-filename-regex`), never dragging the gate down. The pure layout
+# (`h-ebpf-common`), the decoder, the offset resolver, and the synthesizer are
+# NOT excluded; they are the host-tested contract. See
+# `server/h-ebpf-prog/README.md` for the BPF inventory + residual-line list and
+# `docs/design/02-capture.md` § "Testability split".
 #
 # `--no-report` accumulates profraw into server/target/llvm-cov/ without
-# printing a report; `cargo llvm-cov merge` folds both profraw sets together;
+# printing a report; `cargo llvm-cov merge` folds all profraw sets together;
 # `cargo llvm-cov report --json --summary-only` emits the merged numbers.
 # `cargo-llvm-cov` must be installed (`cargo install cargo-llvm-cov --locked`).
 #
@@ -40,13 +59,30 @@ SUMMARY_PY="$PROJECT_ROOT/scripts/coverage/lib/summarize_coverage.py"
 HERON_COV_MIN="${HERON_COV_MIN:-90}"
 GATE="${HERON_COV_GATE:-0}"
 
+# eBPF measurement exception: the aya loader is environment-gated integration
+# code (CAP_BPF + the BPF toolchain to build; no host unit tests), so it is
+# excluded from the coverage report. Everything else in the eBPF path — the
+# shared layout, the decoder, the offset resolver, the synthesizer — IS host
+# tested and stays in the report.
+EBPF_IGNORE='ebpf/source\.rs$'
+
 usage() {
     echo ""
     echo "🧪 just test coverage rs   Rust workspace coverage (cargo-llvm-cov, merged)"
     echo ""
+    echo "   Merges up to 3 runs: workspace (default), h-storage-duckdb"
+    echo "   --features fault-injection, and h-capture --features ebpf (Linux +"
+    echo "   the nightly BPF toolchain only; skipped otherwise)."
+    echo ""
+    echo "   eBPF measurement exception: h-capture/src/ebpf/source.rs (the aya"
+    echo "   loader) is excluded — it needs CAP_BPF + the BPF toolchain to build"
+    echo "   and has no host unit tests. The pure eBPF layout/decoder/offset/"
+    echo "   synth modules are NOT excluded (host-tested contract)."
+    echo ""
     echo "   Env:"
     echo "     HERON_COV_MIN=<pct>   gate threshold (default 90)"
     echo "     HERON_COV_GATE=1      exit 1 if coverage < threshold (default: report-only)"
+    echo "     HERON_COV_EBPF=0      skip the eBPF-feature run even on a BPF host (default: auto)"
     echo ""
 }
 
@@ -81,20 +117,57 @@ echo -e "${BLUE}[rs] cargo llvm-cov test -p h-storage-duckdb --features fault-in
     cargo llvm-cov test -p h-storage-duckdb --features fault-injection --no-report --quiet
 )
 
-# ── merge the two profraw runs, then emit the merged report ─────────────────
-# `merge --no-report` folds both runs' profraw into one profdata; `--ignore-run-version`
-# tolerates the recompile the fault-injection feature forces on h-storage-duckdb.
+# ── run 3: eBPF userspace unit tests (Linux + nightly BPF toolchain) ───────
+# `--features ebpf` compiles the BPF program out-of-band (build.rs), so this
+# only runs where the nightly toolchain + bpf-linker are installed. Best-effort:
+# a build failure (no/missing toolchain) is logged and skipped — it must not
+# fail the coverage run. The eBPF userspace contract (decode/offsets/synth) is
+# already instrumented by run 1 (always-compiled modules); this run catches
+# anything that lands behind the feature later and is merged only when it
+# builds ("when they add measurable lines"). Disable explicitly with
+# HERON_COV_EBPF=0.
+ebpf_toolchain_ready() {
+    [ "$(uname -s)" = "Linux" ] || return 1
+    [ "${HERON_COV_EBPF:-1}" != "0" ] || return 1
+    # Cheap fast-path so a host without the BPF toolchain doesn't attempt a
+    # long doomed compile. build.rs needs: the nightly toolchain (for
+    # `-Z build-std=core` + rust-src) and bpf-linker. `bpfel-unknown-none` is a
+    # built-in rustc target (used with build-std), so it is NOT `rustup target
+    # add`'d — we don't (and can't) check `rustup target list --installed`.
+    rustup toolchain list 2>/dev/null | grep -q nightly || return 1
+    command -v bpf-linker >/dev/null 2>&1 || return 1
+    return 0
+}
+
+if ebpf_toolchain_ready; then
+    echo -e "${BLUE}[rs] cargo llvm-cov test -p h-capture --features ebpf (userspace, Linux)${NC}"
+    if (cd "$SERVER_DIR" && cargo llvm-cov test -p h-capture --features ebpf --no-report --quiet); then
+        echo -e "${DIM}[rs] eBPF-feature run merged${NC}"
+    else
+        echo -e "${DIM}[rs] eBPF-feature run skipped (build failed — BPF toolchain incomplete); pure userspace ebpf tests already in run 1${NC}"
+    fi
+else
+    echo -e "${DIM}[rs] eBPF-feature run skipped (not Linux / BPF toolchain not installed); pure userspace ebpf tests already in run 1${NC}"
+fi
+
+# ── merge all profraw runs, then emit the merged report ────────────────────
+# `merge --no-report` folds every run's profraw into one profdata;
+# `--ignore-run-version` tolerates the recompiles the feature runs force.
+# The report step drops the aya loader (`ebpf/source.rs`) via
+# --ignore-filename-regex — the eBPF measurement exception (see header).
 echo -e "${BLUE}[rs] cargo llvm-cov merge → report${NC}"
 (
     cd "$SERVER_DIR"
     cargo llvm-cov merge --no-report --ignore-run-version >/dev/null
-    cargo llvm-cov report --json --summary-only >"$PROJECT_ROOT/$JSON_OUT"
+    cargo llvm-cov report --json --summary-only \
+        --ignore-filename-regex "$EBPF_IGNORE" >"$PROJECT_ROOT/$JSON_OUT"
 )
 
 # Also write a human text report (raw llvm-cov text view) alongside the JSON.
 (
     cd "$SERVER_DIR"
-    cargo llvm-cov report --text 2>/dev/null >"$OUT_DIR/coverage-raw.txt" || true
+    cargo llvm-cov report --text --ignore-filename-regex "$EBPF_IGNORE" \
+        2>/dev/null >"$OUT_DIR/coverage-raw.txt" || true
 )
 
 # ── summarize ──────────────────────────────────────────────────────────────

--- a/scripts/routers/shared/test.sh
+++ b/scripts/routers/shared/test.sh
@@ -24,6 +24,14 @@ show_help() {
     echo "   just test coverage rs       Rust only (merged report incl. fault-injection)"
     echo "   just test coverage ts       Console only (denominator over src/**)"
     echo "   just test coverage gate     Hard-fail if either < HERON_COV_MIN (default 90)"
+    echo ""
+    echo "   eBPF measurement exception: the Rust run also attempts a"
+    echo "   --features ebpf userspace run on Linux (nightly BPF toolchain only;"
+    echo "   skipped otherwise). The aya loader (h-capture/src/ebpf/source.rs) is"
+    echo "   excluded from the report — it needs CAP_BPF + the BPF toolchain to"
+    echo "   build and has no host unit tests. The pure eBPF layout/decoder/"
+    echo "   offset/synth modules are NOT excluded (host-tested contract). See"
+    echo "   server/h-ebpf-prog/README.md for the BPF inventory + residual lines."
 }
 
 run_rs() {

--- a/server/h-capture/Cargo.toml
+++ b/server/h-capture/Cargo.toml
@@ -8,8 +8,13 @@ license.workspace = true
 # eBPF SSL-uprobe capture (Linux only). Off by default so macOS dev builds and
 # the Linux CI stay green without the aya/BPF toolchain. Enables the aya loader
 # (`src/ebpf/source.rs`) + the out-of-band BPF program build (build.rs +
-# aya-build). The cross-platform pump (`src/ebpf/mod.rs`) is always built/tested.
-ebpf = ["dep:aya", "dep:h-ebpf-common", "tokio/net"]
+# aya-build). The cross-platform pump (`src/ebpf/mod.rs`), the ring-buffer
+# decoder (`src/ebpf/decode.rs`), and the static-target offset resolver
+# (`src/ebpf/offsets.rs`) are always built/tested — only the aya loader is
+# feature-gated. `h-ebpf-common` is a plain (non-optional) dep because the
+# decoder, always compiled, needs the shared `SslEvent` layout; that crate is
+# dependency-free `no_std` so it builds on every host.
+ebpf = ["dep:aya", "tokio/net"]
 
 [dependencies]
 h-common.workspace = true
@@ -24,12 +29,16 @@ thiserror.workspace = true
 tokio-util.workspace = true
 serde.workspace = true
 snap = "1"
+# The shared `SslEvent` ring-buffer layout — dependency-free `no_std`, so it
+# builds on every host. Always a dep: the cross-platform decoder
+# (`src/ebpf/decode.rs`) reads it back from raw bytes and is built/tested
+# everywhere (not just behind the `ebpf` feature).
+h-ebpf-common = { path = "../h-ebpf-common" }
 
 # eBPF deps are Linux-only and optional (pulled in only by the `ebpf` feature),
 # so neither macOS nor a default Linux build compiles them.
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { version = "0.13", optional = true }
-h-ebpf-common = { path = "../h-ebpf-common", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/server/h-capture/src/ebpf/decode.rs
+++ b/server/h-capture/src/ebpf/decode.rs
@@ -1,0 +1,275 @@
+//! Decode the eBPF ring-buffer record into the cross-platform [`SslEvent`].
+//!
+//! This is the userspace half of the contract that `h-ebpf-common` pins from
+//! the BPF side: a `SslEvent` (`#[repr(C)]`, POD) arrives as an unaligned byte
+//! slice in the ring buffer, and [`decode_event`] reads it back into the
+//! [`crate::ebpf::SslEvent`] the pump consumes. It is pure over the input
+//! bytes — no kernel, no aya, no tokio — so the decode logic (and its
+//! direction mapping, `data_len` clamping, NUL-trimmed `comm`, best-effort
+//! `/proc/<pid>/exe` attribution) is unit-tested on every host without the BPF
+//! toolchain or `CAP_BPF`. The Linux-only loader feeds it real ring-buffer
+//! slices; tests feed it hand-built records.
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+
+use h_ebpf_common::{kind, SslEvent as RawSslEvent, DATA_CAP};
+
+use crate::ebpf::SslEvent;
+use crate::synth::StreamDir;
+
+/// Cap on the pid→exe memo so a long capture across heavy pid churn can't grow
+/// it without bound. Cleared wholesale on overflow (cheap; re-warms on demand).
+pub(crate) const EXE_CACHE_CAP: usize = 4096;
+
+/// Decode one ring-buffer record into a cross-platform [`SslEvent`].
+///
+/// Returns `None` for a short slice or an unknown `kind` (the loader drops the
+/// record and bumps `EbpfEventsDropped`). `data_len` is clamped to `DATA_CAP` so
+/// a corrupt/garbage record can't index past the inline payload array.
+//
+// `clippy::cast_ptr_alignment`: the ring buffer hands an unaligned `&[u8]`
+// slice; the cast to the POD record is deliberate and paired with
+// `read_unaligned` (never a ref/deref), so the higher-alignment cast is safe.
+#[allow(clippy::cast_ptr_alignment)]
+pub(crate) fn decode_event(
+    bytes: &[u8],
+    exe_cache: &mut HashMap<u32, Option<String>>,
+) -> Option<SslEvent> {
+    if bytes.len() < RawSslEvent::SIZE {
+        return None;
+    }
+    // The ring buffer gives an unaligned slice; read the POD struct unaligned.
+    let raw: RawSslEvent = unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RawSslEvent) };
+    let comm = comm_to_string(&raw.comm);
+    match raw.kind {
+        kind::CLOSE => Some(SslEvent::Close {
+            conn_id: raw.conn_id,
+            ktime_ns: raw.ktime_ns,
+        }),
+        kind::DATA_WRITE | kind::DATA_READ => {
+            let len = (raw.data_len as usize).min(DATA_CAP);
+            let dir = if raw.kind == kind::DATA_WRITE {
+                StreamDir::ClientToServer
+            } else {
+                StreamDir::ServerToClient
+            };
+            Some(SslEvent::Data {
+                conn_id: raw.conn_id,
+                pid: raw.pid,
+                comm,
+                exe: resolve_exe(raw.pid, exe_cache),
+                dir,
+                data: Bytes::copy_from_slice(&raw.data[..len]),
+                seq_off: raw.seq_off,
+                ktime_ns: raw.ktime_ns,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Best-effort `/proc/<pid>/exe` resolution, memoized. Returns the absolute
+/// executable path, or `None` when the link can't be read (process exited,
+/// permission denied, or a platform with no `/proc`). Requires the capturing
+/// process to out-rank the target — satisfied when running as root /
+/// CAP_SYS_PTRACE, which the eBPF source needs anyway.
+pub(crate) fn resolve_exe(pid: u32, cache: &mut HashMap<u32, Option<String>>) -> Option<String> {
+    if let Some(v) = cache.get(&pid) {
+        return v.clone();
+    }
+    if cache.len() >= EXE_CACHE_CAP {
+        cache.clear();
+    }
+    // `/proc/<pid>/exe` is Linux-only; on a platform without `/proc` the
+    // readlink fails and we get `None`, which is the correct "no attribution"
+    // result. (Cross-platform callers use it for the decode contract; the live
+    // loader only runs on Linux where `/proc` exists.)
+    let resolved = std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+    cache.insert(pid, resolved.clone());
+    resolved
+}
+
+/// A kernel `comm` (`bpf_get_current_comm`) is NUL-padded; trim to the first
+/// NUL (or the whole field if none), lossy over non-UTF-8.
+pub(crate) fn comm_to_string(comm: &[u8]) -> String {
+    let end = comm.iter().position(|&b| b == 0).unwrap_or(comm.len());
+    String::from_utf8_lossy(&comm[..end]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Decode contract: bytes → `SslEvent`. These run on every host (no aya,
+    //! no `CAP_BPF`), pinning the direction mapping, `data_len` clamp, comm
+    //! NUL-trim, and short-record rejection the live loader depends on.
+
+    use super::*;
+
+    /// A `SslEvent` record with `data_len` valid bytes in the inline payload,
+    /// serialized into a byte vec the way the ring buffer hands it to the
+    /// loader. Built from an aligned stack value then copied out with
+    /// `write_unaligned` — mirroring the loader's `read_unaligned` — so the
+    /// test never performs a misaligned field write (UB) through the buffer.
+    fn raw_record(kind: u32, pid: u32, conn_id: u64, comm: &[u8], data: &[u8]) -> Vec<u8> {
+        raw_record_len(kind, pid, conn_id, comm, data, data.len() as u32)
+    }
+
+    /// Same as [`raw_record`] but with an explicit, possibly forged `data_len`
+    /// (used to assert the decoder clamps a record that claims more payload than
+    /// the inline array holds).
+    #[allow(clippy::cast_ptr_alignment)] // deliberate unaligned write (mirrors decode)
+    fn raw_record_len(
+        kind: u32,
+        pid: u32,
+        conn_id: u64,
+        comm: &[u8],
+        data: &[u8],
+        data_len: u32,
+    ) -> Vec<u8> {
+        let mut raw = RawSslEvent {
+            kind,
+            pid,
+            conn_id,
+            ktime_ns: 1_000_000,
+            seq_off: 0,
+            data_len,
+            comm: [0; h_ebpf_common::COMM_LEN],
+            data: [0; DATA_CAP],
+        };
+        let n = comm.len().min(h_ebpf_common::COMM_LEN);
+        raw.comm[..n].copy_from_slice(&comm[..n]);
+        let m = data.len().min(DATA_CAP);
+        raw.data[..m].copy_from_slice(&data[..m]);
+        let mut bytes = vec![0u8; RawSslEvent::SIZE];
+        unsafe { std::ptr::write_unaligned(bytes.as_mut_ptr() as *mut RawSslEvent, raw) };
+        bytes
+    }
+
+    #[test]
+    fn close_event_decodes_without_payload_or_pid() {
+        let mut cache = HashMap::new();
+        let bytes = raw_record(kind::CLOSE, 0, 42, b"", &[]);
+        let ev = decode_event(&bytes, &mut cache).expect("CLOSE decodes");
+        match ev {
+            SslEvent::Close { conn_id, ktime_ns } => {
+                assert_eq!(conn_id, 42);
+                assert_eq!(ktime_ns, 1_000_000);
+            }
+            other => panic!("expected Close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_event_maps_to_client_to_server_with_seq_off_and_data() {
+        let mut cache = HashMap::new();
+        let payload = b"POST /v1/messages HTTP/1.1\r\n\r\n";
+        let bytes = raw_record(kind::DATA_WRITE, 4242, 7, b"node\0", payload);
+        let ev = decode_event(&bytes, &mut cache).expect("DATA_WRITE decodes");
+        match ev {
+            SslEvent::Data {
+                conn_id,
+                pid,
+                comm,
+                dir,
+                data,
+                seq_off,
+                ..
+            } => {
+                assert_eq!(conn_id, 7);
+                assert_eq!(pid, 4242);
+                assert_eq!(comm, "node");
+                assert_eq!(dir, StreamDir::ClientToServer);
+                assert_eq!(&data[..], payload);
+                assert_eq!(seq_off, 0);
+            }
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_event_maps_to_server_to_client() {
+        let mut cache = HashMap::new();
+        let payload = b"HTTP/1.1 200 OK\r\n\r\n";
+        let bytes = raw_record(kind::DATA_READ, 1, 9, b"curl\0\0", payload);
+        let ev = decode_event(&bytes, &mut cache).expect("DATA_READ decodes");
+        match ev {
+            SslEvent::Data { dir, comm, .. } => {
+                assert_eq!(dir, StreamDir::ServerToClient);
+                assert_eq!(comm, "curl");
+            }
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn data_len_clamped_to_data_cap_on_a_garbage_record() {
+        // A record claiming more bytes than DATA_CAP must not index past the
+        // inline array. With data_len = u32::MAX, decode clamps to DATA_CAP and
+        // copies only the (zero-filled) payload bytes — no out-of-bounds read.
+        let mut cache = HashMap::new();
+        let bytes = raw_record_len(kind::DATA_WRITE, 1, 1, b"x", &[0u8; 8], u32::MAX);
+        let ev = decode_event(&bytes, &mut cache).expect("clamps, not rejects");
+        match ev {
+            SslEvent::Data { data, .. } => assert_eq!(data.len(), DATA_CAP),
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn short_record_is_rejected() {
+        let mut cache = HashMap::new();
+        // One byte short of a full record → no decode (the loader drops it).
+        let mut bytes = raw_record(kind::CLOSE, 0, 1, b"", &[]);
+        bytes.pop();
+        assert!(decode_event(&bytes, &mut cache).is_none());
+    }
+
+    #[test]
+    fn unknown_kind_is_rejected() {
+        let mut cache = HashMap::new();
+        let bytes = raw_record(99, 0, 1, b"", &[]);
+        assert!(decode_event(&bytes, &mut cache).is_none());
+    }
+
+    #[test]
+    fn comm_is_nul_trimmed_and_lossy() {
+        let mut cache = HashMap::new();
+        // "node" then a NUL then padding — only "node" survives, and a
+        // non-UTF-8 byte elsewhere would be lossy (validated by from_utf8_lossy).
+        let comm = b"node\0garbage";
+        let bytes = raw_record(kind::DATA_WRITE, 1, 1, comm, b"hi");
+        let ev = decode_event(&bytes, &mut cache).expect("decodes");
+        match ev {
+            SslEvent::Data { comm, .. } => assert_eq!(comm, "node"),
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_exe_memoizes_and_caches_none_on_failure() {
+        // PID 0 is never a real process; readlink fails (or `/proc` is absent)
+        // → None, cached so the lookup isn't retried per event.
+        let mut cache = HashMap::new();
+        assert!(resolve_exe(0, &mut cache).is_none());
+        assert!(cache.contains_key(&0), "the None is cached");
+        // Second call hits the cache (no new syscall), still None.
+        assert!(resolve_exe(0, &mut cache).is_none());
+    }
+
+    #[test]
+    fn exe_cache_clears_wholesale_on_overflow() {
+        let mut cache = HashMap::new();
+        // Fill to the cap with distinct pids so the next insert trips the cap.
+        for pid in 1..=EXE_CACHE_CAP {
+            cache.insert(pid as u32, None);
+        }
+        assert_eq!(cache.len(), EXE_CACHE_CAP);
+        resolve_exe(EXE_CACHE_CAP as u32 + 1, &mut cache);
+        // The overflow path clears the whole map then re-inserts the one pid.
+        assert!(cache.len() <= 2, "cleared on overflow, not grown past cap");
+        assert!(cache.contains_key(&(EXE_CACHE_CAP as u32 + 1)));
+    }
+}

--- a/server/h-capture/src/ebpf/mod.rs
+++ b/server/h-capture/src/ebpf/mod.rs
@@ -38,6 +38,15 @@ mod source;
 #[cfg(all(target_os = "linux", feature = "ebpf"))]
 pub use source::EbpfSource;
 
+// Pure helpers split out of the Linux/aya-gated `source.rs` so the testable
+// surface — ring-buffer decode (`decode`) and static-target offset resolution
+// (`offsets`) — builds and runs on every host without the BPF toolchain or
+// `CAP_BPF`. The loader imports these; its own code is only aya attach glue.
+// Private modules: only `ebpf`'s siblings (the loader) reach them via the
+// `crate::ebpf::` path; nothing outside the crate needs them.
+mod decode;
+mod offsets;
+
 // Byte-signature scanning for offset-based uprobe attach on symbol-stripped
 // static TLS stacks (Bun/BoringSSL, Phase 3). Pure + cross-platform so the
 // matcher is built and unit-tested on every host, like `synth`.
@@ -538,5 +547,53 @@ mod tests {
         for f in fins.iter().filter(|f| !f.is_heartbeat()) {
             assert!(f.process.is_none());
         }
+    }
+
+    /// End-to-end userspace contract: a raw `h-ebpf-common` ring-buffer record
+    /// (as the BPF program would write) → `decode::decode_event` → the pump →
+    /// synthesized frames, with no kernel, no aya, no `CAP_BPF`. This is the
+    /// path the live loader runs; testing it here means the BPF↔userspace ABI
+    /// stays green on every host.
+    #[test]
+    #[allow(clippy::cast_ptr_alignment)] // deliberate unaligned write (mirrors decode)
+    fn raw_record_decodes_and_pumps_to_frames_without_cap_bpf() {
+        use crate::ebpf::decode::decode_event;
+        use h_ebpf_common::{kind, SslEvent as RawSslEvent, DATA_CAP};
+        use std::collections::HashMap;
+
+        let mut p = pump(vec![]);
+        let mut cache = HashMap::new();
+
+        // A DATA_WRITE record carrying a real request line.
+        let mut raw = RawSslEvent {
+            kind: kind::DATA_WRITE,
+            pid: 100,
+            conn_id: 7,
+            ktime_ns: 1_000_000,
+            seq_off: 0,
+            data_len: 0,
+            comm: [0; h_ebpf_common::COMM_LEN],
+            data: [0; DATA_CAP],
+        };
+        let payload = b"POST /v1/messages HTTP/1.1\r\n\r\n";
+        raw.data_len = payload.len() as u32;
+        raw.comm[..5].copy_from_slice(b"node\0");
+        raw.data[..payload.len()].copy_from_slice(payload);
+        let mut bytes = vec![0u8; RawSslEvent::SIZE];
+        unsafe {
+            std::ptr::write_unaligned(bytes.as_mut_ptr() as *mut RawSslEvent, raw);
+        }
+
+        let ev = decode_event(&bytes, &mut cache).expect("record decodes");
+        // The pump needs the connection opened first (Phase 1: no connect
+        // kprobe, so the loader opens lazily on first data — on_event opens
+        // an unknown conn mid-stream). Feed the Data event directly.
+        let frames = p.on_event(ev);
+        assert_eq!(data_frame_count(&frames), 1, "one segment for the payload");
+        // Process attribution survives the round-trip.
+        let seg = frames.iter().find(|f| !f.is_heartbeat()).unwrap();
+        let proc = seg.process.as_ref().expect("process stamped");
+        assert_eq!(proc.pid, 100);
+        assert_eq!(proc.comm, "node");
     }
 }

--- a/server/h-capture/src/ebpf/offsets.rs
+++ b/server/h-capture/src/ebpf/offsets.rs
@@ -1,0 +1,307 @@
+//! Pure offset-resolution for static-binary (Bun / BoringSSL) eBPF targets.
+//!
+//! The Phase-3 static-target path (`crate::ebpf::source`) locates `SSL_read` /
+//! `SSL_write` in a symbol-stripped, statically-linked TLS stack by byte
+//! signature → ELF **file offset**, then attaches a uprobe at that offset.
+//! Resolving the offsets from a binary's bytes is pure (it touches no kernel,
+//! no aya, no tokio) — the fiddly part lives here, cross-platform, so it is
+//! unit-tested on every host without the BPF toolchain or `CAP_BPF`. The
+//! Linux-only loader keeps only the aya attach glue around these helpers.
+//!
+//! Everything here is deterministic over the input bytes: the same `data` +
+//! `target` always yield the same offsets, so a per-inode result can be cached
+//! as "seen" by the loader. Signatures are version-specific **data** (a
+//! prologue pins one statically-linked build), never logic — see
+//! [`flavor_signatures`] and the Phase-3 design note.
+
+use h_common::config::EbpfTarget;
+
+use crate::ebpf::sigscan::{scan_elf_executable, Signature};
+
+/// Built-in BoringSSL prologue signatures for a flavor, using the anchor +
+/// window technique. `SSL_read`'s prologue is distinctive enough to match
+/// uniquely; the `SSL_write` prologue is generic (a common register-save
+/// sequence appears many times), so it is located as the nearest match in a
+/// window *after* the `SSL_read` anchor — robust to the small per-build drift
+/// in the inter-function distance that a hardcoded delta would miss.
+pub(crate) struct FlavorSig {
+    /// Distinctive `SSL_read` prologue — must match uniquely (the anchor).
+    pub read_sig: &'static str,
+    /// `SSL_write` prologue — generic; resolved as the first match within
+    /// `write_window` bytes after the `SSL_read` anchor.
+    pub write_sig: &'static str,
+    pub write_window: u64,
+}
+
+/// Built-in signatures per flavor. Returns `None` for `boringssl` (generic): a
+/// prologue is specific to one statically-linked build, so a bare `boringssl`
+/// target must supply `write_sig`/`read_sig`/`*_offset` in config.
+///
+/// The `bun` signatures are the BoringSSL `SSL_read`/`SSL_write` x86-64
+/// prologues from Bun v1.3.x profile builds (the runtime Claude Code ships),
+/// matching the read-anchored, windowed-write approach from the eunomia-bpf
+/// AgentSight project (MIT). They are still version-bound data — a future Bun
+/// line may shift the prologue; override via config when that happens.
+pub(crate) fn flavor_signatures(flavor: &str) -> Option<FlavorSig> {
+    match flavor {
+        "bun" | "boringssl-bun" | "claude-code" => Some(FlavorSig {
+            read_sig: "55 48 89 e5 41 57 41 56 53 50 48 83 bf 98 00 00 00 00 74",
+            write_sig:
+                "55 48 89 e5 41 57 41 56 41 55 41 54 53 48 83 ec 18 41 89 d7 49 89 f6 48 89 fb",
+            write_window: 0x10000,
+        }),
+        _ => None,
+    }
+}
+
+/// Locate a function as the first signature match within `window` bytes after an
+/// `anchor` offset. Used for the generic `SSL_write` prologue once the unique
+/// `SSL_read` anchor is known — handles a prologue that occurs many times across
+/// the binary by scoping to the SSL function's neighborhood.
+pub(crate) fn resolve_windowed(
+    data: &[u8],
+    pattern: &str,
+    anchor: u64,
+    window: u64,
+    what: &str,
+    binary: &str,
+) -> Option<u64> {
+    let sig = Signature::parse(pattern)?;
+    let hit = scan_elf_executable(data, &sig)
+        .into_iter()
+        .find(|&o| o >= anchor && o < anchor.saturating_add(window));
+    match hit {
+        Some(off) => {
+            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x} (anchored)");
+            Some(off)
+        }
+        None => {
+            tracing::warn!(
+                "ebpf: {binary}: {what} not found within {window:#x} of anchor {anchor:#x}"
+            );
+            None
+        }
+    }
+}
+
+/// Resolve a unique uprobe file offset for `pattern` in `data`. Requires
+/// exactly one match: zero means a stale/wrong signature (skip, don't attach
+/// blindly), and more than one is ambiguous (a too-loose signature would attach
+/// the probe to the wrong function). Both cases log and return `None`.
+pub(crate) fn resolve_single_offset(
+    data: &[u8],
+    pattern: &str,
+    what: &str,
+    binary: &str,
+) -> Option<u64> {
+    let Some(sig) = Signature::parse(pattern) else {
+        tracing::warn!("ebpf: {binary}: malformed {what} signature {pattern:?}");
+        return None;
+    };
+    let hits = scan_elf_executable(data, &sig);
+    match hits.as_slice() {
+        [] => {
+            tracing::warn!("ebpf: {binary}: {what} signature matched nothing (wrong build?)");
+            None
+        }
+        [off] => {
+            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x}");
+            Some(*off)
+        }
+        many => {
+            tracing::warn!(
+                "ebpf: {binary}: {what} signature is ambiguous ({} matches) — refine it",
+                many.len()
+            );
+            None
+        }
+    }
+}
+
+/// Does this target carry enough config to resolve uprobe offsets at all?
+/// (an explicit offset, a config signature, or a flavor with built-in sigs.)
+pub(crate) fn target_has_source(target: &EbpfTarget) -> bool {
+    target.write_offset.is_some()
+        || target.read_offset.is_some()
+        || target.write_sig.is_some()
+        || target.read_sig.is_some()
+        || flavor_signatures(&target.flavor).is_some()
+}
+
+/// True if a `/proc/<pid>/exe` readlink target has the given basename. The
+/// kernel suffixes the link with `" (deleted)"` once the binary is unlinked by
+/// an auto-update, so strip that first. Matching by **basename** (not full path)
+/// is what lets us re-attach across npm's atomic-rename upgrade, which stages the
+/// new build in a `.<pkg>-<hash>/` dir before renaming it over the install path —
+/// the running process's exe then points into that now-deleted staging dir.
+pub(crate) fn exe_link_has_basename(link: &str, basename: &str) -> bool {
+    let path = link.strip_suffix(" (deleted)").unwrap_or(link);
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        == Some(basename)
+}
+
+/// Resolve SSL_read/SSL_write **file offsets** for a target from the given
+/// binary `data` (config offsets first, then config signatures, then built-in
+/// flavor signatures). Pure over `data` — same bytes always yield the same
+/// offsets, so a per-inode result can be cached as "seen".
+pub(crate) fn resolve_target_offsets(
+    data: &[u8],
+    target: &EbpfTarget,
+    label: &str,
+) -> (Option<u64>, Option<u64>) {
+    let mut read_off = target.read_offset;
+    let mut write_off = target.write_offset;
+    if read_off.is_some() && write_off.is_some() {
+        return (read_off, write_off);
+    }
+
+    // Config-supplied signatures take precedence and must match uniquely.
+    if read_off.is_none() {
+        if let Some(p) = &target.read_sig {
+            read_off = resolve_single_offset(data, p, "SSL_read", label);
+        }
+    }
+    if write_off.is_none() {
+        if let Some(p) = &target.write_sig {
+            write_off = resolve_single_offset(data, p, "SSL_write", label);
+        }
+    }
+
+    // Fall back to built-in flavor signatures: anchor on the unique SSL_read
+    // prologue, then locate SSL_write (generic prologue) as the nearest match in
+    // the window after it.
+    if let Some(fs) = flavor_signatures(&target.flavor) {
+        if read_off.is_none() {
+            read_off = resolve_single_offset(data, fs.read_sig, "SSL_read", label);
+        }
+        if write_off.is_none() {
+            match read_off {
+                Some(anchor) => {
+                    write_off = resolve_windowed(
+                        data,
+                        fs.write_sig,
+                        anchor,
+                        fs.write_window,
+                        "SSL_write",
+                        label,
+                    );
+                }
+                None => tracing::warn!(
+                    "ebpf: {label}: no SSL_read anchor — cannot locate SSL_write by window"
+                ),
+            }
+        }
+    }
+    (read_off, write_off)
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests ran only under `--features ebpf` when the helpers lived in
+    //! the Linux/aya-gated `source.rs`; hoisting them here makes the pure
+    //! offset-resolution logic run (and count toward coverage) on every host
+    //! without the BPF toolchain or `CAP_BPF`.
+
+    use super::*;
+
+    fn target(binary: &str, flavor: &str) -> EbpfTarget {
+        EbpfTarget {
+            binary: binary.to_string(),
+            flavor: flavor.to_string(),
+            write_sig: None,
+            read_sig: None,
+            write_offset: None,
+            read_offset: None,
+        }
+    }
+
+    #[test]
+    fn exe_link_basename_matches_plain_path() {
+        assert!(exe_link_has_basename(
+            "/home/user/.nvm/.../claude-code/bin/claude.exe",
+            "claude.exe"
+        ));
+    }
+
+    #[test]
+    fn exe_link_basename_matches_through_deleted_suffix() {
+        // After an npm atomic-rename auto-update the running process's exe points
+        // into the now-unlinked staging dir; the kernel appends " (deleted)".
+        // Basename matching must see through both the staging dir and the suffix.
+        assert!(exe_link_has_basename(
+            "/home/user/.nvm/.../@anthropic-ai/.claude-code-BLnYIOGh/bin/claude.exe (deleted)",
+            "claude.exe"
+        ));
+        assert!(exe_link_has_basename(
+            "/home/user/.nvm/.../opencode-ai/bin/opencode.exe (deleted)",
+            "opencode.exe"
+        ));
+    }
+
+    #[test]
+    fn exe_link_basename_rejects_other_binaries() {
+        assert!(!exe_link_has_basename("/usr/bin/node", "claude.exe"));
+        assert!(!exe_link_has_basename(
+            "/some/where/claude.exe.bak (deleted)",
+            "claude.exe"
+        ));
+    }
+
+    #[test]
+    fn target_has_source_requires_offset_sig_or_flavor() {
+        // Bare boringssl flavor with no offsets/sigs → not enough to attach.
+        assert!(!target_has_source(&target("/x/claude.exe", "boringssl")));
+        // A known flavor with built-in signatures is enough.
+        assert!(target_has_source(&target("/x/claude.exe", "bun")));
+        // An explicit offset is enough regardless of flavor.
+        let mut t = target("/x/claude.exe", "boringssl");
+        t.read_offset = Some(0x1000);
+        assert!(target_has_source(&t));
+    }
+
+    #[test]
+    fn resolve_offsets_passes_config_offsets_through_without_scanning() {
+        let mut t = target("/x/claude.exe", "boringssl");
+        t.read_offset = Some(0x4165_5e0);
+        t.write_offset = Some(0x4165_970);
+        // Empty data would make any scan fail; config offsets must short-circuit.
+        let (r, w) = resolve_target_offsets(&[], &t, "test");
+        assert_eq!(r, Some(0x4165_5e0));
+        assert_eq!(w, Some(0x4165_970));
+    }
+
+    /// A planted prologue at a known file offset is resolved by the built-in
+    /// `bun` flavor's `SSL_read` signature when it is the only match — the
+    /// read-anchored path the loader uses on a real stripped binary, but here
+    /// built from a tiny synthetic ELF so no real Bun binary is needed.
+    #[test]
+    fn flavor_signature_resolves_unique_read_anchor() {
+        // Reuse the sigscan ELF builder shape: a single exec PT_LOAD segment.
+        let mut elf = vec![0u8; 0x200];
+        elf[0..4].copy_from_slice(b"\x7fELF");
+        elf[4] = 2; // 64-bit
+        elf[5] = 1; // little-endian
+        elf[0x20..0x28].copy_from_slice(&0x40u64.to_le_bytes()); // e_phoff
+        elf[0x36..0x38].copy_from_slice(&56u16.to_le_bytes()); // e_phentsize
+        elf[0x38..0x3A].copy_from_slice(&1u16.to_le_bytes()); // e_phnum
+        let ph = 0x40;
+        elf[ph..ph + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+        elf[ph + 4..ph + 8].copy_from_slice(&0x1u32.to_le_bytes()); // PF_X
+        elf[ph + 8..ph + 16].copy_from_slice(&0x100u64.to_le_bytes()); // p_offset
+        elf[ph + 32..ph + 40].copy_from_slice(&0x80u64.to_le_bytes()); // p_filesz
+        // Plant the built-in bun SSL_read prologue at file offset 0x110.
+        let fs = flavor_signatures("bun").expect("bun has built-in signatures");
+        let sig = Signature::parse(fs.read_sig).expect("read_sig parses");
+        elf[0x110..0x110 + sig.len()].copy_from_slice(&sig.bytes);
+        // `target("…", "bun")` carries no config sig/offset → resolve falls back
+        // to the built-in flavor signatures (the read-anchored path).
+        let t = target("/x/claude.exe", "bun");
+        let (read_off, write_off) = resolve_target_offsets(&elf, &t, "test");
+        assert_eq!(read_off, Some(0x110), "anchored on the unique SSL_read match");
+        // No SSL_write planted in the window → write stays unresolved, not a
+        // bogus offset (the loader skips a target whose write is missing).
+        assert!(write_off.is_none(), "no SSL_write match → None, not a guess");
+    }
+}

--- a/server/h-capture/src/ebpf/source.rs
+++ b/server/h-capture/src/ebpf/source.rs
@@ -2,9 +2,10 @@
 //!
 //! Loads the embedded BPF program (`h-ebpf-prog`, built by `build.rs`), attaches
 //! uprobes to `SSL_write` / `SSL_read` / `SSL_shutdown` on the host's `libssl`,
-//! polls the ring buffer, decodes [`RawSslEvent`] records into the
-//! cross-platform [`SslEvent`], and drives an [`EbpfPump`] whose synthesized
-//! [`RawPacket`]s flow into the standard pipeline.
+//! polls the ring buffer, decodes the raw `h-ebpf-common::SslEvent` records
+//! (see `crate::ebpf::decode`) into the cross-platform [`SslEvent`], and
+//! drives an [`EbpfPump`] whose synthesized [`RawPacket`]s flow into the
+//! standard pipeline.
 //!
 //! Phase 1 MVP: no connect-side 5-tuple recovery yet — connections use a
 //! synthetic tuple and the reassembler syncs mid-stream on the first request
@@ -17,7 +18,6 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use tokio::io::unix::AsyncFd;
 use tokio_util::sync::CancellationToken;
 
@@ -28,15 +28,17 @@ use aya::Ebpf;
 
 use h_common::config::{CaptureSourceConfig, EbpfTarget};
 use h_common::internal_metrics::{Metric, MetricsWorker};
-use h_ebpf_common::{kind, SslEvent as RawSslEvent, DATA_CAP};
 
-use crate::ebpf::sigscan::{scan_elf_executable, Signature};
+use crate::ebpf::decode::decode_event;
+use crate::ebpf::offsets::{
+    exe_link_has_basename, resolve_target_offsets, target_has_source,
+};
 use crate::ebpf::{BootClock, EbpfPump, SslEvent};
 use crate::packet::RawPacket;
 use crate::pcap_dump::PacketDumperConfig;
 use crate::routing::RoutingSender;
 use crate::source::CaptureSource;
-use crate::synth::{StreamDir, SynthConfig};
+use crate::synth::SynthConfig;
 
 /// The uprobe links installed on one target inode: the `(program_name,
 /// link_id)` pairs returned by each [`UProbe::attach`]. We keep the ids so the
@@ -320,69 +322,6 @@ impl CaptureSource for EbpfSource {
     }
 }
 
-/// Cap on the pid→exe memo so a long capture across heavy pid churn can't grow
-/// it without bound. Cleared wholesale on overflow (cheap; re-warms on demand).
-const EXE_CACHE_CAP: usize = 4096;
-
-/// Decode one ring-buffer record into a cross-platform [`SslEvent`].
-fn decode_event(bytes: &[u8], exe_cache: &mut HashMap<u32, Option<String>>) -> Option<SslEvent> {
-    if bytes.len() < RawSslEvent::SIZE {
-        return None;
-    }
-    // The ring buffer gives an unaligned slice; read the POD struct unaligned.
-    let raw: RawSslEvent = unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const RawSslEvent) };
-    let comm = comm_to_string(&raw.comm);
-    match raw.kind {
-        kind::CLOSE => Some(SslEvent::Close {
-            conn_id: raw.conn_id,
-            ktime_ns: raw.ktime_ns,
-        }),
-        kind::DATA_WRITE | kind::DATA_READ => {
-            let len = (raw.data_len as usize).min(DATA_CAP);
-            let dir = if raw.kind == kind::DATA_WRITE {
-                StreamDir::ClientToServer
-            } else {
-                StreamDir::ServerToClient
-            };
-            Some(SslEvent::Data {
-                conn_id: raw.conn_id,
-                pid: raw.pid,
-                comm,
-                exe: resolve_exe(raw.pid, exe_cache),
-                dir,
-                data: Bytes::copy_from_slice(&raw.data[..len]),
-                seq_off: raw.seq_off,
-                ktime_ns: raw.ktime_ns,
-            })
-        }
-        _ => None,
-    }
-}
-
-/// Best-effort `/proc/<pid>/exe` resolution, memoized. Returns the absolute
-/// executable path, or `None` when the link can't be read (process exited,
-/// permission denied). Requires the capturing process to out-rank the target —
-/// satisfied when running as root / CAP_SYS_PTRACE, which the eBPF source needs
-/// anyway.
-fn resolve_exe(pid: u32, cache: &mut HashMap<u32, Option<String>>) -> Option<String> {
-    if let Some(v) = cache.get(&pid) {
-        return v.clone();
-    }
-    if cache.len() >= EXE_CACHE_CAP {
-        cache.clear();
-    }
-    let resolved = std::fs::read_link(format!("/proc/{pid}/exe"))
-        .ok()
-        .map(|p| p.to_string_lossy().into_owned());
-    cache.insert(pid, resolved.clone());
-    resolved
-}
-
-fn comm_to_string(comm: &[u8]) -> String {
-    let end = comm.iter().position(|&b| b == 0).unwrap_or(comm.len());
-    String::from_utf8_lossy(&comm[..end]).into_owned()
-}
-
 /// Load a BPF program by name. Called once per program before any attach,
 /// because the kernel rejects a second `load()` while the program is attached
 /// at multiple sites (each libssl + each static target).
@@ -476,127 +415,11 @@ fn detach_links(ebpf: &mut Ebpf, links: InodeLinks) {
     }
 }
 
-/// Built-in BoringSSL prologue signatures for a flavor, using the anchor + window
-/// technique. `SSL_read`'s prologue is distinctive enough to match uniquely; the
-/// `SSL_write` prologue is generic (a common register-save sequence appears many
-/// times), so it is located as the nearest match in a window *after* the
-/// `SSL_read` anchor — robust to the small per-build drift in the inter-function
-/// distance that a hardcoded delta would miss.
-struct FlavorSig {
-    /// Distinctive `SSL_read` prologue — must match uniquely (the anchor).
-    read_sig: &'static str,
-    /// `SSL_write` prologue — generic; resolved as the first match within
-    /// `write_window` bytes after the `SSL_read` anchor.
-    write_sig: &'static str,
-    write_window: u64,
-}
-
-/// Built-in signatures per flavor. Returns `None` for `boringssl` (generic): a
-/// prologue is specific to one statically-linked build, so a bare `boringssl`
-/// target must supply `write_sig`/`read_sig`/`*_offset` in config.
-///
-/// The `bun` signatures are the BoringSSL `SSL_read`/`SSL_write` x86-64
-/// prologues from Bun v1.3.x profile builds (the runtime Claude Code ships),
-/// matching the read-anchored, windowed-write approach from the eunomia-bpf
-/// AgentSight project (MIT). They are still version-bound data — a future Bun
-/// line may shift the prologue; override via config when that happens.
-fn flavor_signatures(flavor: &str) -> Option<FlavorSig> {
-    match flavor {
-        "bun" | "boringssl-bun" | "claude-code" => Some(FlavorSig {
-            read_sig: "55 48 89 e5 41 57 41 56 53 50 48 83 bf 98 00 00 00 00 74",
-            write_sig:
-                "55 48 89 e5 41 57 41 56 41 55 41 54 53 48 83 ec 18 41 89 d7 49 89 f6 48 89 fb",
-            write_window: 0x10000,
-        }),
-        _ => None,
-    }
-}
-
-/// Locate a function as the first signature match within `window` bytes after an
-/// `anchor` offset. Used for the generic `SSL_write` prologue once the unique
-/// `SSL_read` anchor is known — handles a prologue that occurs many times across
-/// the binary by scoping to the SSL function's neighborhood.
-fn resolve_windowed(
-    data: &[u8],
-    pattern: &str,
-    anchor: u64,
-    window: u64,
-    what: &str,
-    binary: &str,
-) -> Option<u64> {
-    let sig = Signature::parse(pattern)?;
-    let hit = scan_elf_executable(data, &sig)
-        .into_iter()
-        .find(|&o| o >= anchor && o < anchor.saturating_add(window));
-    match hit {
-        Some(off) => {
-            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x} (anchored)");
-            Some(off)
-        }
-        None => {
-            tracing::warn!(
-                "ebpf: {binary}: {what} not found within {window:#x} of anchor {anchor:#x}"
-            );
-            None
-        }
-    }
-}
-
-/// Resolve a unique uprobe file offset for `pattern` in `data`. Requires
-/// exactly one match: zero means a stale/wrong signature (skip, don't attach
-/// blindly), and more than one is ambiguous (a too-loose signature would attach
-/// the probe to the wrong function). Both cases log and return `None`.
-fn resolve_single_offset(data: &[u8], pattern: &str, what: &str, binary: &str) -> Option<u64> {
-    let Some(sig) = Signature::parse(pattern) else {
-        tracing::warn!("ebpf: {binary}: malformed {what} signature {pattern:?}");
-        return None;
-    };
-    let hits = scan_elf_executable(data, &sig);
-    match hits.as_slice() {
-        [] => {
-            tracing::warn!("ebpf: {binary}: {what} signature matched nothing (wrong build?)");
-            None
-        }
-        [off] => {
-            tracing::info!("ebpf: {binary}: {what} resolved at offset {off:#x}");
-            Some(*off)
-        }
-        many => {
-            tracing::warn!(
-                "ebpf: {binary}: {what} signature is ambiguous ({} matches) — refine it",
-                many.len()
-            );
-            None
-        }
-    }
-}
-
 /// How often to re-scan target processes for new inodes (auto-update rotation)
 /// and freshly-spawned sessions. Short enough that a new Claude Code / opencode
 /// session is captured within seconds of starting; cheap (a `/proc` walk plus a
 /// signature scan only for inodes not seen before).
 const RESCAN_INTERVAL_SECS: u64 = 15;
-
-/// Does this target carry enough config to resolve uprobe offsets at all?
-/// (an explicit offset, a config signature, or a flavor with built-in sigs.)
-fn target_has_source(target: &EbpfTarget) -> bool {
-    target.write_offset.is_some()
-        || target.read_offset.is_some()
-        || target.write_sig.is_some()
-        || target.read_sig.is_some()
-        || flavor_signatures(&target.flavor).is_some()
-}
-
-/// True if a `/proc/<pid>/exe` readlink target has the given basename. The
-/// kernel suffixes the link with `" (deleted)"` once the binary is unlinked by
-/// an auto-update, so strip that first. Matching by **basename** (not full path)
-/// is what lets us re-attach across npm's atomic-rename upgrade, which stages the
-/// new build in a `.<pkg>-<hash>/` dir before renaming it over the install path —
-/// the running process's exe then points into that now-deleted staging dir.
-fn exe_link_has_basename(link: &str, basename: &str) -> bool {
-    let path = link.strip_suffix(" (deleted)").unwrap_or(link);
-    Path::new(path).file_name().and_then(|f| f.to_str()) == Some(basename)
-}
 
 /// (dev, inode) identity of `path`, following symlinks — so `/proc/<pid>/exe`
 /// resolves to the real (possibly deleted) inode. Returns `None` if it can't be
@@ -626,61 +449,6 @@ fn target_pids(basename: &str) -> Vec<u32> {
         }
     }
     pids
-}
-
-/// Resolve SSL_read/SSL_write **file offsets** for a target from the given
-/// binary `data` (config offsets first, then config signatures, then built-in
-/// flavor signatures). Pure over `data` — same bytes always yield the same
-/// offsets, so a per-inode result can be cached as "seen".
-fn resolve_target_offsets(
-    data: &[u8],
-    target: &EbpfTarget,
-    label: &str,
-) -> (Option<u64>, Option<u64>) {
-    let mut read_off = target.read_offset;
-    let mut write_off = target.write_offset;
-    if read_off.is_some() && write_off.is_some() {
-        return (read_off, write_off);
-    }
-
-    // Config-supplied signatures take precedence and must match uniquely.
-    if read_off.is_none() {
-        if let Some(p) = &target.read_sig {
-            read_off = resolve_single_offset(data, p, "SSL_read", label);
-        }
-    }
-    if write_off.is_none() {
-        if let Some(p) = &target.write_sig {
-            write_off = resolve_single_offset(data, p, "SSL_write", label);
-        }
-    }
-
-    // Fall back to built-in flavor signatures: anchor on the unique SSL_read
-    // prologue, then locate SSL_write (generic prologue) as the nearest match in
-    // the window after it.
-    if let Some(fs) = flavor_signatures(&target.flavor) {
-        if read_off.is_none() {
-            read_off = resolve_single_offset(data, fs.read_sig, "SSL_read", label);
-        }
-        if write_off.is_none() {
-            match read_off {
-                Some(anchor) => {
-                    write_off = resolve_windowed(
-                        data,
-                        fs.write_sig,
-                        anchor,
-                        fs.write_window,
-                        "SSL_write",
-                        label,
-                    );
-                }
-                None => tracing::warn!(
-                    "ebpf: {label}: no SSL_read anchor — cannot locate SSL_write by window"
-                ),
-            }
-        }
-    }
-    (read_off, write_off)
 }
 
 /// Attach the (already-loaded) SSL uprobes to `attach_path` at the resolved
@@ -887,75 +655,4 @@ fn bump_memlock_rlimit() -> std::io::Result<()> {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn target(binary: &str, flavor: &str) -> EbpfTarget {
-        EbpfTarget {
-            binary: binary.to_string(),
-            flavor: flavor.to_string(),
-            write_sig: None,
-            read_sig: None,
-            write_offset: None,
-            read_offset: None,
-        }
-    }
-
-    #[test]
-    fn exe_link_basename_matches_plain_path() {
-        assert!(exe_link_has_basename(
-            "/home/user/.nvm/.../claude-code/bin/claude.exe",
-            "claude.exe"
-        ));
-    }
-
-    #[test]
-    fn exe_link_basename_matches_through_deleted_suffix() {
-        // After an npm atomic-rename auto-update the running process's exe points
-        // into the now-unlinked staging dir; the kernel appends " (deleted)".
-        // Basename matching must see through both the staging dir and the suffix.
-        assert!(exe_link_has_basename(
-            "/home/user/.nvm/.../@anthropic-ai/.claude-code-BLnYIOGh/bin/claude.exe (deleted)",
-            "claude.exe"
-        ));
-        assert!(exe_link_has_basename(
-            "/home/user/.nvm/.../opencode-ai/bin/opencode.exe (deleted)",
-            "opencode.exe"
-        ));
-    }
-
-    #[test]
-    fn exe_link_basename_rejects_other_binaries() {
-        assert!(!exe_link_has_basename("/usr/bin/node", "claude.exe"));
-        assert!(!exe_link_has_basename(
-            "/some/where/claude.exe.bak (deleted)",
-            "claude.exe"
-        ));
-    }
-
-    #[test]
-    fn target_has_source_requires_offset_sig_or_flavor() {
-        // Bare boringssl flavor with no offsets/sigs → not enough to attach.
-        assert!(!target_has_source(&target("/x/claude.exe", "boringssl")));
-        // A known flavor with built-in signatures is enough.
-        assert!(target_has_source(&target("/x/claude.exe", "bun")));
-        // An explicit offset is enough regardless of flavor.
-        let mut t = target("/x/claude.exe", "boringssl");
-        t.read_offset = Some(0x1000);
-        assert!(target_has_source(&t));
-    }
-
-    #[test]
-    fn resolve_offsets_passes_config_offsets_through_without_scanning() {
-        let mut t = target("/x/claude.exe", "boringssl");
-        t.read_offset = Some(0x4165_5e0);
-        t.write_offset = Some(0x4165_970);
-        // Empty data would make any scan fail; config offsets must short-circuit.
-        let (r, w) = resolve_target_offsets(&[], &t, "test");
-        assert_eq!(r, Some(0x4165_5e0));
-        assert_eq!(w, Some(0x4165_970));
-    }
 }

--- a/server/h-capture/src/synth.rs
+++ b/server/h-capture/src/synth.rs
@@ -685,4 +685,144 @@ mod tests {
         let frames = s.data(1, StreamDir::ClientToServer, &body, 0, 0);
         assert_eq!(frames.len(), 2, "default segment size still chunks");
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Reassembler contract invariants (see the module-level docs).
+    //
+    // The reassembler (`h-protocol`) derives each segment's on-wire length from
+    // the IP/TCP header fields and discards a flow whose claimed length exceeds
+    // the captured bytes. These tests pin the synthesizer's half of that
+    // contract directly on the emitted bytes — no parser dependency — so a
+    // regression that would truncate or pad a frame is caught here.
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// IPv4 `total_length` (bytes 16..18 of the IPv4 header).
+    fn ipv4_total_length(pkt: &RawPacket) -> u16 {
+        let ip = ETH_HDR_LEN;
+        u16::from_be_bytes([pkt.data[ip + 2], pkt.data[ip + 3]])
+    }
+
+    /// IPv6 `payload_length` (bytes 4..6 of the IPv6 header).
+    fn ipv6_payload_length(pkt: &RawPacket) -> u16 {
+        let ip = ETH_HDR_LEN;
+        u16::from_be_bytes([pkt.data[ip + 4], pkt.data[ip + 5]])
+    }
+
+    /// IPv4 header checksum (bytes 10..12) — left zero, never validated.
+    fn ipv4_checksum(pkt: &RawPacket) -> u16 {
+        let ip = ETH_HDR_LEN;
+        u16::from_be_bytes([pkt.data[ip + 10], pkt.data[ip + 11]])
+    }
+
+    /// TCP checksum (offset 16..18 in the TCP header) — left zero.
+    fn tcp_checksum(pkt: &RawPacket) -> u16 {
+        let tcp = ETH_HDR_LEN + IPV4_HDR_LEN;
+        u16::from_be_bytes([pkt.data[tcp + 16], pkt.data[tcp + 17]])
+    }
+
+    #[test]
+    fn ipv4_total_length_covers_exactly_headers_plus_payload() {
+        // The reassembler's truncation guard requires
+        // `wire_payload_len == payload.len()`. The synthesizer sets the IPv4
+        // total_length to exactly IPV4(20) + TCP(20) + payload — no more, no
+        // less — so the segment is never misread as truncated/overlong.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        for body in [
+            b"".as_slice(),
+            b"GET / HTTP/1.1\r\n".as_slice(),
+            &[b'A'; 40_000][..],
+        ] {
+            let frames = s.data(1, StreamDir::ClientToServer, body, 0, 10);
+            for f in &frames {
+                let (_, _, payload) = ipv4_tcp(f);
+                assert_eq!(
+                    ipv4_total_length(f) as usize,
+                    IPV4_HDR_LEN + TCP_HDR_LEN + payload.len(),
+                    "total_length must cover exactly the carried payload"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ipv6_payload_length_covers_tcp_header_plus_payload() {
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        let tuple = ConnTuple {
+            client: "[2001:db8::1]:50000".parse().unwrap(),
+            server: "[2606:4700::1]:443".parse().unwrap(),
+        };
+        s.open(1, tuple, 0);
+        let body = b"POST /v1/messages HTTP/1.1\r\n\r\n";
+        let frames = s.data(1, StreamDir::ClientToServer, body, 0, 0);
+        for f in &frames {
+            let tcp = ETH_HDR_LEN + IPV6_HDR_LEN;
+            let payload = &f.data[tcp + TCP_HDR_LEN..];
+            assert_eq!(
+                ipv6_payload_length(f) as usize,
+                TCP_HDR_LEN + payload.len(),
+                "IPv6 payload_length must cover TCP header + payload"
+            );
+        }
+    }
+
+    #[test]
+    fn checksums_are_left_zero() {
+        // No checksums are computed (the L3/L4 decoders don't validate them);
+        // the fields stay zero so a future validator isn't fed stale garbage.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        let f = &s.data(1, StreamDir::ClientToServer, b"hi", 0, 0)[0];
+        assert_eq!(ipv4_checksum(f), 0);
+        assert_eq!(tcp_checksum(f), 0);
+    }
+
+    #[test]
+    fn frames_are_never_heartbeats() {
+        // Synthetic frames carry a real IP ethertype (0x0800 / 0x86dd), never
+        // the 0xFFFF heartbeat sentinel, so `is_heartbeat()` is false for
+        // every emitted SYN/SYN-ACK/data/FIN — the reassembler parses them.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        let handshake = s.open(1, v4_tuple(), 0);
+        for f in &handshake {
+            assert!(!f.is_heartbeat());
+            assert_eq!(ethertype(f), ETHERTYPE_IPV4);
+        }
+        let data = s.data(1, StreamDir::ClientToServer, b"GET / HTTP/1.1\r\n", 0, 0);
+        for f in &data {
+            assert!(!f.is_heartbeat());
+        }
+        let fins = s.close(1, 99);
+        for f in &fins {
+            assert!(!f.is_heartbeat());
+        }
+    }
+
+    #[test]
+    fn seq_advances_by_payload_len_per_direction() {
+        // Sequence numbers advance monotonically per direction by the emitted
+        // payload length; there are no retransmits or out-of-order frames. Two
+        // sequential writes leave a contiguous, gapless c2s sequence space.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        let a = s.data(1, StreamDir::ClientToServer, b"AAAA", 0, 0);
+        let b = s.data(1, StreamDir::ClientToServer, b"BB", 4, 1);
+        let (seq_a, _, pl_a) = ipv4_tcp(&a[0]);
+        let (seq_b, _, pl_b) = ipv4_tcp(&b[0]);
+        assert_eq!(seq_a, 1);
+        assert_eq!(seq_b, seq_a + pl_a.len() as u32, "second write continues the stream");
+        assert_eq!(pl_b.len(), 2);
+    }
+
+    #[test]
+    fn caplen_equals_wirelen_equals_frame_len() {
+        // Synthetic frames are never snaplen-truncated: caplen == wirelen ==
+        // the full emitted length, so the reassembler sees the whole segment.
+        let mut s = FlowSynthesizer::new(SynthConfig::default());
+        s.open(1, v4_tuple(), 0);
+        let f = &s.data(1, StreamDir::ClientToServer, b"POST /v1/messages HTTP/1.1\r\n", 0, 0)[0];
+        assert_eq!(f.caplen, f.wirelen);
+        assert_eq!(f.caplen as usize, f.data.len());
+        assert_eq!(f.link_type, LINKTYPE_ETHERNET);
+    }
 }

--- a/server/h-ebpf-common/src/lib.rs
+++ b/server/h-ebpf-common/src/lib.rs
@@ -9,6 +9,11 @@
 //! host identically. The layout is `#[repr(C)]` and POD; the loader reads each
 //! ring-buffer slice with an unaligned read, so no alignment guarantees are
 //! required from the ring buffer.
+//!
+//! The layout is the contract between the BPF program and userspace, so it is
+//! locked by host unit tests (see the `tests` module) — a field reorder or a
+//! changed `DATA_CAP` that would silently break the ring-buffer read is caught
+//! on every platform without the BPF toolchain or `CAP_BPF`.
 
 #![no_std]
 
@@ -80,3 +85,129 @@ impl SslEvent {
     /// Total size of the record on the wire.
     pub const SIZE: usize = core::mem::size_of::<Self>();
 }
+
+#[cfg(test)]
+mod tests {
+    //! Layout contract for the shared ring-buffer record.
+    //!
+    //! The BPF program (`h-ebpf-prog`) writes these `#[repr(C)]` records into
+    //! the ring buffer and the userspace loader (`h-capture`) reads each slice
+    //! back with an unaligned read, so the two sides must agree byte-for-byte on
+    //! field order, sizes, and padding. These tests pin that layout on the host
+    //! — no BPF toolchain or `CAP_BPF` required — so a future edit that would
+    //! silently break the ring-buffer read (a reordered field, a resized
+    //! `DATA_CAP`, a changed discriminant) fails `cargo test` on every
+    //! platform. This is why the shared layout lives in a dependency-free
+    //! `no_std` crate rather than being duplicated on each side.
+
+    use super::*;
+    use core::mem::{align_of, size_of, MaybeUninit};
+    use core::ptr::addr_of;
+
+    /// An uninitialized `SslEvent` used solely to take field *addresses*. We
+    /// never read the field values (only `addr_of` their offsets), so
+    /// `MaybeUninit::uninit` suffices and is safe — no validity assumption on
+    /// the bytes is made.
+    fn uninit_event() -> MaybeUninit<SslEvent> {
+        MaybeUninit::<SslEvent>::uninit()
+    }
+
+    #[test]
+    fn constants_match_their_documented_values() {
+        // Kernel `TASK_COMM_LEN` and the 32 KiB single-event payload cap. The
+        // cap is sized so a real ~23 KiB Claude Code `/v1/messages` request
+        // arrives whole in one event (see DATA_CAP's doc comment) — changing it
+        // silently resizes the ring-buffer record and the BPF reservation.
+        assert_eq!(COMM_LEN, 16);
+        assert_eq!(DATA_CAP, 32_768);
+    }
+
+    #[test]
+    fn kind_discriminants_are_stable_wire_values() {
+        // The BPF program stamps `kind` and userspace matches on it
+        // (`decode_event`); these integers are a wire ABI, not an enum repr.
+        assert_eq!(kind::DATA_WRITE, 1);
+        assert_eq!(kind::DATA_READ, 2);
+        assert_eq!(kind::CLOSE, 3);
+        // The three kinds are distinct so decode can't conflate them.
+        assert_ne!(kind::DATA_WRITE, kind::DATA_READ);
+        assert_ne!(kind::DATA_WRITE, kind::CLOSE);
+        assert_ne!(kind::DATA_READ, kind::CLOSE);
+    }
+
+    #[test]
+    fn repr_c_field_offsets_are_pinned() {
+        // `#[repr(C)]` gives a fixed field order; lock each offset so a
+        // reorder is caught. Computed from the declared order (not a magic
+        // table): kind/pid at 0/4, the three u64s at 8/16/24, then data_len at
+        // 32, comm at 36, data at 52.
+        let ev = uninit_event();
+        let base = ev.as_ptr();
+        assert_eq!(addr_of!((*base).kind) as usize - base as usize, 0);
+        assert_eq!(addr_of!((*base).pid) as usize - base as usize, 4);
+        assert_eq!(addr_of!((*base).conn_id) as usize - base as usize, 8);
+        assert_eq!(addr_of!((*base).ktime_ns) as usize - base as usize, 16);
+        assert_eq!(addr_of!((*base).seq_off) as usize - base as usize, 24);
+        assert_eq!(addr_of!((*base).data_len) as usize - base as usize, 32);
+        assert_eq!(addr_of!((*base).comm) as usize - base as usize, 36);
+        assert_eq!(addr_of!((*base).data) as usize - base as usize, 52);
+    }
+
+    #[test]
+    fn record_size_is_the_pinned_field_sum_rounded_to_alignment() {
+        // The on-wire size = sum of the fields, rounded up to the struct's
+        // alignment (the largest member, `u64` → 8). Deriving it here, rather
+        // than asserting a single number, keeps the test honest about *why*
+        // the trailing padding exists and survives a `DATA_CAP` change (the
+        // round-up recomputes). `SslEvent::SIZE` is `size_of::<Self>()`, which
+        // is what the loader checks against the ring-buffer slice length. The
+        // trailing pad is `align - field_sum % align`.
+        let field_sum = size_of::<u32>()  // kind
+            + size_of::<u32>()            // pid
+            + size_of::<u64>()            // conn_id
+            + size_of::<u64>()            // ktime_ns
+            + size_of::<u64>()            // seq_off
+            + size_of::<u32>()            // data_len
+            + COMM_LEN                    // comm
+            + DATA_CAP;                   // data
+        let align = align_of::<SslEvent>();
+        assert_eq!(align, 8, "largest member is u64");
+        let rounded = field_sum + (align - field_sum % align) % align;
+        assert_eq!(SslEvent::SIZE, rounded);
+        // 4+4+8+8+8+4+16+32768 = 32820 → round up to 32824.
+        assert_eq!(field_sum, 32_820);
+        assert_eq!(SslEvent::SIZE, 32_824);
+        // The size must cover the full payload array (the BPF program fills
+        // `data[..data_len]` up to DATA_CAP, reserving one whole record).
+        assert!(SslEvent::SIZE >= DATA_CAP + 52);
+    }
+
+    #[test]
+    fn size_is_the_same_on_bpf_and_host_targets() {
+        // The whole point of this crate: the layout is identical whether it's
+        // compiled for `bpfel-unknown-none` (BPF program) or the host
+        // (userspace loader). Both read `SslEvent::SIZE`, so it must be a pure
+        // function of the type — re-derive it from a fresh query to be sure the
+        // const and the runtime value agree.
+        assert_eq!(SslEvent::SIZE, size_of::<SslEvent>());
+    }
+
+    #[test]
+    fn data_array_is_a_trailing_inline_buffer() {
+        // `data` must be an inline `[u8; DATA_CAP]` (not a pointer/Vec): the BPF
+        // program does `bpf_probe_read_user` straight into the reserved record
+        // and userspace reads `data[..data_len]` from the same record, so the
+        // payload travels inside the ring-buffer entry, not through a follow-on
+        // pointer. It starts at offset 52 (pinned above) and the record is
+        // large enough to hold the whole array — the few bytes from the array's
+        // end (32_820) to `SIZE` (32_824) are `repr(C)` trailing alignment pad,
+        // not payload.
+        let ev = uninit_event();
+        let base = ev.as_ptr();
+        let data_off = addr_of!((*base).data) as usize - base as usize;
+        assert_eq!(data_off, 52);
+        assert_eq!(size_of::<[u8; DATA_CAP]>(), DATA_CAP);
+        assert!(data_off + DATA_CAP <= SslEvent::SIZE);
+    }
+}
+

--- a/server/h-ebpf-prog/README.md
+++ b/server/h-ebpf-prog/README.md
@@ -1,0 +1,104 @@
+# `h-ebpf-prog` — BPF program for SSL-uprobe capture
+
+The eBPF program that attaches to `SSL_read` / `SSL_write` / `SSL_shutdown` /
+`SSL_free` and streams the plaintext (and connection lifecycle) to userspace
+over a ring buffer as `SslEvent` records. The shared record layout lives in
+[`h-ebpf-common`](../h-ebpf-common); the userspace loader is
+[`h-capture`'s `ebpf` feature](../h-capture/src/ebpf). See the design notes:
+[02-capture.md § eBPF](../../docs/design/02-capture.md#ebpf-ssl-uprobe-capture-linux-experimental)
+and [03-ebpf-static-targets.md](../../docs/design/03-ebpf-static-targets.md).
+
+This is a **standalone workspace** (excluded from `server/Cargo.toml`): it builds
+for `bpfel-unknown-none` with a pinned nightly toolchain and `bpf-linker`, so it
+must never be pulled into a host `cargo build` / `cargo test --workspace`. The
+loader embeds the compiled object out-of-band via `h-capture/build.rs`.
+
+## Inventory
+
+### Probes (`#[uprobe]` / `#[uretprobe]` entry points)
+
+| Program | Attach | Direction | Emits |
+|---|---|---|---|
+| `ssl_write` | uprobe on `SSL_write` (entry) | client→server | `DATA_WRITE` |
+| `ssl_read_enter` | uprobe on `SSL_read` (entry) | — | stashes `ssl`/`buf` in `READ_ARGS` by `tid` |
+| `ssl_read_exit` | uretprobe on `SSL_read` (return) | server→client | `DATA_READ` (ret>0) or `CLOSE` (ret==0, peer close_notify) |
+| `ssl_shutdown` | uprobe on `SSL_shutdown` | — | `CLOSE` |
+| `ssl_free` | uprobe on `SSL_free` | — | `CLOSE` (frees the `SSL*` for reuse → flow resets) |
+
+`SSL_read` reads its buffer only on return, so entry stashes the args and the
+uretprobe emits using the real byte count.
+
+### Maps (`#[map]`)
+
+| Map | Type | Key → Value | Max entries | Role |
+|---|---|---|---|---|
+| `EVENTS` | `RingBuf` | — | 16 MiB (byte size) | Carries `SslEvent` records to userspace |
+| `READ_ARGS` | `HashMap` | `tid: u32` → `ReadArgs{ssl,buf}` | 10240 | `SSL_read` entry→return arg stash |
+| `WRITE_OFF` | `HashMap` | `conn_id: u64` → next c2s byte offset | 10240 | Running client→server stream offset |
+| `READ_OFF` | `HashMap` | `conn_id: u64` → next s2c byte offset | 10240 | Running server→client stream offset |
+
+The two `*_OFF` maps give a large `SSL_*` call split across several events — and
+successive calls on a keep-alive connection — a monotonic per-direction
+position (`seq_off`), cleared on close so a reused `SSL*` pointer restarts at 0.
+
+### Emit paths
+
+- `emit_data(ev_kind, ssl, buf, len)` — streams one `SSL_read`/`SSL_write`
+  buffer to userspace as up to `MAX_CHUNKS` (8) consecutive `DATA_CAP`-sized
+  events on the same `conn_id` + direction. Each chunk is stamped with its
+  absolute stream offset (`base + start`).
+- `emit_chunk_at(...)` — emits ONE `DATA_CAP`-sized chunk of `buf[start..]` if
+  `start < len`: reserves a `SslEvent`, fills `kind`/`pid`/`conn_id`/`ktime_ns`/
+  `seq_off`/`data_len`/`comm`, `bpf_probe_read_user`s the payload, submits.
+- `emit_close(ssl)` — forgets both per-connection offsets and emits one `CLOSE`.
+- `stream_off` / `set_stream_off` — read/write the running offset for a
+  `(conn_id, direction)`.
+
+### Constants
+
+- `DATA_CAP = 32_768` (from `h-ebpf-common`) — max plaintext bytes per event.
+- `MAX_CHUNKS = 8` — max `DATA_CAP`-sized chunks per `SSL_*` call (a write larger
+  than 256 KiB loses its tail; the userspace parser tolerates a shorter body).
+
+## Residual BPF-only lines (NOT host-testable)
+
+`h-ebpf-common` (the shared `SslEvent` layout) and `h-capture`'s
+`ebpf/{decode,offsets,sigscan,synth}` modules are pure and host-unit-tested on
+every platform. **This file is the residual**: everything in `src/main.rs` runs
+only in the BPF program under the kernel verifier and cannot be extracted to
+host-testable code without breaking the verifier. The reasons, line by line:
+
+- **`emit_chunk_at` is `#[inline(always)]` and invoked from an UNROLLED
+  sequence, not a loop.** A real `for` loop's back-edge makes the 5.15 BPF
+  verifier reject the program ("R1 type=ctx expected=fp"), and a non-inlined
+  helper becomes a BPF-to-BPF call the verifier also rejects. Inlined + unrolled,
+  the body is straight-line code the verifier accepts. Extracting it to a
+  callable function (host or otherwise) is therefore **not verifier-safe**.
+- **`emit_data`'s body is the unrolled 8× `emit_chunk_at` call**, for the same
+  reason — it is residual by construction, not oversight.
+- **`stream_off` / `set_stream_off` are `#[inline(always)]`** for the same
+  verifier reason (a non-inlined BPF-to-BPF call trips the 5.15 verifier). They
+  are kept as the smallest straight-line read/write of the offset maps.
+- **The `bpf_*` helper calls** (`bpf_probe_read_user`, `bpf_get_current_comm`,
+  `bpf_ktime_get_ns`, `bpf_get_current_pid_tgid`) and the ring-buffer
+  `reserve`/`submit` are BPF-only kernel APIs with no host analogue.
+- **`#[panic_handler]`** is required by the `no_std` BPF target.
+
+So this program is validated end-to-end by the **`ebpf-soak`** workflow on the
+staging VM (real Bun/BoringSSL TLS → captured plaintext → persisted
+process-attributed `LlmCall`), not by host unit tests. The pure contract it
+relies on — the `SslEvent` layout, the decode, the offset resolution, and the
+frame synthesis — *is* host-tested in `h-ebpf-common` and `h-capture`.
+
+## Build
+
+```sh
+# From the server/ workspace — the loader's build.rs does this out-of-band when
+# `--features ebpf` is on, so you rarely invoke it directly.
+rustup run nightly cargo build -Z build-std=core --release \
+    --target bpfel-unknown-none
+```
+
+Requires the `nightly` toolchain (with `rust-src`), the `bpfel-unknown-none`
+target, and `bpf-linker` (see `rust-toolchain.toml` and `.cargo/config.toml`).
+The object is embedded into `h-capture` and loaded by `EbpfSource`.


### PR DESCRIPTION
Automated pull request for Hera task `04d6c6f0-c31c-4c6b-a824-d94569c5c164`.

INPUT: design §5; `h-ebpf-common`, `h-ebpf-prog`, `h-capture` ebpf userspace; coverage merge from t1.
WORK: Host unit tests for `SslEvent` layout/constants/sizes; inventory BPF probes/maps/emit paths in `h-ebpf-prog` and document residual BPF-only lines; extract pure helpers to host-testable code only if verifier-safe; extend userspace synthesizer/contract tests; ensure coverage command merges `--features ebpf` userspace unit tests on Linux when they add measurable lines; document eBPF measurement exception in coverage help output.