### PR TITLE
hera: app/heron CLI, doctor/validate, and pipeline tests

### DIFF
--- a/server/app/heron/tests/cmd_config.rs
+++ b/server/app/heron/tests/cmd_config.rs
@@ -1,0 +1,447 @@
+//! Table-driven tests for `heron config validate` and `heron doctor` —
+//! the pre-flight diagnostic subcommands.
+//!
+//! These exercise the **process-level** wiring that's invisible to unit
+//! tests: clap parsing, exit-code contracts, and JSON output shape. The
+//! `run` functions live in the private `cmd` module of the binary crate, so
+//! the only way to drive them (and assert on their printed output) is to
+//! spawn the compiled `heron` binary with `-c <tmpfile>` and inspect stdout
+//! + the exit status — the same shape `cli_smoke.rs` uses for `--help`.
+//!
+//! Configs are written to temp files (tempfile) so every case is hermetic
+//! and no real capture/storage is touched. None of these need
+//! CAP_NET_RAW/root — `validate` never opens a NIC, and `doctor`'s
+//! capture-capability check only *reads* `/proc/self/status`. The cases
+//! below pin behavior to the documented exit-code table:
+//!
+//! validate: 0 = valid, 1 = validation issues, 2 = IO/parse error
+//! doctor:   0 = no `fail` check, 1 = ≥1 `fail` check
+
+use std::fs;
+use std::process::Command;
+
+use serde::Deserialize;
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_heron")
+}
+
+/// Run `heron <subcommand> --config <path>` (plus optional extra args) and
+/// return (exit_code, stdout, stderr). `--config` is a global flag so it
+/// works for both `config validate` and `doctor`.
+fn run(args: &[&str], config_path: &str) -> (i32, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .arg("--config")
+        .arg(config_path)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn heron {:?}: {e}", args));
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (code, stdout, stderr)
+}
+
+/// Write `contents` to a `config.toml` inside a fresh temp dir and return
+/// `(dir, config_path)`. The TempDir is held by the caller for the test's
+/// duration so the file outlives the spawned child.
+fn write_config(contents: &str) -> (TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, contents).expect("write config");
+    (dir, path.to_string_lossy().into_owned())
+}
+
+/// A minimal valid config: one pipeline with one pcap-file source. Retention
+/// defaults (spans=traces=30) are clean so `validate()` returns no issues.
+/// `validate`/`doctor` never open the pcap file, so its path need not exist.
+/// The API binds `127.0.0.1:0` so `doctor`'s `api.bind` check passes
+/// deterministically (OS-assigned ephemeral port). The DuckDB path lives
+/// under `data_dir` so `doctor`'s `storage.path` writability probe passes
+/// without depending on the test CWD being writable, and there's no
+/// cross-run file pollution.
+fn valid_config_for(data_dir: &std::path::Path) -> String {
+    let duckdb_path = data_dir.join("heron.duckdb").to_string_lossy().into_owned();
+    format!(
+        r#"[storage]
+backend = "duckdb"
+[storage.duckdb]
+path = "{duckdb_path}"
+
+[api]
+listen = "127.0.0.1"
+port = 0
+
+[[pipeline]]
+name = "local"
+[[pipeline.sources]]
+type = "pcap-file"
+path = "/tmp/does-not-need-to-exist.pcap"
+"#
+    )
+}
+
+/// Write a valid config to a fresh temp dir and return `(dir, config_path)`.
+fn write_valid_config() -> (TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cfg = valid_config_for(dir.path());
+    let path = dir.path().join("config.toml");
+    fs::write(&path, &cfg).expect("write config");
+    (dir, path.to_string_lossy().into_owned())
+}
+
+/// Write a valid config + extra appended TOML sections to a fresh temp dir.
+/// The base config's DuckDB path is anchored to that temp dir so the
+/// appended `[storage.*]` overrides compose correctly.
+fn write_valid_config_plus(extra: &str) -> (TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cfg = format!("{}\n{extra}", valid_config_for(dir.path()));
+    let path = dir.path().join("config.toml");
+    fs::write(&path, &cfg).expect("write config");
+    (dir, path.to_string_lossy().into_owned())
+}
+
+#[derive(Deserialize)]
+struct ValidateJson {
+    ok: bool,
+    config_path: String,
+    issues: Vec<serde_json::Value>,
+}
+
+fn issue_codes(v: &ValidateJson) -> Vec<String> {
+    v.issues
+        .iter()
+        .filter_map(|i| i["code"].as_str().map(String::from))
+        .collect()
+}
+
+// ---- validate: success paths ----
+
+#[test]
+fn validate_valid_config_exits_zero_and_reports_ok() {
+    let (_dir, path) = write_valid_config();
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 0, "valid config must exit 0; stdout:\n{stdout}");
+    let v: ValidateJson =
+        serde_json::from_str(stdout.trim()).expect("validate emits JSON by default");
+    assert!(v.ok, "ok=true for valid config; got {v:?}");
+    assert!(v.issues.is_empty(), "no issues for valid config; got {:?}", v.issues);
+    assert!(
+        v.config_path.ends_with("config.toml"),
+        "config_path echoes the file: {v:?}"
+    );
+}
+
+#[test]
+fn validate_text_mode_lists_ok_for_valid_config() {
+    let (_dir, path) = write_valid_config();
+    let (code, stdout, _stderr) = run(&["config", "validate", "--text"], &path);
+    assert_eq!(code, 0, "valid config --text must exit 0; stdout:\n{stdout}");
+    assert!(
+        stdout.contains("ok") && stdout.contains("config valid"),
+        "text mode reports ok for valid config; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn validate_empty_config_is_warn_only_and_exits_zero() {
+    // No [[pipeline]] → NoPipelines (Warn). No error issues → exit 0. The
+    // runtime tolerates this (idle-API mode), so validate must NOT fail it.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cfg = valid_config_for(dir.path());
+    // Strip the [[pipeline]] block: keep only storage + api.
+    let base = cfg.split("\n\n[[pipeline]]").next().unwrap().to_string();
+    let path = dir.path().join("config.toml");
+    fs::write(&path, &base).expect("write");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path.to_string_lossy());
+    assert_eq!(code, 0, "NoPipelines is a warning, not an error — exit 0; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(v.ok, "ok=true despite the warn; got {v:?}");
+    assert_eq!(v.issues.len(), 1, "exactly the NoPipelines warn; got {v:?}");
+    assert_eq!(v.issues[0]["code"], "no_pipelines", "warn code is no_pipelines; got {:?}", v.issues[0]);
+    assert_eq!(v.issues[0]["severity"], "warn");
+    // Hold the temp dir for the test duration.
+    drop(dir);
+}
+
+// ---- validate: error paths (exit 1) ----
+
+#[test]
+fn validate_duplicate_pipeline_name_exits_one() {
+    let extra = "[[pipeline]]\nname = \"dup\"\n[[pipeline.sources]]\ntype = \"pcap-file\"\npath = \"/tmp/x.pcap\"\n\
+                 [[pipeline]]\nname = \"dup\"\n[[pipeline.sources]]\ntype = \"pcap-file\"\npath = \"/tmp/y.pcap\"\n";
+    let (_dir, path) = write_valid_config_plus(extra);
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "duplicate pipeline name is an error → exit 1; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(!v.ok);
+    assert!(
+        issue_codes(&v).contains(&"duplicate_pipeline_name".to_string()),
+        "expected duplicate_pipeline_name issue; got {:?}",
+        issue_codes(&v)
+    );
+}
+
+#[test]
+fn validate_duplicate_source_id_exits_one() {
+    // Two pcap-file sources with the same basename → same resolved source_id.
+    let extra = "[[pipeline]]\nname = \"p\"\n[[pipeline.sources]]\ntype = \"pcap-file\"\npath = \"/tmp/same.pcap\"\n\
+                 [[pipeline.sources]]\ntype = \"pcap-file\"\npath = \"/elsewhere/same.pcap\"\n";
+    let (_dir, path) = write_valid_config_plus(extra);
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "duplicate source_id is an error; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(issue_codes(&v).contains(&"duplicate_source_id".to_string()));
+}
+
+#[test]
+fn validate_traces_outliving_spans_exits_one() {
+    let (_dir, path) = write_valid_config_plus("[storage.retention]\nspans = 7\ntraces = 30\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "traces>spans retention is an error → exit 1; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(issue_codes(&v).contains(&"traces_retention_exceeds_spans".to_string()));
+}
+
+#[test]
+fn validate_traces_zero_with_finite_spans_exits_one() {
+    // traces=0 is the "never expire" sentinel; with finite spans it violates
+    // the no-JOIN read-path constraint.
+    let (_dir, path) = write_valid_config_plus("[storage.retention]\nspans = 7\ntraces = 0\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "traces=0 with finite spans is an error; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(issue_codes(&v).contains(&"traces_retention_exceeds_spans".to_string()));
+}
+
+#[test]
+fn validate_spans_zero_satisfies_any_traces() {
+    // spans=0 = infinite, so any finite traces is fine → exit 0.
+    let (_dir, path) = write_valid_config_plus("[storage.retention]\nspans = 0\ntraces = 999\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 0, "spans=0 (infinite) satisfies traces=999; stdout:\n{stdout}");
+}
+
+#[test]
+fn validate_unknown_retention_granularity_exits_one() {
+    let (_dir, path) =
+        write_valid_config_plus("[storage.retention.metrics]\n\"10sec\" = 5\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "unknown granularity typo is an error; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(issue_codes(&v).contains(&"unknown_retention_granularity".to_string()));
+}
+
+#[test]
+fn validate_unsafe_pcap_dump_pipeline_name_exits_one() {
+    // pipeline name ".." sanitizes to an unsafe path component when
+    // pcap_dump is enabled → UnsafePcapDumpPipelineName (Error).
+    let extra = "[[pipeline]]\nname = \"..\"\n[[pipeline.sources]]\ntype = \"pcap-file\"\npath = \"/tmp/x.pcap\"\n\
+                 [pipeline.pcap_dump]\nenabled = true\ndir = \"/tmp/dumps\"\n";
+    let (_dir, path) = write_valid_config_plus(extra);
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 1, "unsafe pcap_dump name is an error; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(issue_codes(&v).contains(&"unsafe_pcap_dump_pipeline_name".to_string()));
+}
+
+#[test]
+fn validate_no_sources_is_warn_not_error() {
+    // A pipeline with zero sources is a Warn (runtime tolerates it), so the
+    // overall exit is 0 — guards against a regression that turns it into an
+    // error and breaks idle-API deployments.
+    let (_dir, path) = write_valid_config_plus("[[pipeline]]\nname = \"empty\"\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 0, "NoSourcesInPipeline is a warn → exit 0; stdout:\n{stdout}");
+    let v: ValidateJson = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert!(v.ok);
+    assert!(issue_codes(&v).contains(&"no_sources_in_pipeline".to_string()));
+}
+
+// ---- validate: IO/parse error paths (exit 2) ----
+
+#[test]
+fn validate_missing_file_exits_two() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("absent.toml").to_string_lossy().into_owned();
+    let (code, stdout, _stderr) = run(&["config", "validate"], &missing);
+    assert_eq!(code, 2, "missing config file → exit 2; stdout:\n{stdout}");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["error"], "io");
+}
+
+#[test]
+fn validate_unparseable_toml_exits_two() {
+    // Missing a closing quote → TOML parse error (not a validation issue).
+    let (_dir, path) = write_config("[storage]\nbackend = \"duckdb\n");
+    let (code, stdout, _stderr) = run(&["config", "validate"], &path);
+    assert_eq!(code, 2, "unparseable TOML → exit 2; stdout:\n{stdout}");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["error"], "parse");
+}
+
+// ---- doctor ----
+
+#[derive(Deserialize)]
+struct DoctorReport {
+    ok: bool,
+    checks: Vec<DoctorCheck>,
+}
+
+#[derive(Deserialize)]
+struct DoctorCheck {
+    name: String,
+    status: String,
+    detail: String,
+}
+
+fn doctor_check<'a>(report: &'a DoctorReport, name: &str) -> &'a DoctorCheck {
+    report
+        .checks
+        .iter()
+        .find(|c| c.name == name)
+        .unwrap_or_else(|| panic!("missing check {name}; got {:?}", report.checks))
+}
+
+/// Status of a named check as `&str` — keeps `assert_eq!` comparisons as
+/// `&str == &str` (avoids `&String`-vs-`&str` ambiguity).
+fn doctor_status(report: &DoctorReport, name: &str) -> &str {
+    doctor_check(report, name).status.as_str()
+}
+
+#[test]
+fn doctor_valid_config_passes_config_checks() {
+    // `doctor` aggregates every check. On an unprivileged host the
+    // capture.capabilities check may be `fail` (flipping the overall exit to
+    // 1), so this asserts on the *config* checks (discovery, parse, validate,
+    // storage.path, api.bind) being `pass` rather than pinning the overall
+    // exit code — the capture-privilege outcome is environment-dependent.
+    let (_dir, path) = write_valid_config();
+    let (_code, stdout, _stderr) = run(&["doctor"], &path);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("doctor emits JSON");
+    assert_eq!(doctor_status(&report, "config.discovery"), "pass");
+    assert_eq!(doctor_status(&report, "config.parse"), "pass");
+    assert_eq!(doctor_status(&report, "config.validate"), "pass");
+    assert_eq!(doctor_status(&report, "storage.path"), "pass");
+    assert_eq!(doctor_status(&report, "api.bind"), "pass");
+    let cap = doctor_status(&report, "capture.capabilities");
+    assert!(
+        cap == "pass" || cap == "warn" || cap == "fail",
+        "capture.capabilities is one of pass/warn/fail; got {cap}"
+    );
+}
+
+#[test]
+fn doctor_missing_config_fails_discovery_check() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("absent.toml").to_string_lossy().into_owned();
+    let (code, stdout, _stderr) = run(&["doctor"], &missing);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(
+        doctor_status(&report, "config.discovery"), "fail",
+        "missing file fails config.discovery"
+    );
+    assert_eq!(code, 1, "a fail check flips doctor to exit 1; stdout:\n{stdout}");
+    // parse/validate are skipped (warn), not re-failed, when discovery fails.
+    assert_eq!(doctor_status(&report, "config.parse"), "warn");
+}
+
+#[test]
+fn doctor_unparseable_config_fails_parse_check() {
+    let (_dir, path) = write_config("[storage]\nbackend = \"duckdb\n");
+    let (code, stdout, _stderr) = run(&["doctor"], &path);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(
+        doctor_status(&report, "config.parse"), "fail",
+        "parse error fails config.parse"
+    );
+    assert_eq!(code, 1, "parse fail → exit 1; stdout:\n{stdout}");
+}
+
+#[test]
+fn doctor_validation_error_fails_validate_check() {
+    let (_dir, path) = write_valid_config_plus("[storage.retention]\nspans = 7\ntraces = 30\n");
+    let (code, stdout, _stderr) = run(&["doctor"], &path);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(
+        doctor_status(&report, "config.validate"), "fail",
+        "a validation error (traces>spans) fails config.validate"
+    );
+    assert_eq!(code, 1, "validate fail → exit 1; stdout:\n{stdout}");
+}
+
+#[test]
+fn doctor_text_mode_runs_and_mentions_overall() {
+    let (_dir, path) = write_valid_config();
+    let (_code, stdout, _stderr) = run(&["doctor", "--text"], &path);
+    assert!(
+        stdout.contains("overall:"),
+        "text mode prints an 'overall:' line; got:\n{stdout}"
+    );
+}
+
+/// When the DuckDB file already exists, `doctor` probes it read/write instead
+/// of the creatability path — covers the `path.exists()` arm of
+/// `check_storage_path`.
+#[test]
+fn doctor_existing_duckdb_file_probes_rw() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Pre-create an empty file at the configured DuckDB path.
+    let duckdb = dir.path().join("existing.duckdb");
+    fs::write(&duckdb, b"").expect("create empty duckdb file");
+    let cfg = valid_config_for(dir.path())
+        .replace("heron.duckdb", "existing.duckdb");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, &cfg).expect("write config");
+    let (_code, stdout, _stderr) = run(&["doctor"], &path);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(
+        doctor_status(&report, "storage.path"), "pass",
+        "an existing empty file is openable rw → pass"
+    );
+}
+
+/// A non-duckdb backend skips the path probe entirely — covers the
+/// `backend != "duckdb"` early return in `check_storage_path`.
+#[test]
+fn doctor_clickhouse_backend_skips_path_probe() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cfg = valid_config_for(dir.path());
+    // Swap the backend to clickhouse; validate() only probes duckdb paths, so
+    // the swap keeps config.validate clean.
+    cfg = cfg.replace("backend = \"duckdb\"", "backend = \"clickhouse\"");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, &cfg).expect("write config");
+    let (_code, stdout, _stderr) = run(&["doctor"], &path);
+    let report: DoctorReport = serde_json::from_str(stdout.trim()).expect("JSON");
+    assert_eq!(doctor_status(&report, "storage.path"), "pass");
+    let storage = doctor_check(&report, "storage.path");
+    assert!(
+        storage.detail.contains("backend=clickhouse"),
+        "detail notes the backend and skipped probe; got: {}",
+        storage.detail
+    );
+}
+
+/// Global `--config` must be accepted ahead of the subcommand too (clap
+/// global flag), not only after it. Guards against an arg-ordering regression
+/// that would force users to repeat `-c` after the subcommand.
+#[test]
+fn config_flag_before_subcommand_still_works() {
+    let (_dir, path) = write_valid_config();
+    let out = Command::new(bin())
+        .arg("--config")
+        .arg(&path)
+        .args(["config", "validate"])
+        .output()
+        .expect("spawn");
+    let code = out.status.code().unwrap_or(-1);
+    assert_eq!(
+        code, 0,
+        "global -c before subcommand; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/server/app/heron/tests/pipeline_helpers.rs
+++ b/server/app/heron/tests/pipeline_helpers.rs
@@ -1,0 +1,127 @@
+//! Unit tests for the pure, extractable helpers of the composition root —
+//! `StageTask::Display` and `Pipeline::supervise`. Both are re-exported from
+//! `heron::` (`lib.rs`), so they're testable here without going through the
+//! binary's private `cmd` module.
+//!
+//! `supervise` is the panic/cancel detector: it resolves as soon as any
+//! stage task exits with a `JoinError` (panic or cancellation), and returns
+//! `None` when every stage exits cleanly. These two outcomes drive the
+//! shutdown coordinator in `main.rs`, so the contract is worth pinning.
+
+use std::time::Duration;
+
+use heron::{Pipeline, StageTask};
+
+fn task(stage: &'static str, shard: Option<usize>, pipeline: Option<&str>) -> StageTask {
+    StageTask {
+        stage,
+        shard,
+        pipeline: pipeline.map(String::from),
+    }
+}
+
+// ---- StageTask::Display ----
+
+#[test]
+fn stagetask_display_pipeline_and_shard() {
+    // Per-pipeline sharded worker: the canonical "pipeline.stage.shard" label.
+    let t = task("protocol", Some(3), Some("local"));
+    assert_eq!(t.to_string(), "local.protocol.3");
+}
+
+#[test]
+fn stagetask_display_pipeline_no_shard() {
+    // Per-pipeline singleton stage (e.g. a single dispatcher): "pipeline.stage".
+    let t = task("dispatcher", None, Some("local"));
+    assert_eq!(t.to_string(), "local.dispatcher");
+}
+
+#[test]
+fn stagetask_display_shard_no_pipeline() {
+    // Shared stage with shards (none exist today, but the format must stay
+    // stable): "stage.shard", no leading pipeline dot.
+    let t = task("storage_sink", Some(0), None);
+    assert_eq!(t.to_string(), "storage_sink.0");
+}
+
+#[test]
+fn stagetask_display_no_pipeline_no_shard() {
+    // Shared singleton stage (the actual storage_sink / pair_sweeper shape):
+    // just the stage name.
+    let t = task("pair_sweeper", None, None);
+    assert_eq!(t.to_string(), "pair_sweeper");
+}
+
+#[test]
+fn stagetask_display_pipeline_dotname_is_preserved() {
+    // A pipeline name containing a dot is emitted verbatim — the label is
+    // for humans/logs, not re-parsed, so dots in names don't need escaping.
+    let t = task("metrics", Some(1), Some("us-east-1"));
+    assert_eq!(t.to_string(), "us-east-1.metrics.1");
+}
+
+// ---- Pipeline::supervise ----
+
+#[tokio::test]
+async fn supervise_returns_none_when_all_stages_exit_cleanly() {
+    let handles: Vec<(StageTask, tokio::task::JoinHandle<()>)> = vec![
+        (task("dispatcher", None, Some("local")), tokio::spawn(async {})),
+        (task("protocol", Some(0), Some("local")), tokio::spawn(async {})),
+        (task("storage_sink", None, None), tokio::spawn(async {})),
+    ];
+    let result = Pipeline::supervise(handles).await;
+    assert!(result.is_none(), "all-clean exit → None (drained); got {result:?}");
+}
+
+#[tokio::test]
+async fn supervise_surfaces_first_panicking_stage() {
+    // A panicking stage resolves `supervise` with the panicking task's label,
+    // so the shutdown coordinator can name the dead worker. The clean stages
+    // are still in the set; `supervise` returns on the first JoinError.
+    let panic_label = task("protocol", Some(2), Some("local"));
+    let handles: Vec<(StageTask, tokio::task::JoinHandle<()>)> = vec![
+        (task("dispatcher", None, Some("local")), tokio::spawn(async {}),
+        (
+            panic_label.clone(),
+            tokio::spawn(async {
+                panic!("synthetic protocol worker panic");
+            }),
+        ),
+        (task("storage_sink", None, None), tokio::spawn(async {})),
+    ];
+    let result = Pipeline::supervise(handles).await;
+    let (label, err) = result.expect("panic → Some((label, JoinError))");
+    assert_eq!(label.to_string(), "local.protocol.2");
+    assert!(err.is_panic(), "the error should be a panic; got {err:?}");
+}
+
+#[tokio::test]
+async fn supervise_returns_none_for_empty_handle_set() {
+    // No stages at all → trivially drained. Guards the JoinSet::join_next loop
+    // against an empty-input edge case.
+    let result = Pipeline::supervise(Vec::new()).await;
+    assert!(result.is_none(), "empty handle set → None");
+}
+
+#[tokio::test]
+async fn supervise_returns_none_when_stages_exit_after_short_work() {
+    // Stages that do real (tiny) work then finish cleanly must still drain.
+    // Catches a regression where a slow-but-clean stage is misreported as
+    // a failure due to a select!/timeout interaction.
+    let handles: Vec<(StageTask, tokio::task::JoinHandle<()>)> = vec![
+        (
+            task("llm", Some(0), Some("local")),
+            tokio::spawn(async {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }),
+        ),
+        (
+            task("turn", Some(0), Some("local")),
+            tokio::spawn(async {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }),
+        ),
+    ];
+    let result = Pipeline::supervise(handles).await;
+    assert!(result.is_none(), "short clean work → None; got {result:?}");
+}

--- a/server/app/heron/tests/pipeline_synth.rs
+++ b/server/app/heron/tests/pipeline_synth.rs
@@ -1,0 +1,468 @@
+//! Pipeline E2E driven by SYNTHESIZED pcaps — no privileged capture required.
+//!
+//! The existing `pipeline_e2e.rs` skips when its gitignored pcap fixtures are
+//! absent, so it contributes nothing to CI coverage of the composition root.
+//! This test builds the pcap fixtures **on the fly** from `FlowSynthesizer`
+//! frames (the same pure, cross-platform synthesizer that backs eBPF capture),
+//! writes them as real pcap files, runs them through `Pipeline::build`, and
+//! asserts the three storage tables populate with the expected wire APIs.
+//!
+//! That exercises the full wiring — dispatcher → protocol → llm → turn →
+//! metrics → shared storage sink — end to end on every CI run, with no
+//! CAP_NET_RAW/root and no binary fixture checked in.
+
+use std::path::PathBuf;
+
+use duckdb::Connection;
+use h_capture::{
+    CaptureSource, ConnTuple, FlowSynthesizer, PcapFileSource, StreamDir, SynthConfig,
+};
+use h_common::config::{
+    CaptureSourceConfig, DuckDbConfig, PipelineDef, RetentionConfig, StorageConfig,
+    StorageSinkConfig,
+};
+use h_common::internal_metrics::{Metric, MetricsSystem};
+use h_llm::wire_apis as wa;
+use heron::create_backend;
+use heron::Pipeline;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+/// pcap global header (little-endian, magic 0xa1b2c3d4) + one record per
+/// `RawPacket`. Link type 1 = Ethernet, which is what `FlowSynthesizer`
+/// stamps on every frame (`LINKTYPE_ETHERNET`).
+fn write_pcap(path: &std::path::Path, packets: &[h_capture::RawPacket]) {
+    let mut buf: Vec<u8> = Vec::with_capacity(24 + packets.len() * 64);
+    // Global header.
+    buf.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes()); // magic
+    buf.extend_from_slice(&2u16.to_le_bytes()); // version major
+    buf.extend_from_slice(&4u16.to_le_bytes()); // version minor
+    buf.extend_from_slice(&0i32.to_le_bytes()); // thiszone
+    buf.extend_from_slice(&0u32.to_le_bytes()); // sigfigs
+    buf.extend_from_slice(&65535u32.to_le_bytes()); // snaplen
+    buf.extend_from_slice(&1u32.to_le_bytes()); // link type (Ethernet)
+    for p in packets {
+        let ts_sec = (p.timestamp_us / 1_000_000) as u32;
+        let ts_usec = (p.timestamp_us % 1_000_000) as u32;
+        buf.extend_from_slice(&ts_sec.to_le_bytes());
+        buf.extend_from_slice(&ts_usec.to_le_bytes());
+        buf.extend_from_slice(&(p.caplen as u32).to_le_bytes());
+        buf.extend_from_slice(&(p.wirelen as u32).to_le_bytes());
+        buf.extend_from_slice(&p.data);
+    }
+    std::fs::write(path, &buf).expect("write synth pcap");
+}
+
+/// A complete, minimal Anthropic Messages exchange as synthetic TCP frames.
+/// Non-streaming JSON response with a `usage` block so token accounting lands
+/// in `spans` and the metrics stage emits a row.
+fn anthropic_frames(source_id: &str, conn_id: u64, ts_base_us: i64) -> Vec<h_capture::RawPacket> {
+    let mut s = FlowSynthesizer::new(SynthConfig {
+        source_id: source_id.to_string(),
+        ..SynthConfig::default()
+    });
+    let tuple = ConnTuple {
+        client: "203.0.113.4:51000".parse().unwrap(),
+        server: "192.0.2.10:443".parse().unwrap(),
+    };
+    let req_body = r#"{"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}"#;
+    let req = format!(
+        "POST /v1/messages HTTP/1.1\r\nHost: api.anthropic.com\r\n\
+         x-api-key: sk-ant-test-key\r\nanthropic-version: 2023-06-01\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{req_body}",
+        req_body.len()
+    );
+    let resp_body = r#"{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-6","stop_reason":"end_turn","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":10,"output_tokens":5}}"#;
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{resp_body}",
+        resp_body.len()
+    );
+
+    let mut frames = s.open(conn_id, tuple, ts_base_us);
+    frames.extend(s.data(
+        conn_id,
+        StreamDir::ClientToServer,
+        req.as_bytes(),
+        0,
+        ts_base_us + 1000,
+    ));
+    frames.extend(s.data(
+        conn_id,
+        StreamDir::ServerToClient,
+        resp.as_bytes(),
+        0,
+        ts_base_us + 2000,
+    ));
+    frames.extend(s.close(conn_id, ts_base_us + 3000));
+    frames
+}
+
+/// A complete, minimal OpenAI Responses exchange (Codex-style). `POST
+/// /v1/responses` with `Authorization: Bearer`, body `{model, input}` (no
+/// `messages`), and a non-streaming `status: "completed"` response with
+/// `usage`.
+fn openai_responses_frames(
+    source_id: &str,
+    conn_id: u64,
+    ts_base_us: i64,
+) -> Vec<h_capture::RawPacket> {
+    let mut s = FlowSynthesizer::new(SynthConfig {
+        source_id: source_id.to_string(),
+        ..SynthConfig::default()
+    });
+    // Distinct 5-tuple from the anthropic connection so flow keys don't collide.
+    let tuple = ConnTuple {
+        client: "198.51.100.7:52000".parse().unwrap(),
+        server: "192.0.2.20:443".parse().unwrap(),
+    };
+    let req_body = r#"{"model":"codex-1","input":[{"type":"message","role":"user","content":"hi"}]}"#;
+    let req = format!(
+        "POST /v1/responses HTTP/1.1\r\nHost: api.openai.com\r\n\
+         Authorization: Bearer sk-test-key\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\n\r\n{req_body}",
+        req_body.len()
+    );
+    let resp_body = r#"{"id":"resp_01","status":"completed","model":"codex-1","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],"usage":{"input_tokens":8,"output_tokens":3,"total_tokens":11}}"#;
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{resp_body}",
+        resp_body.len()
+    );
+
+    let mut frames = s.open(conn_id, tuple, ts_base_us);
+    frames.extend(s.data(
+        conn_id,
+        StreamDir::ClientToServer,
+        req.as_bytes(),
+        0,
+        ts_base_us + 1000,
+    ));
+    frames.extend(s.data(
+        conn_id,
+        StreamDir::ServerToClient,
+        resp.as_bytes(),
+        0,
+        ts_base_us + 2000,
+    ));
+    frames.extend(s.close(conn_id, ts_base_us + 3000));
+    frames
+}
+
+fn build_storage_config(db_path: &str) -> StorageConfig {
+    StorageConfig {
+        backend: "duckdb".into(),
+        duckdb: DuckDbConfig {
+            path: db_path.into(),
+        },
+        sink: StorageSinkConfig::default(),
+        retention: RetentionConfig::default(),
+        ..Default::default()
+    }
+}
+
+/// Run `pcap_specs` (synth-generated pcap + pipeline name) through the full
+/// pipeline into an on-disk DuckDB. Each spec becomes its own pipeline (so
+/// flow keys / turn state stay isolated) fanning into the shared storage
+/// sink. Returns the temp dir + db path so the caller can verify.
+async fn run_synth_pipeline(
+    pcap_specs: &[(&str, PathBuf, Vec<h_capture::RawPacket>)],
+) -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("synth.duckdb");
+    let storage_config = build_storage_config(&db_path.to_string_lossy());
+
+    let storage = create_backend(&storage_config).expect("create backend");
+    storage.init().await.expect("init storage");
+
+    // Write each synth pcap to disk and build a one-source pipeline per file.
+    let pipeline_defs: Vec<PipelineDef> = pcap_specs
+        .iter()
+        .map(|(name, path, frames)| {
+            write_pcap(path, frames);
+            PipelineDef {
+                name: (*name).to_string(),
+                sources: vec![CaptureSourceConfig::PcapFile {
+                    path: path.to_string_lossy().to_string(),
+                    realtime: false,
+                    source_id: None,
+                    loop_count: 1,
+                    loop_secs: 0,
+                    rate_pps: 0,
+                }],
+                ..PipelineDef::default()
+            }
+        })
+        .collect();
+
+    let mut per_pipeline_metrics: Vec<MetricsSystem> = (0..pipeline_defs.len())
+        .map(|_| MetricsSystem::new())
+        .collect();
+    let mut shared_metrics = MetricsSystem::new();
+
+    // Register capture metrics for each pipeline's single source.
+    let capture_metrics: Vec<_> = per_pipeline_metrics
+        .iter_mut()
+        .enumerate()
+        .map(|(i, sys)| {
+            sys.register_worker(
+                &format!("capture.synth.{i}"),
+                &[
+                    Metric::CapturePacketsReceived,
+                    Metric::CaptureKernelPacketsDropped,
+                    Metric::CaptureTruncatedPackets,
+                ],
+            )
+        })
+        .collect();
+
+    let sink_config = h_storage::StorageSinkConfig {
+        batch_size: storage_config.sink.batch_size,
+        flush_interval_ms: storage_config.sink.flush_interval_ms,
+    };
+
+    let Pipeline {
+        pipeline_txs,
+        pipeline_sources: _,
+        stage_handles,
+    } = Pipeline::build(
+        &pipeline_defs,
+        &sink_config,
+        storage.clone(),
+        &mut per_pipeline_metrics,
+        &mut shared_metrics,
+        h_turn::new_active_trace_registry(),
+        h_llm::agent_classifier::ClassifierConfig::default(),
+        h_common::config::BodyCapConfig::default(),
+    );
+    let _metrics_svcs: Vec<_> = per_pipeline_metrics.into_iter().map(|s| s.start()).collect();
+    let _shared_metrics_svc = shared_metrics.start();
+
+    // Each pcap source owns its pipeline's sender; EOF cascades down on drop.
+    let mut src_tasks = Vec::new();
+    for ((path, (_name, tx)), metrics) in pcap_specs
+        .iter()
+        .map(|(_, p, _)| p.clone())
+        .zip(pipeline_txs.into_iter())
+        .zip(capture_metrics.into_iter())
+    {
+        let cancel = CancellationToken::new();
+        src_tasks.push(tokio::spawn(async move {
+            let source_id = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let source = Box::new(PcapFileSource::new(path, source_id, None));
+            let _ = source.run(tx, metrics, cancel).await;
+        }));
+    }
+    for t in src_tasks {
+        t.await.expect("synth pcap source task panicked");
+    }
+    // Await every stage that drains on EOF (dispatcher → … → storage_sink).
+    // The pair_sweeper is a long-lived background loop (sleep + sweep, forever,
+    // holding its own `Arc<StorageBackend>`) — awaiting it would hang, so we
+    // detach it here and explicitly abort it once the draining stages are done.
+    // (`pipeline_e2e.rs` skips without fixtures so this latent issue is masked
+    // there; our synth pcaps always run, so we must not await the sweeper.)
+    for (task, h) in stage_handles {
+        if task.stage == "pair_sweeper" {
+            h.abort();
+            // A tokio task that has been aborted yields a JoinError (Cancelled)
+            // when awaited; await it to reap and ignore.
+            let _ = h.await;
+        } else {
+            h.await
+                .unwrap_or_else(|e| panic!("stage '{task}' panicked: {e}"));
+        }
+    }
+    drop(storage);
+    (tmp, db_path)
+}
+
+fn count(conn: &Connection, table: &str) -> i64 {
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+        .unwrap_or_else(|e| panic!("count {table}: {e}"))
+}
+
+fn distinct_wire_apis(conn: &Connection, table: &str) -> Vec<String> {
+    conn.prepare(&format!("SELECT DISTINCT wire_api FROM {table} ORDER BY 1"))
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+}
+
+/// A single anthropic synth pcap must populate all three tables and extract
+/// a complete `spans` row with the right model / path / tokens — the
+/// same ground truth `pipeline_e2e.rs` asserts against the binary fixture,
+/// now driven by generated bytes so it runs unconditionally.
+#[tokio::test]
+async fn synth_anthropic_pcap_populates_all_three_tables() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pcap_path = dir.path().join("claude-synth.pcap");
+    let frames = anthropic_frames("claude-synth", 1, 1_700_000_000_000_000);
+
+    // Keep the temp dir holding the pcap alive across the run.
+    let (_tmp, db_path) =
+        run_synth_pipeline(&[("claude", pcap_path, frames)]).await;
+
+    let conn = Connection::open(&db_path).expect("reopen duckdb");
+    let calls = count(&conn, "spans");
+    let turns = count(&conn, "traces");
+    let metrics = count(&conn, "llm_metrics");
+    assert!(calls >= 1, "expected >=1 spans, got {calls}");
+    assert!(turns >= 1, "expected >=1 traces, got {turns}");
+    assert!(metrics >= 1, "expected >=1 llm_metrics, got {metrics}");
+
+    let wire_apis = distinct_wire_apis(&conn, "spans");
+    assert!(
+        wire_apis.iter().any(|w| w == wa::ANTHROPIC),
+        "expected anthropic in spans wire_apis, got {wire_apis:?}"
+    );
+
+    // The synthesized response carried input=10 / output=5; the span row must
+    // reflect that extraction end-to-end.
+    let (model, path, status, in_t, out_t): (String, String, Option<u16>, Option<u32>, Option<u32>) =
+        conn.query_row(
+            "SELECT model, request_path, status_code, input_tokens, output_tokens \
+             FROM spans WHERE wire_api = 'anthropic' LIMIT 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .expect("anthropic span row");
+    assert_eq!(model, "claude-sonnet-4-6");
+    assert_eq!(path, "/v1/messages");
+    assert_eq!(status, Some(200));
+    assert_eq!(in_t, Some(10));
+    assert_eq!(out_t, Some(5));
+
+    // Metrics must have at least one anthropic 10s bucket — proves the
+    // llm stage → metrics shard → shared sink wiring.
+    let anthropic_10s: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(call_count), 0) FROM llm_metrics \
+             WHERE granularity = '10s' AND wire_api = 'anthropic'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("metrics sum");
+    assert!(anthropic_10s >= 1, "expected >=1 anthropic 10s metric, got {anthropic_10s}");
+
+    drop(conn);
+    drop(dir);
+}
+
+/// Two synth pcaps (anthropic + openai-responses) through two pipelines in
+/// parallel: both wire APIs land in `spans`, and each produces its own
+/// complete turn — proves per-pipeline isolation + the shared sink fan-in
+/// without any binary fixture.
+#[tokio::test]
+async fn synth_two_pipelines_isolated_metrics_merged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let anthropic_path = dir.path().join("claude-synth.pcap");
+    let openai_path = dir.path().join("codex-synth.pcap");
+    let anthropic = anthropic_frames("claude-synth", 1, 1_700_000_000_000_000);
+    let openai = openai_responses_frames("codex-synth", 2, 1_700_000_000_000_000);
+
+    let specs = [
+        ("claude", anthropic_path, anthropic),
+        ("codex", openai_path, openai),
+    ];
+    let (_tmp, db_path) = run_synth_pipeline(&specs).await;
+
+    let conn = Connection::open(&db_path).expect("reopen duckdb");
+
+    let span_apis = distinct_wire_apis(&conn, "spans");
+    assert!(
+        span_apis.iter().any(|w| w == wa::ANTHROPIC),
+        "expected anthropic in spans, got {span_apis:?}"
+    );
+    assert!(
+        span_apis.iter().any(|w| w == wa::OPENAI_RESPONSES),
+        "expected openai-responses in spans, got {span_apis:?}"
+    );
+
+    // Each pipeline produced its own turn (≥1 each) — proves neither
+    // sub-pipeline starved the other and turn state didn't leak.
+    let anthropic_turns: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM traces WHERE wire_api = 'anthropic' AND status = 'complete'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("anthropic turn count");
+    assert!(anthropic_turns >= 1, "anthropic pipeline produced a turn");
+    let openai_turns: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM traces WHERE wire_api = 'openai-responses'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("openai turn count");
+    assert!(openai_turns >= 1, "openai-responses pipeline produced a turn");
+
+    // Per-source metrics: both wire APIs appear in llm_metrics, each emitted
+    // by its own source_id (the pcap basename).
+    let metric_apis = distinct_wire_apis(&conn, "llm_metrics");
+    assert!(metric_apis.iter().any(|w| w == wa::ANTHROPIC));
+    assert!(metric_apis.iter().any(|w| w == wa::OPENAI_RESPONSES));
+
+    let source_ids: Vec<String> = conn
+        .prepare("SELECT DISTINCT source_id FROM llm_metrics ORDER BY 1")
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(source_ids.len(), 2, "expected 2 source_ids, got {source_ids:?}");
+    assert!(source_ids.iter().any(|s| s == "claude-synth"));
+    assert!(source_ids.iter().any(|s| s == "codex-synth"));
+
+    drop(conn);
+    drop(dir);
+}
+
+/// A pcap with no LLM-shaped traffic must drain cleanly and leave all three
+/// tables empty — guards against the pipeline inventing rows from noise and
+/// proves the EOF cascade still terminates with nothing to write.
+#[tokio::test]
+async fn synth_non_llm_pcap_drains_with_empty_tables() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pcap_path = dir.path().join("noise.pcap");
+    // A single TCP segment carrying plain text (not an HTTP request) — the
+    // HTTP parser / wire-API detector never accepts it, so no LlmCall is
+    // extracted. We synthesize via FlowSynthesizer so the frame decodes.
+    let mut s = FlowSynthesizer::new(SynthConfig {
+        source_id: "noise".to_string(),
+        ..SynthConfig::default()
+    });
+    let tuple = ConnTuple {
+        client: "203.0.113.9:53000".parse().unwrap(),
+        server: "192.0.2.30:80".parse().unwrap(),
+    };
+    let mut frames = s.open(7, tuple, 1_700_000_000_000_000);
+    frames.extend(s.data(
+        7,
+        StreamDir::ClientToServer,
+        b"not an http request just bytes",
+        0,
+        1_700_000_000_000_000 + 1000,
+    ));
+    frames.extend(s.data(
+        7,
+        StreamDir::ServerToClient,
+        b"nor is this a response",
+        0,
+        1_700_000_000_000_000 + 2000,
+    ));
+    frames.extend(s.close(7, 1_700_000_000_000_000 + 3000));
+
+    let (_tmp, db_path) = run_synth_pipeline(&[("noise", pcap_path, frames)]).await;
+    let conn = Connection::open(&db_path).expect("reopen duckdb");
+    assert_eq!(count(&conn, "spans"), 0, "no LLM traffic → no spans");
+    assert_eq!(count(&conn, "traces"), 0, "no LLM traffic → no traces");
+    assert_eq!(count(&conn, "llm_metrics"), 0, "no LLM traffic → no metrics");
+    drop(conn);
+    drop(dir);
+}


### PR DESCRIPTION
Automated pull request for Hera task `62c81c08-3524-47ea-b2a1-a75e79269232`.

INPUT: baseline gaps in `app/heron` (`pipeline.rs`, `cmd/*`, CLI); existing `cli_smoke`, `pipeline_e2e`, `signal_shutdown`; design §4.5.
WORK: Add table-driven tests for doctor/validate and config error paths with temp files; expand pipeline/CLI coverage using synth/file sources only (no CAP_NET_RAW/root); unit-test pure pipeline helpers where extractable.