### PR TITLE
hera: Console pure-logic coverage: lib, hooks, stores

### DIFF
--- a/console/src/hooks/use-agent-overview.test.ts
+++ b/console/src/hooks/use-agent-overview.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useAgentActivity, useAgentSummary } from "./use-agent-overview"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+describe("useAgentSummary", () => {
+  it("hits /api/traces/summary with the toolbar window", async () => {
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(() => useAgentSummary())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+    }, "/api/traces/summary"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+    void result
+  })
+})
+
+describe("useAgentActivity", () => {
+  it("hits /api/traces/activity with the toolbar window", async () => {
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(() => useAgentActivity())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+    }, "/api/traces/activity"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+  })
+})

--- a/console/src/hooks/use-agent-sessions.test.ts
+++ b/console/src/hooks/use-agent-sessions.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { act, waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import {
+  useAgentSessionDetail,
+  useAgentSessions,
+  useSessionTurns,
+} from "./use-agent-sessions"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+describe("useAgentSessions", () => {
+  it("hits /api/agent-sessions with window + page_size + agent_kind (cursor omitted on first page)", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () => useAgentSessions({ agentKind: "claude-cli", pageSize: 25 }),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      page_size: "25",
+      agent_kind: "claude-cli",
+      cursor: null,
+    }, "/api/agent-sessions"))
+    expect(qs.get("page_size")).toBe("25")
+    expect(qs.get("agent_kind")).toBe("claude-cli")
+    expect(qs.has("cursor")).toBe(false)
+  })
+
+  it("omits agent_kind when empty (|| undefined → omitted)", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () => useAgentSessions({ agentKind: "" }),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    findRequest(urls, { agent_kind: null }, "/api/agent-sessions")
+  })
+
+  it("defaults page_size to 50 when omitted", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(() => useAgentSessions({}))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(qsOf(findRequest(urls, { page_size: "50" }, "/api/agent-sessions")).get("page_size")).toBe("50")
+  })
+})
+
+describe("useAgentSessionDetail", () => {
+  it("is disabled when sourceId/sessionId are null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    renderHookWithProviders(() => useAgentSessionDetail(null, null))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+  })
+
+  it("hits /api/agent-sessions/:source/:session with URL-encoded ids", async () => {
+    const fake = { source_id: "s 1", session_id: "x y" }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useAgentSessionDetail("s 1", "x y"))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, `/api/agent-sessions/${encodeURIComponent("s 1")}/${encodeURIComponent("x y")}`))
+      .toBe(`/api/agent-sessions/${encodeURIComponent("s 1")}/${encodeURIComponent("x y")}`)
+    expect(result.current.data).toEqual(fake)
+  })
+})
+
+describe("useSessionTurns", () => {
+  it("is disabled when sourceId/sessionId are null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: { items: [], next_cursor: null } })
+    })
+    renderHookWithProviders(() => useSessionTurns(null, null))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+  })
+
+  it("hits the turns endpoint with page_size (cursor omitted on first page)", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(() => useSessionTurns("s1", "ses1", 30))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, { page_size: "30", cursor: null }, "/api/agent-sessions/s1/ses1/turns"))
+    expect(qs.get("page_size")).toBe("30")
+    expect(qs.has("cursor")).toBe(false)
+  })
+
+  it("sends the cursor when provided via pageParam (next page)", async () => {
+    const urls: string[] = []
+    // First page (no cursor) → next_cursor "cur2"; second page (cursor=cur2)
+    // → next_cursor null (last page) so hasNextPage flips to false.
+    mockFetch((input) => {
+      const u = String(input)
+      urls.push(u)
+      const qs = new URLSearchParams(u.split("?")[1] ?? "")
+      const next_cursor = qs.get("cursor") === "cur2" ? null : "cur2"
+      return jsonResponse({ code: 0, message: "ok", data: { items: [], next_cursor } })
+    })
+    const { result } = renderHookWithProviders(() => useSessionTurns("s1", "ses1"))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.hasNextPage).toBe(true)
+    // Fetch the next page; pageParam becomes "cur2" → cursor=cur2.
+    await act(async () => {
+      await result.current.fetchNextPage()
+    })
+    await waitFor(() => expect(result.current.hasNextPage).toBe(false))
+    // The cursor=cur2 request was sent.
+    findRequest(urls, { cursor: "cur2" }, "/api/agent-sessions/s1/ses1/turns")
+  })
+})

--- a/console/src/hooks/use-agent-turns.test.ts
+++ b/console/src/hooks/use-agent-turns.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import {
+  useAgentTurnCalls,
+  useAgentTurnDetail,
+  useAgentTurnProxyView,
+  useAgentTurns,
+} from "./use-agent-turns"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+const baseParams = {
+  page: 2,
+  pageSize: 25,
+  sortBy: "ts",
+  sortOrder: "asc" as const,
+}
+
+describe("useAgentTurns", () => {
+  it("hits /api/traces with window + pagination + sort", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useAgentTurns(baseParams),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      page: "2",
+      page_size: "25",
+      sort_by: "ts",
+      sort_order: "asc",
+    }, "/api/traces"))
+    // /api/traces is a prefix of /api/traces/:id; the list fetch carries
+    // page/page_size so findRequest's full match picks it over a detail fetch.
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("page")).toBe("2")
+    expect(qs.get("page_size")).toBe("25")
+    expect(qs.get("sort_by")).toBe("ts")
+    expect(qs.get("sort_order")).toBe("asc")
+  })
+
+  it("serializes every CSV/flag filter when set, including include_proxy_hops", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () =>
+        useAgentTurns({
+          ...baseParams,
+          status: "success,error",
+          agentKind: "claude-cli,codex-cli",
+          clientIp: "10.0.0.1,10.0.0.2",
+          serverPort: "4210,9000",
+          includeProxyHops: true,
+        }),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      status: "success,error",
+      agent_kind: "claude-cli,codex-cli",
+      client_ip: "10.0.0.1,10.0.0.2",
+      server_port: "4210,9000",
+      include_proxy_hops: "true",
+    }, "/api/traces"))
+    expect(qs.get("status")).toBe("success,error")
+    expect(qs.get("agent_kind")).toBe("claude-cli,codex-cli")
+    expect(qs.get("client_ip")).toBe("10.0.0.1,10.0.0.2")
+    expect(qs.get("server_port")).toBe("4210,9000")
+    expect(qs.get("include_proxy_hops")).toBe("true")
+  })
+
+  it("omits empty CSV filters and keeps include_proxy_hops off when false", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () =>
+        useAgentTurns({
+          ...baseParams,
+          status: "",
+          agentKind: "",
+          clientIp: "",
+          serverPort: "",
+          includeProxyHops: false,
+        }),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      status: null,
+      agent_kind: null,
+      client_ip: null,
+      server_port: null,
+      include_proxy_hops: null,
+    }, "/api/traces"))
+    for (const k of ["status", "agent_kind", "client_ip", "server_port", "include_proxy_hops"]) {
+      expect(qs.has(k)).toBe(false)
+    }
+  })
+
+  it("includes the route-supported dimension filters", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useAgentTurns(baseParams),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    }, "/api/traces"))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+  })
+})
+
+describe("useAgentTurnDetail", () => {
+  it("is disabled when id is null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    const { result } = renderHookWithProviders(() => useAgentTurnDetail(null))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+    expect(result.current.fetchStatus).toBe("idle")
+  })
+
+  it("hits /api/traces/:id when id is set", async () => {
+    const urls = captureRequests({ id: "t1" })
+    const { result } = renderHookWithProviders(() => useAgentTurnDetail("t1"))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/traces/t1")).toBe("/api/traces/t1")
+  })
+})
+
+describe("useAgentTurnCalls", () => {
+  it("hits /api/traces/:id/spans with no query when lite is false", async () => {
+    const urls = captureRequests([])
+    const { result } = renderHookWithProviders(() => useAgentTurnCalls("t1", false))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, { lite: null }, "/api/traces/t1/spans")).toBe("/api/traces/t1/spans")
+  })
+
+  it("adds lite=1 when lite is true (heavy-field NULLing)", async () => {
+    const urls = captureRequests([])
+    const { result } = renderHookWithProviders(() => useAgentTurnCalls("t1", true))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, { lite: "1" }, "/api/traces/t1/spans"))
+    expect(qs.get("lite")).toBe("1")
+  })
+
+  it("is disabled when id is null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: [] })
+    })
+    renderHookWithProviders(() => useAgentTurnCalls(null))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+  })
+})
+
+describe("useAgentTurnProxyView", () => {
+  it("is disabled when id is null (regardless of enabled)", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    renderHookWithProviders(() => useAgentTurnProxyView(null, true))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+  })
+
+  it("is disabled when enabled is false even with an id", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    renderHookWithProviders(() => useAgentTurnProxyView("t1", false))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+  })
+
+  it("hits /api/traces/:id/proxy-view when enabled with an id", async () => {
+    const urls = captureRequests({ legs: [] })
+    const { result } = renderHookWithProviders(() => useAgentTurnProxyView("t1", true))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/traces/t1/proxy-view")).toBe("/api/traces/t1/proxy-view")
+  })
+})

--- a/console/src/hooks/use-auto-refresh.test.ts
+++ b/console/src/hooks/use-auto-refresh.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import { renderHookWithProviders, resetStore, setWindowOrigin } from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useAutoRefresh } from "./use-auto-refresh"
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+// useToolbarStore is a module singleton shared across test files in one bun
+// worker process. Replacing one of its action methods with a spy would leak
+// that spy into every later file in the process (e.g. use-url-sync's
+// setPreset would become a no-op). So we capture the real actions up front and
+// restore them — and the whole window — in afterEach.
+const REAL_ACTIONS = {
+  setPreset: useToolbarStore.getState().setPreset,
+  setCustomRange: useToolbarStore.getState().setCustomRange,
+  setFilter: useToolbarStore.getState().setFilter,
+  setRefreshInterval: useToolbarStore.getState().setRefreshInterval,
+  _hydrate: useToolbarStore.getState()._hydrate,
+}
+
+function restoreStore() {
+  resetStore(useToolbarStore, {
+    preset: "1h",
+    start: 0,
+    end: PRESET_SECONDS["1h"],
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+    setPreset: REAL_ACTIONS.setPreset,
+    setCustomRange: REAL_ACTIONS.setCustomRange,
+    setFilter: REAL_ACTIONS.setFilter,
+    setRefreshInterval: REAL_ACTIONS.setRefreshInterval,
+    _hydrate: REAL_ACTIONS._hydrate,
+  })
+}
+
+// useAutoRefresh reads refreshInterval + preset off the toolbar store and
+// calls setPreset on an interval — skipped when refreshInterval <= 0 or the
+// preset is "custom". We spy on setPreset to assert the cadence + the guard.
+// A short refreshInterval (25ms) keeps the suite fast.
+function renderWith(refreshInterval: number, preset: string, spy: ReturnType<typeof mock>) {
+  resetStore(useToolbarStore, {
+    preset: preset as ReturnType<typeof useToolbarStore.getState>["preset"],
+    start: 0,
+    end: 0,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval,
+    setPreset: spy as unknown as ReturnType<typeof useToolbarStore.getState>["setPreset"],
+  })
+  return renderHookWithProviders(() => useAutoRefresh())
+}
+
+afterEach(() => restoreStore())
+
+describe("useAutoRefresh", () => {
+  it("calls setPreset on the interval when refreshInterval > 0 and preset is not custom", async () => {
+    const spy = mock(() => {})
+    const { unmount } = renderWith(25, "1h", spy)
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1), { timeout: 500 })
+    // A second tick confirms it's recurring, not one-shot.
+    await waitFor(() => expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2), { timeout: 500 })
+    unmount()
+  })
+
+  it("does NOT call setPreset when refreshInterval <= 0", async () => {
+    const spy = mock(() => {})
+    const { unmount } = renderWith(0, "1h", spy)
+    // Wait past a couple of would-be ticks.
+    await new Promise((r) => setTimeout(r, 60))
+    expect(spy).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it("does NOT call setPreset when the preset is 'custom'", async () => {
+    const spy = mock(() => {})
+    const { unmount } = renderWith(25, "custom", spy)
+    await new Promise((r) => setTimeout(r, 60))
+    expect(spy).not.toHaveBeenCalled()
+    unmount()
+  })
+})

--- a/console/src/hooks/use-capture-interfaces.test.ts
+++ b/console/src/hooks/use-capture-interfaces.test.ts
@@ -1,0 +1,35 @@
+import { beforeAll, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  renderHookWithProviders,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { useCaptureInterfaces } from "./use-capture-interfaces"
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+describe("useCaptureInterfaces", () => {
+  it("hits /api/capture/interfaces (no params) and returns the data", async () => {
+    const fake = { interfaces: [] }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useCaptureInterfaces())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/capture/interfaces")).toBe("/api/capture/interfaces")
+    expect(result.current.data).toEqual(fake)
+  })
+
+  it("does not auto-refetch on mount (staleTime Infinity)", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: { interfaces: [] } })
+    })
+    const { result } = renderHookWithProviders(() => useCaptureInterfaces())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(calls).toBe(1) // a single fetch, no background refetch
+  })
+})

--- a/console/src/hooks/use-filter-values.test.ts
+++ b/console/src/hooks/use-filter-values.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import {
+  useAgentKinds,
+  useFinishReasons,
+  useModelNames,
+  useServerIps,
+  useWireApis,
+} from "./use-filter-values"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+describe("useWireApis / useModelNames / useServerIps", () => {
+  it("hits the matching filter endpoint with no params", async () => {
+    const urls = captureRequests({ values: [] })
+    const { result } = renderHookWithProviders(() => useWireApis())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/filters/wire-apis")).toBe("/api/filters/wire-apis")
+  })
+
+  it("useModelNames hits /api/filters/models", async () => {
+    const urls = captureRequests({ values: [] })
+    const { result } = renderHookWithProviders(() => useModelNames())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/filters/models")).toBe("/api/filters/models")
+  })
+
+  it("useServerIps hits /api/filters/server-ips", async () => {
+    const urls = captureRequests({ values: [] })
+    const { result } = renderHookWithProviders(() => useServerIps())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/filters/server-ips")).toBe("/api/filters/server-ips")
+  })
+})
+
+describe("useAgentKinds", () => {
+  it("hits /api/filters/agent-kinds with the toolbar window + supported dims", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests({ values: [] })
+    const { result } = renderHookWithProviders(
+      () => useAgentKinds(),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      end: String(NOW_S),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+      include_proxy_hops: null,
+    }, "/api/filters/agent-kinds"))
+    expect(qs.get("start")).toBe(String(NOW_S - 100))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+    expect(qs.has("include_proxy_hops")).toBe(false)
+  })
+
+  it("adds include_proxy_hops=true only when the flag is set", async () => {
+    const urls = captureRequests({ values: [] })
+    const { result } = renderHookWithProviders(
+      () => useAgentKinds({ includeProxyHops: true }),
+      { initialEntries: ["/agent-turns"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(qsOf(findRequest(urls, { include_proxy_hops: "true" }, "/api/filters/agent-kinds")).get("include_proxy_hops")).toBe("true")
+  })
+})
+
+describe("useFinishReasons", () => {
+  it("hits /api/filters/finish-reasons and returns pairs", async () => {
+    const fake = { pairs: [{ wire_api: "anthropic", finish_reason: "end_turn" }] }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useFinishReasons())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/filters/finish-reasons")).toBe("/api/filters/finish-reasons")
+    expect(result.current.data).toEqual(fake)
+  })
+
+  it("is disabled (no fetch) when enabled:false", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: { pairs: [] } })
+    })
+    const { result } = renderHookWithProviders(() => useFinishReasons({ enabled: false }))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+    expect(result.current.fetchStatus).toBe("idle")
+  })
+})

--- a/console/src/hooks/use-finish-reason-timeseries.test.ts
+++ b/console/src/hooks/use-finish-reason-timeseries.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useFinishReasonTimeseries } from "./use-finish-reason-timeseries"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setRange(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setRange(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+function granularityOf(urls: string[], start: string, end: string): string | null {
+  return qsOf(findRequest(urls, { start, end }, "/api/metrics/finish-reasons")).get("granularity")
+}
+
+describe("useFinishReasonTimeseries", () => {
+  it("hits /api/metrics/finish-reasons with window + granularity", async () => {
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(
+      () => useFinishReasonTimeseries(),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      granularity: "1m", // 1h (3600s) → 1m
+    }, "/api/metrics/finish-reasons"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+    expect(qs.get("granularity")).toBe("1m")
+  })
+
+  it("includes the route-supported dimension filters", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(
+      () => useFinishReasonTimeseries(),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    }, "/api/metrics/finish-reasons"))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+  })
+
+  const granularityCases: Array<[number, string]> = [
+    [900, "10s"],
+    [901, "1m"],
+    [7200, "1m"],
+    [7201, "5m"],
+    [86400, "5m"],
+    [86401, "1h"],
+  ]
+  for (const [span, expected] of granularityCases) {
+    it(`range ${span}s → granularity ${expected}`, async () => {
+      setRange(NOW_S - span, NOW_S)
+      const urls = captureRequests({ series: [] })
+      const { result } = renderHookWithProviders(
+        () => useFinishReasonTimeseries(),
+        { initialEntries: ["/llm-calls"] },
+      )
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(granularityOf(urls, String(NOW_S - span), String(NOW_S))).toBe(expected)
+    })
+  }
+
+  it("an explicit granularity opts out of auto-compute", async () => {
+    setRange(NOW_S - 24 * 3600, NOW_S) // would auto-pick 5m
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(
+      () => useFinishReasonTimeseries({ granularity: "1h" }),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(granularityOf(urls, String(NOW_S - 24 * 3600), String(NOW_S))).toBe("1h")
+  })
+})

--- a/console/src/hooks/use-http-exchange.test.ts
+++ b/console/src/hooks/use-http-exchange.test.ts
@@ -1,0 +1,40 @@
+import { beforeAll, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  renderHookWithProviders,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { useHttpExchange } from "./use-http-exchange"
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+describe("useHttpExchange", () => {
+  it("is disabled (no fetch) when id is null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    const { result } = renderHookWithProviders(() => useHttpExchange(null))
+    // Give any pending fetch a chance to run (it shouldn't).
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it("hits /api/http-exchanges/:id with URL-encoded id when id is set", async () => {
+    const id = "a b" // space — a realistic opaque id that must be encoded
+    const fake = { id }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useHttpExchange(id))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, `/api/http-exchanges/${encodeURIComponent(id)}`))
+      .toBe(`/api/http-exchanges/${encodeURIComponent(id)}`)
+    expect(result.current.data).toEqual(fake)
+  })
+})

--- a/console/src/hooks/use-http-exchanges.test.ts
+++ b/console/src/hooks/use-http-exchanges.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useHttpExchanges } from "./use-http-exchanges"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+const baseParams = {
+  page: 1,
+  pageSize: 50,
+  sortBy: "ts",
+  sortOrder: "desc" as const,
+}
+
+describe("useHttpExchanges", () => {
+  it("hits /api/http-exchanges with window + pagination + sort", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useHttpExchanges(baseParams),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      page: "1",
+      page_size: "50",
+      sort_by: "ts",
+      sort_order: "desc",
+    }, "/api/http-exchanges"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("page")).toBe("1")
+    expect(qs.get("page_size")).toBe("50")
+    expect(qs.get("sort_by")).toBe("ts")
+    expect(qs.get("sort_order")).toBe("desc")
+  })
+
+  it("serializes the method/status/clientIp/uri filters when set", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () =>
+        useHttpExchanges({
+          ...baseParams,
+          method: "GET,POST",
+          status: "200,500",
+          clientIp: "10.0.0.1",
+          uri: "/v1/chat",
+        }),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      method: "GET,POST",
+      status: "200,500",
+      client_ip: "10.0.0.1",
+      uri: "/v1/chat",
+    }, "/api/http-exchanges"))
+    expect(qs.get("method")).toBe("GET,POST")
+    expect(qs.get("status")).toBe("200,500")
+    expect(qs.get("client_ip")).toBe("10.0.0.1")
+    expect(qs.get("uri")).toBe("/v1/chat")
+  })
+
+  it("omits empty method/status/clientIp/uri and includes only serverIp dimension", async () => {
+    // /http-exchanges spec is ["serverIp"] — wireApi/model are stripped.
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useHttpExchanges(baseParams),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      server_ip: "10.0.0.1",
+      method: null,
+      status: null,
+      client_ip: null,
+      uri: null,
+      is_sse: null,
+      wire_api: null,
+      model: null,
+    }, "/api/http-exchanges"))
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+    expect(qs.has("wire_api")).toBe(false)
+    expect(qs.has("model")).toBe(false)
+    for (const k of ["method", "status", "client_ip", "uri", "is_sse"]) {
+      expect(qs.has(k)).toBe(false)
+    }
+  })
+
+  it("serializes is_sse as 'true' when true (SSE only)", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useHttpExchanges({ ...baseParams, isSse: true }),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(qsOf(findRequest(urls, { is_sse: "true" }, "/api/http-exchanges")).get("is_sse")).toBe("true")
+  })
+
+  it("serializes is_sse as 'false' when false (non-SSE only)", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useHttpExchanges({ ...baseParams, isSse: false }),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(qsOf(findRequest(urls, { is_sse: "false" }, "/api/http-exchanges")).get("is_sse")).toBe("false")
+  })
+
+  it("omits is_sse when undefined (any)", async () => {
+    const urls = captureRequests({ items: [], page: 1, total: 0 })
+    const { result } = renderHookWithProviders(
+      () => useHttpExchanges({ ...baseParams }),
+      { initialEntries: ["/http-exchanges"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    findRequest(urls, { is_sse: null }, "/api/http-exchanges")
+  })
+})

--- a/console/src/hooks/use-internal-metrics.test.ts
+++ b/console/src/hooks/use-internal-metrics.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  createTestQueryClient,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { usePipelineHealthStore } from "@/stores/pipeline-health"
+import { useInternalMetrics, useInternalMetricsSeries } from "./use-internal-metrics"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => (restoreClock = pinClock(NOW_S * 1000)))
+afterEach(() => {
+  restoreClock()
+  resetStore(usePipelineHealthStore, {
+    intervalMs: 2000,
+    selectedPipeline: null,
+    tableGroupFilter: "all",
+    tableOnlyWarn: false,
+  })
+})
+
+// The resolved `refetchInterval` option isn't surfaced on the query result
+// object in this TanStack version; read it off the live QueryObserver instead.
+function observerRefetchInterval(qcKey: ReturnType<typeof createTestQueryClient>): number | false | undefined {
+  const q = qcKey.getQueryCache().getAll()[0]
+  return q.observers[0]?.options.refetchInterval
+}
+
+describe("useInternalMetrics", () => {
+  it("hits /api/internal-metrics (no params) and returns the data", async () => {
+    const fake = { ts: 1, metrics: [] }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useInternalMetrics())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/internal-metrics")).toBe("/api/internal-metrics")
+    expect(result.current.data).toEqual(fake)
+  })
+
+  it("maps a null intervalMs (paused) to refetchInterval=false", () => {
+    resetStore(usePipelineHealthStore, {
+      intervalMs: null,
+      selectedPipeline: null,
+      tableGroupFilter: "all",
+      tableOnlyWarn: false,
+    })
+    const qc = createTestQueryClient()
+    renderHookWithProviders(() => useInternalMetrics(), { queryClient: qc })
+    expect(observerRefetchInterval(qc)).toBe(false)
+  })
+
+  it("maps a numeric intervalMs to refetchInterval (ms)", () => {
+    resetStore(usePipelineHealthStore, {
+      intervalMs: 1234,
+      selectedPipeline: null,
+      tableGroupFilter: "all",
+      tableOnlyWarn: false,
+    })
+    const qc = createTestQueryClient()
+    const { unmount } = renderHookWithProviders(() => useInternalMetrics(), { queryClient: qc })
+    expect(observerRefetchInterval(qc)).toBe(1234)
+    // Unmount before the refetch timer fires to keep the run act-clean.
+    unmount()
+  })
+})
+
+describe("useInternalMetricsSeries", () => {
+  it("hits the bare series URL when no since/metrics are given", async () => {
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(() => useInternalMetricsSeries())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/internal-metrics/series")).toBe("/api/internal-metrics/series")
+  })
+
+  it("appends since + metrics query params when provided", async () => {
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(() =>
+      useInternalMetricsSeries({ sinceMs: 1000, metrics: ["flows_active", "turns_active"] }),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      since: "1000",
+      metrics: "flows_active,turns_active",
+    }, "/api/internal-metrics/series"))
+    expect(qs.get("since")).toBe("1000")
+    expect(qs.get("metrics")).toBe("flows_active,turns_active")
+  })
+
+  it("omits since when <= 0, and metrics when empty", async () => {
+    const urls = captureRequests({ series: [] })
+    const { result } = renderHookWithProviders(() =>
+      useInternalMetricsSeries({ sinceMs: 0, metrics: [] }),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    // since=0 → omitted; empty metrics → omitted → bare series URL.
+    expect(findRequest(urls, { since: null, metrics: null }, "/api/internal-metrics/series"))
+      .toBe("/api/internal-metrics/series")
+    void result
+  })
+
+  it("defaults the poll interval to 10s", () => {
+    const qc = createTestQueryClient()
+    const { unmount } = renderHookWithProviders(() => useInternalMetricsSeries(), { queryClient: qc })
+    expect(observerRefetchInterval(qc)).toBe(10_000)
+    unmount()
+  })
+
+  it("honours an explicit intervalMs option", () => {
+    const qc = createTestQueryClient()
+    const { unmount } = renderHookWithProviders(() => useInternalMetricsSeries({ intervalMs: 3000 }), { queryClient: qc })
+    expect(observerRefetchInterval(qc)).toBe(3000)
+    unmount()
+  })
+
+  it("honours a null intervalMs (paused)", () => {
+    const qc = createTestQueryClient()
+    renderHookWithProviders(() => useInternalMetricsSeries({ intervalMs: null }), { queryClient: qc })
+    expect(observerRefetchInterval(qc)).toBe(false)
+  })
+})

--- a/console/src/hooks/use-llm-call-detail.test.ts
+++ b/console/src/hooks/use-llm-call-detail.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  jsonResponse,
+  mockFetch,
+  renderHookWithProviders,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { useLlmCallDetail } from "./use-llm-call-detail"
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+describe("useLlmCallDetail", () => {
+  it("is disabled (no fetch) when id is null", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls++
+      return jsonResponse({ code: 0, message: "ok", data: {} })
+    })
+    const { result } = renderHookWithProviders(() => useLlmCallDetail(null))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(0)
+    expect(result.current.fetchStatus).toBe("idle")
+  })
+
+  it("hits /api/spans/:id with URL-encoded id when id is set", async () => {
+    const id = "s 1"
+    const fake = { id }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useLlmCallDetail(id))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, `/api/spans/${encodeURIComponent(id)}`))
+      .toBe(`/api/spans/${encodeURIComponent(id)}`)
+    expect(result.current.data).toEqual(fake)
+  })
+})

--- a/console/src/hooks/use-llm-calls.test.ts
+++ b/console/src/hooks/use-llm-calls.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useLlmCalls } from "./use-llm-calls"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+const baseParams = {
+  page: 1,
+  pageSize: 50,
+  sortBy: "ts",
+  sortOrder: "desc" as const,
+}
+
+describe("useLlmCalls", () => {
+  it("hits /api/spans with window + pagination + sort params", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () => useLlmCalls(baseParams),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      page: "1",
+      page_size: "50",
+      sort_by: "ts",
+      sort_order: "desc",
+    }, "/api/spans"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+    expect(qs.get("page")).toBe("1")
+    expect(qs.get("page_size")).toBe("50")
+    expect(qs.get("sort_by")).toBe("ts")
+    expect(qs.get("sort_order")).toBe("desc")
+  })
+
+  it("omits empty/undefined page-specific filters", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () => useLlmCalls(baseParams),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      status_code: null,
+      finish_reason: null,
+      client_ip: null,
+      server_port: null,
+      request_path: null,
+      is_stream: null,
+    }, "/api/spans"))
+    for (const key of ["status_code", "finish_reason", "client_ip", "server_port", "request_path", "is_stream"]) {
+      expect(qs.has(key)).toBe(false)
+    }
+  })
+
+  it("serializes every page-specific filter when set", async () => {
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () =>
+        useLlmCalls({
+          ...baseParams,
+          statusCode: "500",
+          finishReason: "stop",
+          clientIp: "10.0.0.1",
+          serverPort: "443,9000",
+          requestPath: "/v1/chat",
+          isStream: "stream",
+        }),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      status_code: "500",
+      finish_reason: "stop",
+      client_ip: "10.0.0.1",
+      server_port: "443,9000",
+      request_path: "/v1/chat",
+      is_stream: "stream",
+    }, "/api/spans"))
+    expect(qs.get("status_code")).toBe("500")
+    expect(qs.get("finish_reason")).toBe("stop")
+    expect(qs.get("client_ip")).toBe("10.0.0.1")
+    expect(qs.get("server_port")).toBe("443,9000")
+    expect(qs.get("request_path")).toBe("/v1/chat")
+    expect(qs.get("is_stream")).toBe("stream")
+  })
+
+  it("includes the route-supported dimension filters (wireApi/model/serverIp)", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests({ items: [], next_cursor: null })
+    const { result } = renderHookWithProviders(
+      () => useLlmCalls(baseParams),
+      { initialEntries: ["/llm-calls"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    }, "/api/spans"))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+  })
+})

--- a/console/src/hooks/use-metrics.test.ts
+++ b/console/src/hooks/use-metrics.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useMetricsSummary, useModels, useTimeseries } from "./use-metrics"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setRange(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setRange(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+function granularityOf(urls: string[], start: string, end: string): string | null {
+  return qsOf(findRequest(urls, { start, end, fields: "ttft_p95" }, "/api/metrics/timeseries")).get("granularity")
+}
+
+describe("useMetricsSummary", () => {
+  it("hits /api/metrics/summary with window + supported dims", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(
+      () => useMetricsSummary(),
+      { initialEntries: ["/performance"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      end: String(NOW_S),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    }, "/api/metrics/summary"))
+    expect(qs.get("start")).toBe(String(NOW_S - 100))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+  })
+})
+
+describe("useModels", () => {
+  it("hits /api/metrics/models with window + supported dims", async () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: NOW_S - 100,
+      end: NOW_S,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(
+      () => useModels(),
+      { initialEntries: ["/models"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - 100),
+      end: String(NOW_S),
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    }, "/api/metrics/models"))
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+  })
+})
+
+describe("useTimeseries — granularity auto-compute", () => {
+  // Buckets: ≤900s → 10s, ≤7200s → 1m, ≤86400s → 5m, else 1h.
+  const cases: Array<[number, string]> = [
+    [15 * 60, "10s"], // 900s
+    [900, "10s"], // exactly 900s boundary
+    [901, "1m"], // just over → 1m
+    [2 * 3600, "1m"], // 7200s
+    [7200, "1m"], // exactly 7200s
+    [7201, "5m"], // just over → 5m
+    [24 * 3600, "5m"], // 86400s
+    [86401, "1h"], // over a day → 1h
+    [7 * 24 * 3600, "1h"], // 7d
+  ]
+
+  for (const [spanSec, expected] of cases) {
+    it(`range ${spanSec}s → granularity ${expected}`, async () => {
+      setRange(NOW_S - spanSec, NOW_S)
+      const urls = captureRequests()
+      const { result } = renderHookWithProviders(
+        () => useTimeseries("ttft_p95"),
+        { initialEntries: ["/performance"] },
+      )
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(granularityOf(urls, String(NOW_S - spanSec), String(NOW_S))).toBe(expected)
+    })
+  }
+
+  it("an explicit granularity opts out of auto-compute", async () => {
+    setRange(NOW_S - 24 * 3600, NOW_S) // would auto-pick 5m
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(
+      () => useTimeseries("ttft_p95", { granularity: "30s" }),
+      { initialEntries: ["/performance"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(granularityOf(urls, String(NOW_S - 24 * 3600), String(NOW_S))).toBe("30s")
+  })
+
+  it("sends fields + group_by + tool_surface", async () => {
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(
+      () => useTimeseries("ttft_p95,e2e", { groupBy: "model", toolSurface: "mcp" }),
+      { initialEntries: ["/performance"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      fields: "ttft_p95,e2e",
+      group_by: "model",
+      tool_surface: "mcp",
+    }, "/api/metrics/timeseries"))
+    expect(qs.get("fields")).toBe("ttft_p95,e2e")
+    expect(qs.get("group_by")).toBe("model")
+    expect(qs.get("tool_surface")).toBe("mcp")
+  })
+
+  it("omits tool_surface when the option is an empty string", async () => {
+    const urls = captureRequests()
+    const { result } = renderHookWithProviders(
+      () => useTimeseries("ttft_p95", { toolSurface: "" }),
+      { initialEntries: ["/performance"] },
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    findRequest(urls, { fields: "ttft_p95", tool_surface: null }, "/api/metrics/timeseries")
+  })
+})

--- a/console/src/hooks/use-runtime-config.test.ts
+++ b/console/src/hooks/use-runtime-config.test.ts
@@ -1,0 +1,22 @@
+import { beforeAll, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  renderHookWithProviders,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { useRuntimeConfig } from "./use-runtime-config"
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+describe("useRuntimeConfig", () => {
+  it("hits /api/runtime-config (no params) and returns the data", async () => {
+    const fake = { loaded_at_ms: 1, config_path: "/x", version: "0.7", ebpf_available: false, config: {} }
+    const urls = captureRequests(fake)
+    const { result } = renderHookWithProviders(() => useRuntimeConfig())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(findRequest(urls, {}, "/api/runtime-config")).toBe("/api/runtime-config")
+    expect(result.current.data).toEqual(fake)
+  })
+})

--- a/console/src/hooks/use-search-param-state.test.ts
+++ b/console/src/hooks/use-search-param-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test"
+import { act, waitFor } from "@testing-library/react"
+import { renderHookWithProviders } from "../../test/mocks"
+import { useSearchParamState } from "./use-search-param-state"
+
+// Two hook instances under one router so their setValue calls in the same
+// tick share the module-level batched-flush. Returns both [value, setter].
+function useTwo(k1: string, d1: string, k2: string, d2: string) {
+  const a = useSearchParamState(k1, d1)
+  const b = useSearchParamState(k2, d2)
+  return { a, b }
+}
+
+describe("useSearchParamState", () => {
+  it("returns the default when the param is absent", () => {
+    const { result } = renderHookWithProviders(() => useSearchParamState("foo", "bar"), {
+      initialEntries: ["/x"],
+    })
+    expect(result.current[0]).toBe("bar")
+  })
+
+  it("reads the initial value from the URL", () => {
+    const { result } = renderHookWithProviders(() => useSearchParamState("foo", "bar"), {
+      initialEntries: ["/x?foo=zzz"],
+    })
+    expect(result.current[0]).toBe("zzz")
+  })
+
+  it("setValue updates the param (and reflects in the next render)", async () => {
+    const { result } = renderHookWithProviders(() => useSearchParamState("foo", "bar"), {
+      initialEntries: ["/x"],
+    })
+    await act(async () => {
+      result.current[1]("newval")
+    })
+    await waitFor(() => expect(result.current[0]).toBe("newval"))
+  })
+
+  it("setting the default value clears (deletes) the param", async () => {
+    const { result } = renderHookWithProviders(() => useSearchParamState("foo", "bar"), {
+      initialEntries: ["/x?foo=zzz"],
+    })
+    await act(async () => {
+      result.current[1]("bar") // equal to default → null → delete
+    })
+    await waitFor(() => expect(result.current[0]).toBe("bar"))
+    // The param is no longer in the URL (value falls back to default).
+  })
+
+  it("batches two keys set in the same tick into one navigation (later does not overwrite earlier)", async () => {
+    const { result } = renderHookWithProviders(
+      () => useTwo("a", "0", "b", "0"),
+      { initialEntries: ["/x"] },
+    )
+    // Fire both setters synchronously in one tick.
+    await act(async () => {
+      result.current.a[1]("1")
+      result.current.b[1]("2")
+      // The microtask flush runs after this sync block; let it drain.
+      await Promise.resolve()
+    })
+    // Both params land in the same URL (single replace navigation).
+    await waitFor(() => {
+      expect(result.current.a[0]).toBe("1")
+      expect(result.current.b[0]).toBe("2")
+    })
+  })
+})

--- a/console/src/hooks/use-services-topology.test.ts
+++ b/console/src/hooks/use-services-topology.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useServicesTopology } from "./use-services-topology"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+describe("useServicesTopology", () => {
+  it("hits /api/services/topology with the toolbar window", async () => {
+    const urls = captureRequests({ nodes: [], edges: [] })
+    const { result } = renderHookWithProviders(() => useServicesTopology())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+    }, "/api/services/topology"))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+  })
+})

--- a/console/src/hooks/use-services.test.ts
+++ b/console/src/hooks/use-services.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import {
+  captureRequests,
+  findRequest,
+  pinClock,
+  qsOf,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useServices } from "./use-services"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+function setWindow(start: number, end: number) {
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start,
+    end,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+}
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  setWindow(NOW_S - PRESET_SECONDS["1h"], NOW_S)
+})
+afterEach(() => restoreClock())
+
+// Capture every fetch URL the hook makes into an array; assert on the request
+// whose params identify THIS test (via findRequest) so a stray refetch from
+// another query under parallel contention can't masquerade as this one.
+describe("useServices", () => {
+  it("hits /api/services with the toolbar window + sort/limit params", async () => {
+    const urls = captureRequests({ services: [] })
+    const { result } = renderHookWithProviders(() =>
+      useServices({ sortBy: "call_count", sortOrder: "desc", limit: 50 }),
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      sort_by: "call_count",
+      sort_order: "desc",
+      limit: "50",
+    }))
+    expect(qs.get("start")).toBe(String(NOW_S - PRESET_SECONDS["1h"]))
+    expect(qs.get("end")).toBe(String(NOW_S))
+    expect(qs.get("sort_by")).toBe("call_count")
+    expect(qs.get("sort_order")).toBe("desc")
+    expect(qs.get("limit")).toBe("50")
+    expect(result.current.data).toEqual({ services: [] })
+  })
+
+  it("defaults sortBy=call_count, sortOrder=desc, limit=200 when omitted", async () => {
+    const urls = captureRequests({ services: [] })
+    const { result } = renderHookWithProviders(() => useServices())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, {
+      start: String(NOW_S - PRESET_SECONDS["1h"]),
+      end: String(NOW_S),
+      sort_by: "call_count",
+      sort_order: "desc",
+      limit: "200",
+    }))
+    expect(qs.get("sort_by")).toBe("call_count")
+    expect(qs.get("sort_order")).toBe("desc")
+    expect(qs.get("limit")).toBe("200")
+    void result
+  })
+
+  it("honours a custom toolbar window for the request", async () => {
+    setWindow(1000, 2000)
+    const urls = captureRequests({ services: [] })
+    const { result } = renderHookWithProviders(() => useServices())
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const qs = qsOf(findRequest(urls, { start: "1000", end: "2000" }))
+    expect(qs.get("start")).toBe("1000")
+    expect(qs.get("end")).toBe("2000")
+  })
+})

--- a/console/src/hooks/use-supported-filters.test.ts
+++ b/console/src/hooks/use-supported-filters.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { pinClock, renderHookWithProviders, resetStore, setWindowOrigin } from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useSupportedFilterParams } from "./use-supported-filters"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  resetStore(useToolbarStore, {
+    preset: "custom",
+    start: NOW_S - PRESET_SECONDS["1h"],
+    end: NOW_S,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+})
+afterEach(() => restoreClock())
+
+describe("useSupportedFilterParams", () => {
+  it("returns the full spec + all non-empty filters for /llm-calls", () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: 0,
+      end: 1,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const { result } = renderHookWithProviders(() => useSupportedFilterParams(), {
+      initialEntries: ["/llm-calls"],
+    })
+    expect(result.current.spec).toEqual(["wireApi", "model", "serverIp"])
+    expect(result.current.params).toEqual({
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+    })
+  })
+
+  it("returns only serverIp-spec for /http-exchanges (wireApi/model omitted even if set)", () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: 0,
+      end: 1,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const { result } = renderHookWithProviders(() => useSupportedFilterParams(), {
+      initialEntries: ["/http-exchanges"],
+    })
+    expect(result.current.spec).toEqual(["serverIp"])
+    // wireApi/model aren't in the route spec → omitted from params.
+    expect(result.current.params).toEqual({ server_ip: "10.0.0.1" })
+  })
+
+  it("returns [] spec + empty params for /agent-sessions", () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: 0,
+      end: 1,
+      filters: { wireApi: "anthropic", model: "claude-3", serverIp: "10.0.0.1" },
+      refreshInterval: 5000,
+    })
+    const { result } = renderHookWithProviders(() => useSupportedFilterParams(), {
+      initialEntries: ["/agent-sessions"],
+    })
+    expect(result.current.spec).toEqual([])
+    expect(result.current.params).toEqual({})
+  })
+
+  it("omits empty-string filters (empty = 'all')", () => {
+    resetStore(useToolbarStore, {
+      preset: "custom",
+      start: 0,
+      end: 1,
+      filters: { wireApi: "", model: "claude-3", serverIp: "" },
+      refreshInterval: 5000,
+    })
+    const { result } = renderHookWithProviders(() => useSupportedFilterParams(), {
+      initialEntries: ["/llm-calls"],
+    })
+    expect(result.current.params).toEqual({ model: "claude-3" })
+  })
+
+  it("returns [] spec for an unknown route", () => {
+    const { result } = renderHookWithProviders(() => useSupportedFilterParams(), {
+      initialEntries: ["/no-such-page"],
+    })
+    expect(result.current.spec).toEqual([])
+    expect(result.current.params).toEqual({})
+  })
+})

--- a/console/src/hooks/use-turn-url-state.test.ts
+++ b/console/src/hooks/use-turn-url-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "@testing-library/react"
+import { renderHookWithProviders } from "../../test/mocks"
+import { useTurnUrlState } from "./use-turn-url-state"
+
+// Renders the hook at an initial URL via a MemoryRouter. The hook's returned
+// values reflect the parsed + updated search params, so we assert on those
+// rather than reaching into the router's location.
+
+describe("useTurnUrlState", () => {
+  it("parses call + detail from the initial URL", () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x?call=7&detail=1"],
+    })
+    expect(result.current.call).toBe(7)
+    expect(result.current.detail).toBe(true)
+  })
+
+  it("defaults call=null, detail=false when params are absent", () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x"],
+    })
+    expect(result.current.call).toBeNull()
+    expect(result.current.detail).toBe(false)
+  })
+
+  it("setCall(n) writes ?call=n and leaves detail untouched", async () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x?call=1&detail=1"],
+    })
+    await act(async () => {
+      result.current.setCall(42)
+    })
+    expect(result.current.call).toBe(42)
+    // setCall(seq) only updates call; it clears detail only when seq is null.
+    expect(result.current.detail).toBe(true)
+  })
+
+  it("setCall(null) clears call and detail", async () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x?call=1&detail=1"],
+    })
+    await act(async () => {
+      result.current.setCall(null)
+    })
+    expect(result.current.call).toBeNull()
+    expect(result.current.detail).toBe(false)
+  })
+
+  it("setDetail(true/false) toggles the detail flag without touching call", async () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x?call=5"],
+    })
+    await act(async () => {
+      result.current.setDetail(true)
+    })
+    expect(result.current.detail).toBe(true)
+    expect(result.current.call).toBe(5)
+    await act(async () => {
+      result.current.setDetail(false)
+    })
+    expect(result.current.detail).toBe(false)
+    expect(result.current.call).toBe(5)
+  })
+
+  it("openDetail(seq) sets both call=seq and detail=1 in one update", async () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x"],
+    })
+    await act(async () => {
+      result.current.openDetail(99)
+    })
+    expect(result.current.call).toBe(99)
+    expect(result.current.detail).toBe(true)
+  })
+
+  it("detail is false when the param is anything other than '1'", () => {
+    const { result } = renderHookWithProviders(() => useTurnUrlState(), {
+      initialEntries: ["/x?detail=true"],
+    })
+    expect(result.current.detail).toBe(false)
+  })
+})

--- a/console/src/hooks/use-update-sources.test.ts
+++ b/console/src/hooks/use-update-sources.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from "bun:test"
+import { waitFor } from "@testing-library/react"
+import { renderHookWithProviders, setWindowOrigin } from "../../test/mocks"
+import { useUpdateSources } from "./use-update-sources"
+import type { CaptureSource } from "@/types/api"
+
+// useUpdateSources calls fetch("/api/capture/sources", { method: "PUT", ... })
+// directly (not via apiFetch), so each test stubs globalThis.fetch, inspects
+// the request init, and restores it in a finally block. Mutations don't
+// background-refetch, so the simple stub is deterministic here.
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+
+describe("useUpdateSources", () => {
+  it("PUTs the sources to /api/capture/sources and returns restart_in_ms", async () => {
+    const sources: CaptureSource[] = [
+      { type: "pcap", interface: "eth0", bpf_filter: null, snaplen: 65535, source_id: null },
+    ]
+    let capturedUrl = ""
+    let capturedInit: RequestInit | undefined
+    const orig = globalThis.fetch
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(input)
+      capturedInit = init
+      return Promise.resolve(
+        new Response(JSON.stringify({ code: 0, message: "ok", data: { restart_in_ms: 5000 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    }) as typeof fetch
+    try {
+      const { result } = renderHookWithProviders(() => useUpdateSources())
+      result.current.mutate({ pipeline_name: "p1", sources })
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(capturedUrl).toBe("/api/capture/sources")
+      expect(capturedInit?.method).toBe("PUT")
+      const headers = capturedInit?.headers as Record<string, string>
+      expect(headers["content-type"]).toBe("application/json")
+      const body = JSON.parse(String(capturedInit?.body))
+      expect(body).toEqual({ pipeline_name: "p1", sources })
+      expect(result.current.data).toEqual({ restart_in_ms: 5000 })
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+
+  it("throws ApiError on a non-zero envelope code", async () => {
+    const orig = globalThis.fetch
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ code: 7, message: "bad sources" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      )) as typeof fetch
+    try {
+      const { result } = renderHookWithProviders(() => useUpdateSources())
+      result.current.mutate({ pipeline_name: "p1", sources: [] })
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toMatchObject({ name: "ApiError", code: 7, message: "bad sources" })
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+
+  it("falls back to status/statusText when the error body isn't JSON", async () => {
+    const orig = globalThis.fetch
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response("err", { status: 500, statusText: "ISE" }))) as typeof fetch
+    try {
+      const { result } = renderHookWithProviders(() => useUpdateSources())
+      result.current.mutate({ pipeline_name: "p1", sources: [] })
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error).toMatchObject({ name: "ApiError", code: 500, message: "ISE" })
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+})

--- a/console/src/hooks/use-url-sync.test.ts
+++ b/console/src/hooks/use-url-sync.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test"
+import { act, waitFor } from "@testing-library/react"
+import { useLocation } from "react-router"
+import {
+  pinClock,
+  renderHookWithProviders,
+  resetStore,
+  setWindowOrigin,
+} from "../../test/mocks"
+import { PRESET_SECONDS, useToolbarStore } from "@/stores/toolbar"
+import { useToolbarUrlSync } from "./use-url-sync"
+
+const NOW_S = 1_780_000_000
+let restoreClock: () => void
+
+beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+beforeEach(() => {
+  restoreClock = pinClock(NOW_S * 1000)
+  resetStore(useToolbarStore, {
+    preset: "1h",
+    start: NOW_S - PRESET_SECONDS["1h"],
+    end: NOW_S,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+})
+afterEach(() => restoreClock())
+
+// Renders useToolbarUrlSync alongside a useLocation() reader so the test can
+// assert on the URL the router settled to after a sync. Both share the one
+// MemoryRouter created by renderHookWithProviders(initialEntries).
+function renderSync(initialPath: string) {
+  return renderHookWithProviders(
+    () => {
+      useToolbarUrlSync()
+      return useLocation().search
+    },
+    { initialEntries: [initialPath] },
+  )
+}
+
+function searchParams(search: string): URLSearchParams {
+  return new URLSearchParams(search)
+}
+
+describe("useToolbarUrlSync — URL → store", () => {
+  it("hydrates preset + window from a relative-preset URL", async () => {
+    const { result } = renderSync("/llm-calls?preset=15m")
+    await waitFor(() => expect(useToolbarStore.getState().preset).toBe("15m"))
+    expect(useToolbarStore.getState().start).toBe(NOW_S - PRESET_SECONDS["15m"])
+    expect(useToolbarStore.getState().end).toBe(NOW_S)
+    void result
+  })
+
+  it("hydrates absolute start/end from a custom-preset URL", async () => {
+    const { result } = renderSync("/llm-calls?preset=custom&start=100&end=200")
+    await waitFor(() => expect(useToolbarStore.getState().preset).toBe("custom"))
+    expect(useToolbarStore.getState().start).toBe(100)
+    expect(useToolbarStore.getState().end).toBe(200)
+    void result
+  })
+
+  it("hydrates dimension filters present in the URL", async () => {
+    const { result } = renderSync(
+      "/llm-calls?wire_api=anthropic&model=claude-3&server_ip=10.0.0.1",
+    )
+    await waitFor(() => expect(useToolbarStore.getState().filters.wireApi).toBe("anthropic"))
+    expect(useToolbarStore.getState().filters.model).toBe("claude-3")
+    expect(useToolbarStore.getState().filters.serverIp).toBe("10.0.0.1")
+    void result
+  })
+
+  it("hydrates a non-default refresh interval", async () => {
+    const { result } = renderSync("/llm-calls?refresh=15000")
+    await waitFor(() => expect(useToolbarStore.getState().refreshInterval).toBe(15000))
+    void result
+  })
+
+  it("ignores an invalid preset value (no preset set)", async () => {
+    const { result } = renderSync("/llm-calls?preset=bogus")
+    await new Promise((r) => setTimeout(r, 20))
+    expect(useToolbarStore.getState().preset).toBe("1h") // default unchanged
+    void result
+  })
+})
+
+describe("useToolbarUrlSync — store → URL", () => {
+  it("writes a non-default preset to the URL", async () => {
+    const { result } = renderSync("/llm-calls")
+    await act(async () => {
+      useToolbarStore.getState().setPreset("15m")
+    })
+    await waitFor(() =>
+      expect(searchParams(result.current).get("preset")).toBe("15m"),
+    )
+  })
+
+  it("writes absolute start/end when preset is custom", async () => {
+    const { result } = renderSync("/llm-calls")
+    await act(async () => {
+      useToolbarStore.getState().setCustomRange(100, 200)
+    })
+    await waitFor(() => expect(searchParams(result.current).get("preset")).toBe("custom"))
+    expect(searchParams(result.current).get("start")).toBe("100")
+    expect(searchParams(result.current).get("end")).toBe("200")
+  })
+
+  it("writes the route-supported dimension filters (and omits the default preset)", async () => {
+    const { result } = renderSync("/llm-calls")
+    await act(async () => {
+      useToolbarStore.getState().setFilter("wireApi", "anthropic")
+      useToolbarStore.getState().setFilter("model", "claude-3")
+      useToolbarStore.getState().setFilter("serverIp", "10.0.0.1")
+    })
+    await waitFor(() => expect(searchParams(result.current).get("wire_api")).toBe("anthropic"))
+    const qs = searchParams(result.current)
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+    // Default preset ("1h") is omitted.
+    expect(qs.has("preset")).toBe(false)
+  })
+
+  it("strips dimension filters not supported by the current route (serverIp only on /http-exchanges)", async () => {
+    const { result } = renderSync("/http-exchanges")
+    await act(async () => {
+      useToolbarStore.getState().setFilter("wireApi", "anthropic")
+      useToolbarStore.getState().setFilter("model", "claude-3")
+      useToolbarStore.getState().setFilter("serverIp", "10.0.0.1")
+    })
+    await waitFor(() => expect(searchParams(result.current).get("server_ip")).toBe("10.0.0.1"))
+    const qs = searchParams(result.current)
+    expect(qs.has("wire_api")).toBe(false) // not in /http-exchanges spec
+    expect(qs.has("model")).toBe(false)
+  })
+
+  it("writes a non-default refresh interval", async () => {
+    const { result } = renderSync("/llm-calls")
+    await act(async () => {
+      useToolbarStore.getState().setRefreshInterval(15000)
+    })
+    await waitFor(() => expect(searchParams(result.current).get("refresh")).toBe("15000"))
+  })
+})

--- a/console/src/lib/api.test.ts
+++ b/console/src/lib/api.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test"
+import { ApiError, apiFetch, downloadFile } from "./api"
+import { jsonResponse, mockFetch } from "../../test/mocks"
+
+// apiFetch reads window.location.origin to build its URL. happy-dom loads
+// the page as about:blank → origin === "null" → new URL(path, null) throws.
+// Point the happy-dom window at a real origin for this file (each test file
+// gets its own Window from the preload, so this is file-scoped).
+beforeAll(() => {
+  window.location.href = "http://localhost:8080/"
+})
+
+// Restore the process-level stubs mockFetch / createElementMock install.
+const restoreFns: Array<() => void> = []
+afterEach(() => {
+  while (restoreFns.length) restoreFns.pop()?.()
+})
+
+describe("ApiError", () => {
+  it("carries the code + message and the ApiError name", () => {
+    const e = new ApiError(5, "boom")
+    expect(e.code).toBe(5)
+    expect(e.message).toBe("boom")
+    expect(e.name).toBe("ApiError")
+    expect(e instanceof Error).toBe(true)
+  })
+})
+
+describe("apiFetch", () => {
+  it("unwraps ApiResponse.data on success and calls the right path", async () => {
+    let capturedPath = ""
+    mockFetch((input) => {
+      capturedPath = String(input)
+      return jsonResponse({ code: 0, message: "ok", data: { hello: "world" } })
+    })
+    const data = await apiFetch<{ hello: string }>("/api/services")
+    expect(data).toEqual({ hello: "world" })
+    expect(capturedPath).toBe("/api/services")
+  })
+
+  it("serializes params into the query string, omitting undefined and empty", async () => {
+    let capturedPath = ""
+    mockFetch((input) => {
+      capturedPath = String(input)
+      return jsonResponse({ code: 0, message: "ok", data: 1 })
+    })
+    await apiFetch("/api/services", {
+      start: 1000,
+      end: 2000,
+      wire_api: "anthropic",
+      empty: "",
+      skipped: undefined,
+      num: 42,
+      bool: true,
+    })
+    const qs = new URLSearchParams(capturedPath.split("?")[1] ?? "")
+    expect(qs.get("start")).toBe("1000")
+    expect(qs.get("end")).toBe("2000")
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("num")).toBe("42")
+    expect(qs.get("bool")).toBe("true")
+    expect(qs.has("empty")).toBe(false)
+    expect(qs.has("skipped")).toBe(false)
+  })
+
+  it("makes no query string when no params are given", async () => {
+    let capturedPath = ""
+    mockFetch((input) => {
+      capturedPath = String(input)
+      return jsonResponse({ code: 0, message: "ok", data: null })
+    })
+    await apiFetch("/api/health")
+    expect(capturedPath).toBe("/api/health")
+  })
+
+  it("throws ApiError with the envelope code/message on a non-zero envelope code", async () => {
+    mockFetch(() => jsonResponse({ code: 7, message: "validation failed", data: null }))
+    await expect(apiFetch("/api/x")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 7,
+      message: "validation failed",
+    })
+  })
+
+  it("throws ApiError on a non-ok HTTP status, parsing the error body when JSON", async () => {
+    mockFetch(() =>
+      jsonResponse({ code: 404, message: "not found" }, { status: 404 }),
+    )
+    await expect(apiFetch("/api/missing")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 404,
+      message: "not found",
+    })
+  })
+
+  it("falls back to res.status / res.statusText when the error body is not JSON", async () => {
+    mockFetch(() =>
+      new Response("plain text error", { status: 503, statusText: "Service Unavailable" }),
+    )
+    await expect(apiFetch("/api/x")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 503,
+      message: "Service Unavailable",
+    })
+  })
+
+  it("falls back to res.status when envelope has no code field", async () => {
+    // A 500 with a JSON body that lacks code → body.code ?? res.status.
+    mockFetch(() =>
+      jsonResponse({ unexpected: "shape" }, { status: 500, statusText: "ISE" }),
+    )
+    await expect(apiFetch("/api/x")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 500,
+      message: "ISE",
+    })
+  })
+})
+
+describe("downloadFile", () => {
+  // Capture the anchor downloadFile builds + clicks so we can assert the
+  // derived filename reached it, without relying on a real browser click.
+  // Replaces document.createElement for the file's lifetime and no-ops the
+  // anchor's click. URL.createObjectURL / revokeObjectURL are left as the
+  // happy-dom originals (they work and produce real blob: URLs), so we only
+  // intercept anchor construction.
+  function captureAnchor(): { anchor: HTMLAnchorElement | null } {
+    const state: { anchor: HTMLAnchorElement | null } = { anchor: null }
+    const origCreate = document.createElement.bind(document)
+    document.createElement = ((tag: string) => {
+      const el = origCreate(tag)
+      if (tag.toLowerCase() === "a") {
+        state.anchor = el as HTMLAnchorElement
+        // happy-dom anchor.click() is a no-op for navigation; override to
+        // avoid any navigation attempts and keep it deterministic.
+        ;(el as unknown as { click: () => void }).click = () => {}
+      }
+      return el
+    }) as typeof document.createElement
+
+    restoreFns.push(() => {
+      document.createElement = origCreate
+    })
+    return state
+  }
+
+  it("parses the filename out of the content-disposition header and clicks an anchor", async () => {
+    const cap = captureAnchor()
+    mockFetch(() =>
+      new Response("ndjson-line\n", {
+        status: 200,
+        headers: {
+          "content-disposition": 'attachment; filename="turns-abc.ndjson"',
+          "x-export-skipped": "2",
+          "x-export-total": "10",
+          "x-export-written": "8",
+        },
+      }),
+    )
+    const result = await downloadFile("/api/export/trajectory", "fallback.ndjson")
+    expect(result).toEqual({ skipped: 2, total: 10, written: 8 })
+    expect(cap.anchor).not.toBeNull()
+    // downloadFile assigns the blob: object URL the browser produced.
+    expect(cap.anchor?.href.startsWith("blob:")).toBe(true)
+    expect(cap.anchor?.download).toBe("turns-abc.ndjson")
+  })
+
+  it("falls back to the provided name when content-disposition is absent", async () => {
+    const cap = captureAnchor()
+    mockFetch(() => new Response("x", { status: 200 }))
+    await downloadFile("/api/export/trajectory", "fallback.ndjson")
+    expect(cap.anchor?.download).toBe("fallback.ndjson")
+  })
+
+  it("parses an unquoted filename in content-disposition", async () => {
+    const cap = captureAnchor()
+    mockFetch(() =>
+      new Response("x", {
+        status: 200,
+        headers: { "content-disposition": "attachment; filename=sessions.jsonl" },
+      }),
+    )
+    await downloadFile("/p", "fallback")
+    expect(cap.anchor?.download).toBe("sessions.jsonl")
+  })
+
+  it("defaults the X-Export-* counters to 0 when the headers are missing", async () => {
+    mockFetch(() => new Response("x", { status: 200 }))
+    const result = await downloadFile("/p", "f")
+    expect(result).toEqual({ skipped: 0, total: 0, written: 0 })
+  })
+
+  it("throws ApiError on a non-ok HTTP status", async () => {
+    mockFetch(() => jsonResponse({ code: 5, message: "nope" }, { status: 500 }))
+    await expect(downloadFile("/p", "f")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 5,
+      message: "nope",
+    })
+  })
+
+  it("uses status fallback when the error body is not JSON", async () => {
+    mockFetch(() => new Response("err", { status: 418, statusText: "I'm a teapot" }))
+    await expect(downloadFile("/p", "f")).rejects.toMatchObject({
+      name: "ApiError",
+      code: 418,
+      message: "I'm a teapot",
+    })
+  })
+})

--- a/console/src/lib/finish-tone.test.ts
+++ b/console/src/lib/finish-tone.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test"
+import { finishTone, TONE_CLASS, type FinishTone } from "./finish-tone"
+
+describe("finishTone", () => {
+  it("returns 'muted' for null / undefined / empty string", () => {
+    expect(finishTone(null)).toBe("muted")
+    expect(finishTone(undefined)).toBe("muted")
+    expect(finishTone("")).toBe("muted")
+  })
+
+  it("maps natural-completion reasons to 'ok'", () => {
+    for (const r of ["end_turn", "stop", "STOP", "stop_sequence", "completed"]) {
+      expect(finishTone(r)).toBe("ok")
+    }
+  })
+
+  it("maps truncation reasons to 'warn'", () => {
+    for (const r of [
+      "max_tokens",
+      "length",
+      "MAX_TOKENS",
+      "model_context_window_exceeded",
+      "incomplete",
+    ]) {
+      expect(finishTone(r)).toBe("warn")
+    }
+  })
+
+  it("maps tool-use reasons to 'tool'", () => {
+    for (const r of ["tool_use", "tool_calls", "function_call", "TOOL_CALLS"]) {
+      expect(finishTone(r)).toBe("tool")
+    }
+  })
+
+  it("maps server-tool yield to 'pause'", () => {
+    expect(finishTone("pause_turn")).toBe("pause")
+  })
+
+  it("maps safety / failure reasons to 'err'", () => {
+    for (const r of ["refusal", "content_filter", "SAFETY", "RECITATION", "failed", "cancelled"]) {
+      expect(finishTone(r)).toBe("err")
+    }
+  })
+
+  it("falls back to 'muted' for an unknown reason", () => {
+    expect(finishTone("something_weird")).toBe("muted")
+  })
+})
+
+describe("TONE_CLASS", () => {
+  // Every tone the classifier can emit must have a matching class, so a
+  // finish badge never renders without styling.
+  const ALL_TONES: FinishTone[] = ["ok", "warn", "tool", "pause", "err", "muted"]
+
+  it("has a non-empty class string for every FinishTone", () => {
+    for (const t of ALL_TONES) {
+      expect(TONE_CLASS[t].length).toBeGreaterThan(0)
+    }
+  })
+
+  it("each tone has a distinct class set", () => {
+    const classes = ALL_TONES.map((t) => TONE_CLASS[t])
+    expect(new Set(classes).size).toBe(ALL_TONES.length)
+  })
+
+  it("the dark-mode variant is present on every tone", () => {
+    for (const t of ALL_TONES) {
+      expect(TONE_CLASS[t]).toContain("dark:")
+    }
+  })
+})

--- a/console/src/lib/format.test.ts
+++ b/console/src/lib/format.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "bun:test"
-import { formatAxisTime } from "./format"
+import {
+  formatAxisTime,
+  formatBytes,
+  formatDateTime,
+  formatDateTimeMs,
+  formatDuration,
+  formatMs,
+  formatNumber,
+  formatRelativeTime,
+  formatTime,
+} from "./format"
 
-// Note: formatAxisTime renders in the local timezone (via Date.getHours()
-// / getMonth() etc.). Tests assert the *shape* (number of segments,
-// presence of date) rather than literal values, so they pass regardless
-// of the runner's TZ.
+// formatAxisTime / formatTime / formatDateTime* render in the local timezone
+// (via Date.getHours()/getMonth()/etc.). Tests assert the *shape* (number of
+// segments, presence of date) rather than literal values, so they pass
+// regardless of the runner's TZ.
 
 const MINUTE = 60
 const HOUR = 60 * MINUTE
@@ -44,5 +54,177 @@ describe("formatAxisTime", () => {
 
   it("treats the 7d boundary inclusively as date-only", () => {
     expect(formatAxisTime(EPOCH, 7 * DAY)).toMatch(/^\d{2}-\d{2}$/)
+  })
+})
+
+describe("formatTime", () => {
+  it("renders HH:MM:SS.mmm (3-digit millis) from a ms epoch", () => {
+    expect(formatTime(EPOCH * 1000)).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3}$/)
+  })
+
+  it("zero-pads the milliseconds field", () => {
+    // 1970-01-01 00:00:00.000 UTC → ms is "000" everywhere.
+    expect(formatTime(0)).toMatch(/^\d{2}:\d{2}:\d{2}\.000$/)
+  })
+})
+
+describe("formatDateTime / formatDateTimeMs", () => {
+  it("formatDateTime renders YYYY-MM-DD HH:MM:SS", () => {
+    expect(formatDateTime(EPOCH * 1000)).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+    )
+  })
+
+  it("formatDateTimeMs renders YYYY-MM-DD HH:MM:SS.mmm", () => {
+    expect(formatDateTimeMs(EPOCH * 1000)).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/,
+    )
+  })
+})
+
+describe("formatMs", () => {
+  it("returns '—' for null / undefined", () => {
+    expect(formatMs(null)).toBe("—")
+    expect(formatMs(undefined)).toBe("—")
+  })
+
+  it("returns '<1ms' for sub-millisecond values", () => {
+    expect(formatMs(0)).toBe("<1ms")
+    expect(formatMs(0.4)).toBe("<1ms")
+  })
+
+  it("renders sub-second ms with one decimal", () => {
+    expect(formatMs(1)).toBe("1.0ms")
+    expect(formatMs(999)).toBe("999.0ms")
+  })
+
+  it("renders >=1s in seconds with two decimals", () => {
+    expect(formatMs(1000)).toBe("1.00s")
+    expect(formatMs(1500)).toBe("1.50s")
+    expect(formatMs(12345)).toBe("12.35s")
+  })
+})
+
+describe("formatDuration", () => {
+  it("returns '—' for null / undefined", () => {
+    expect(formatDuration(null)).toBe("—")
+    expect(formatDuration(undefined)).toBe("—")
+  })
+
+  it("renders sub-second durations as raw ms", () => {
+    expect(formatDuration(0)).toBe("0ms")
+    expect(formatDuration(999)).toBe("999ms")
+  })
+
+  it("renders <60s durations as seconds with two decimals", () => {
+    expect(formatDuration(1000)).toBe("1.00s")
+    expect(formatDuration(59_999)).toBe("60.00s")
+  })
+
+  it("renders >=1m and <60m as '<m> <s>'", () => {
+    // 1m exactly → "1m 0s"; 90s → "1m 30s"
+    expect(formatDuration(60_000)).toBe("1m 0s")
+    expect(formatDuration(90_000)).toBe("1m 30s")
+  })
+
+  it("renders >=60m as '<h> <m>'", () => {
+    expect(formatDuration(60 * 60_000)).toBe("1h 0m")
+    expect(formatDuration(90 * 60_000)).toBe("1h 30m")
+  })
+})
+
+describe("formatNumber", () => {
+  it("returns '—' for null / undefined", () => {
+    expect(formatNumber(null)).toBe("—")
+    expect(formatNumber(undefined)).toBe("—")
+  })
+
+  it("renders small numbers verbatim", () => {
+    expect(formatNumber(0)).toBe("0")
+    expect(formatNumber(999)).toBe("999")
+  })
+
+  it("renders thousands with a K suffix and one decimal", () => {
+    expect(formatNumber(1_000)).toBe("1.0K")
+    expect(formatNumber(12_345)).toBe("12.3K")
+  })
+
+  it("renders millions with an M suffix and one decimal", () => {
+    expect(formatNumber(1_000_000)).toBe("1.0M")
+    expect(formatNumber(2_500_000)).toBe("2.5M")
+  })
+})
+
+describe("formatBytes", () => {
+  it("returns '—' for null / undefined", () => {
+    expect(formatBytes(null)).toBe("—")
+    expect(formatBytes(undefined)).toBe("—")
+  })
+
+  it("renders raw bytes under 1024", () => {
+    expect(formatBytes(0)).toBe("0 B")
+    expect(formatBytes(512)).toBe("512 B")
+    expect(formatBytes(1023)).toBe("1023 B")
+  })
+
+  it("renders KiB for [1024, 1MiB)", () => {
+    expect(formatBytes(1024)).toBe("1.0 KiB")
+    expect(formatBytes(2048)).toBe("2.0 KiB")
+  })
+
+  it("renders MiB for [1MiB, 1GiB)", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MiB")
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MiB")
+  })
+
+  it("renders GiB at 1GiB and above", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GiB")
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe("3.0 GiB")
+  })
+})
+
+// formatRelativeTime reads Date.now() internally. Pin the clock so the
+// "same day" / "yesterday" / "Nd ago" buckets are deterministic regardless of
+// the runner's wall time. Each test stubs Date.now and restores it.
+describe("formatRelativeTime", () => {
+  const NOW_MS = 1_780_000_000_000 // mid-2026
+  const DAY_MS = 86_400_000
+
+  function stubNow(fixedMs: number): () => void {
+    const orig = Date.now
+    // @ts-expect-error — narrowing the global getter is intentional in tests
+    Date.now = () => fixedMs
+    return () => {
+      Date.now = orig
+    }
+  }
+
+  it('returns "HH:MM" when the timestamp is earlier today', () => {
+    const restore = stubNow(NOW_MS)
+    // A few hours earlier the same calendar day (same-day via toDateString).
+    const earlierSameDay = NOW_MS - 3 * 60 * 60 * 1000
+    expect(formatRelativeTime(earlierSameDay)).toMatch(/^\d{2}:\d{2}$/)
+    restore()
+  })
+
+  it('returns "yesterday" when the timestamp is the previous calendar day', () => {
+    const restore = stubNow(NOW_MS)
+    // 1.5 days ago → previous calendar day in any TZ.
+    const prevDay = NOW_MS - 1.5 * DAY_MS
+    expect(formatRelativeTime(prevDay)).toBe("yesterday")
+    restore()
+  })
+
+  it('returns "Nd ago" for >=2 days', () => {
+    const restore = stubNow(NOW_MS)
+    expect(formatRelativeTime(NOW_MS - 3 * DAY_MS)).toBe("3d ago")
+    restore()
+  })
+
+  it("floors the day count", () => {
+    const restore = stubNow(NOW_MS)
+    // 10 days + a few hours → "10d ago", not rounded up.
+    expect(formatRelativeTime(NOW_MS - 10 * DAY_MS - 3 * 60 * 60 * 1000)).toBe("10d ago")
+    restore()
   })
 })

--- a/console/src/lib/interface-groups.test.ts
+++ b/console/src/lib/interface-groups.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test"
+import { groupInterfaces } from "./interface-groups"
+import type { CaptureInterface } from "@/types/api"
+
+function iface(name: string, addresses: string[] = []): CaptureInterface {
+  return {
+    name,
+    description: null,
+    addresses,
+    is_up: true,
+    is_running: true,
+    is_loopback: name === "lo",
+    is_wireless: false,
+  }
+}
+
+describe("groupInterfaces", () => {
+  it("places 'any' and 'lo' in recommended", () => {
+    const g = groupInterfaces([iface("any"), iface("lo")])
+    expect(g.recommended.map((i) => i.name)).toEqual(["any", "lo"])
+    expect(g.virtual).toEqual([])
+  })
+
+  it("routes virtual prefixes (veth/vnet/virbr/docker/br-/cni/…) into the virtual bucket", () => {
+    const virtual = [
+      iface("veth0a3b"),
+      iface("vnet0"),
+      iface("virbr0"),
+      iface("docker0"),
+      iface("br-abc123"),
+      iface("cni0"),
+      iface("flannel.1"),
+      iface("weave"),
+      iface("cali123"),
+      iface("tap0"),
+      iface("tun0"),
+    ]
+    const g = groupInterfaces(virtual)
+    expect(g.virtual.map((i) => i.name).sort()).toEqual(
+      [
+        "br-abc123",
+        "cni0",
+        "cali123",
+        "docker0",
+        "flannel.1",
+        "tap0",
+        "tun0",
+        "veth0a3b",
+        "virbr0",
+        "vnet0",
+        "weave",
+      ].sort(),
+    )
+    expect(g.recommended).toEqual([])
+  })
+
+  it("places a real-looking NIC into recommended", () => {
+    const g = groupInterfaces([iface("eth0", ["10.0.0.1"])])
+    expect(g.recommended.map((i) => i.name)).toEqual(["eth0"])
+  })
+
+  it("sorts recommended: 'any' first, interfaces with addresses next, then alphabetical, 'lo' last", () => {
+    const g = groupInterfaces([
+      iface("lo"),
+      iface("eno2", []),
+      iface("eno1", ["10.0.0.1"]),
+      iface("any"),
+      iface("eth5", ["10.0.0.5"]),
+      iface("eth1", ["10.0.0.2"]),
+    ])
+    // any → (addressed, alphabetical) eno1, eth1, eth5 → (no addresses, alpha) eno2 → lo
+    expect(g.recommended.map((i) => i.name)).toEqual([
+      "any",
+      "eno1",
+      "eth1",
+      "eth5",
+      "eno2",
+      "lo",
+    ])
+  })
+
+  it("sorts the virtual bucket alphabetically", () => {
+    const g = groupInterfaces([iface("vnet9"), iface("veth1"), iface("virbr0")])
+    expect(g.virtual.map((i) => i.name)).toEqual(["veth1", "virbr0", "vnet9"])
+  })
+
+  it("returns empty buckets for an empty input", () => {
+    const g = groupInterfaces([])
+    expect(g.recommended).toEqual([])
+    expect(g.virtual).toEqual([])
+  })
+
+  it("prefers an interface with addresses over one without, ignoring case-insensitive prefix match only for virtual names", () => {
+    // 'virtnet' is NOT a virtual prefix (virbr is), so it's recommended;
+    // it has an address so it sorts ahead of the address-less real NIC.
+    const g = groupInterfaces([iface("virtnet", ["10.0.0.9"]), iface("eth0", [])])
+    expect(g.recommended.map((i) => i.name)).toEqual(["virtnet", "eth0"])
+  })
+})

--- a/console/src/lib/proxy-meta.test.ts
+++ b/console/src/lib/proxy-meta.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test"
+import { proxyGroupSize, readProxyMeta } from "./proxy-meta"
+
+describe("readProxyMeta", () => {
+  it("returns null when metadata is null/undefined/non-object", () => {
+    expect(readProxyMeta(null)).toBeNull()
+    expect(readProxyMeta(undefined)).toBeNull()
+    expect(readProxyMeta("nope")).toBeNull()
+    expect(readProxyMeta(42)).toBeNull()
+    expect(readProxyMeta([1, 2, 3])).toBeNull()
+  })
+
+  it("returns null when there is no proxy block", () => {
+    expect(readProxyMeta({})).toBeNull()
+    expect(readProxyMeta({ other: "x" })).toBeNull()
+  })
+
+  it("returns null when the proxy block is not an object", () => {
+    expect(readProxyMeta({ proxy: "x" })).toBeNull()
+    expect(readProxyMeta({ proxy: 7 })).toBeNull()
+    expect(readProxyMeta({ proxy: null })).toBeNull()
+  })
+
+  it("returns null when proxy.role is missing or non-string", () => {
+    expect(readProxyMeta({ proxy: {} })).toBeNull()
+    expect(readProxyMeta({ proxy: { role: 5 } })).toBeNull()
+  })
+
+  it("returns the proxy block when role is a string", () => {
+    const proxy = { role: "proxy_in", pair_id: "p1" }
+    expect(readProxyMeta({ proxy })).toEqual(proxy)
+  })
+
+  it("passes through arbitrary role strings (incl. unknown roles)", () => {
+    expect(readProxyMeta({ proxy: { role: "mirror_primary" } })).toEqual({
+      role: "mirror_primary",
+    })
+    expect(readProxyMeta({ proxy: { role: "something_new" } })?.role).toBe(
+      "something_new",
+    )
+  })
+})
+
+describe("proxyGroupSize", () => {
+  it("returns 0 for no proxy", () => {
+    expect(proxyGroupSize(null)).toBe(0)
+  })
+
+  it("returns 1 when there are no peers (single-leg group)", () => {
+    expect(proxyGroupSize({ role: "proxy_in" })).toBe(1)
+  })
+
+  it("returns 2 when only peer_turn_id is set", () => {
+    expect(proxyGroupSize({ role: "proxy_in", peer_turn_id: "t2" })).toBe(2)
+  })
+
+  it("returns peer_turn_ids.length + 1 when peer_turn_ids is a non-empty array", () => {
+    expect(
+      proxyGroupSize({ role: "proxy_in", peer_turn_ids: ["a", "b", "c"] }),
+    ).toBe(4)
+  })
+
+  it("falls back to the peer_turn_id branch when peer_turn_ids is empty", () => {
+    // Empty array → not > 0, so peer_turn_id (if present) → 2, else 1.
+    expect(
+      proxyGroupSize({ role: "proxy_in", peer_turn_ids: [], peer_turn_id: "t" }),
+    ).toBe(2)
+    expect(proxyGroupSize({ role: "proxy_in", peer_turn_ids: [] })).toBe(1)
+  })
+})

--- a/console/src/lib/trajectory-export.test.ts
+++ b/console/src/lib/trajectory-export.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test"
+import {
+  batchTrajectoriesUrl,
+  sessionTrajectoryUrl,
+  turnTrajectoryUrl,
+} from "./trajectory-export"
+
+describe("turnTrajectoryUrl", () => {
+  it("builds a turn-scoped export URL with scope=turn", () => {
+    const url = turnTrajectoryUrl("abc 123")
+    expect(url.startsWith("/api/export/trajectory?")).toBe(true)
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.get("scope")).toBe("turn")
+    expect(qs.get("turn_id")).toBe("abc 123")
+  })
+
+  it("URL-encodes the turn id", () => {
+    const url = turnTrajectoryUrl("a&b=c")
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.get("turn_id")).toBe("a&b=c")
+  })
+})
+
+describe("sessionTrajectoryUrl", () => {
+  it("builds a session-scoped export URL with source_id + session_id", () => {
+    const url = sessionTrajectoryUrl("src-1", "ses-2")
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.get("scope")).toBe("session")
+    expect(qs.get("source_id")).toBe("src-1")
+    expect(qs.get("session_id")).toBe("ses-2")
+  })
+})
+
+describe("batchTrajectoriesUrl", () => {
+  it("always includes start and end (required toolbar window)", () => {
+    const url = batchTrajectoriesUrl({ start: 1000, end: 2000 })
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.get("start")).toBe("1000")
+    expect(qs.get("end")).toBe("2000")
+  })
+
+  it("includes only the endpoint path, not the full envelope (trajectories, plural)", () => {
+    expect(batchTrajectoriesUrl({ start: 1, end: 2 }).startsWith("/api/export/trajectories?")).toBe(true)
+  })
+
+  it("omits optional filters that are undefined or empty", () => {
+    const url = batchTrajectoriesUrl({ start: 1, end: 2, model: "", wire_api: undefined })
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.has("model")).toBe(false)
+    expect(qs.has("wire_api")).toBe(false)
+    expect(qs.has("agent_kind")).toBe(false)
+    expect(qs.has("server_ip")).toBe(false)
+    expect(qs.has("status")).toBe(false)
+    expect(qs.has("client_ip")).toBe(false)
+    expect(qs.has("server_port")).toBe(false)
+  })
+
+  it("includes optional filters that are set", () => {
+    const url = batchTrajectoriesUrl({
+      start: 1,
+      end: 2,
+      wire_api: "anthropic",
+      model: "claude-3",
+      server_ip: "10.0.0.1",
+      status: "success",
+      agent_kind: "claude-cli",
+      client_ip: "192.168.1.5",
+      server_port: "443",
+    })
+    const qs = new URLSearchParams(url.split("?")[1])
+    expect(qs.get("wire_api")).toBe("anthropic")
+    expect(qs.get("model")).toBe("claude-3")
+    expect(qs.get("server_ip")).toBe("10.0.0.1")
+    expect(qs.get("status")).toBe("success")
+    expect(qs.get("agent_kind")).toBe("claude-cli")
+    expect(qs.get("client_ip")).toBe("192.168.1.5")
+    expect(qs.get("server_port")).toBe("443")
+  })
+
+  it("adds include_proxy_hops=true only when the flag is on", () => {
+    expect(
+      new URLSearchParams(
+        batchTrajectoriesUrl({ start: 1, end: 2 }).split("?")[1],
+      ).has("include_proxy_hops"),
+    ).toBe(false)
+    expect(
+      new URLSearchParams(
+        batchTrajectoriesUrl({ start: 1, end: 2, include_proxy_hops: true }).split("?")[1],
+      ).get("include_proxy_hops"),
+    ).toBe("true")
+    // Falsy (false / undefined) → omitted, never "false".
+    expect(
+      new URLSearchParams(
+        batchTrajectoriesUrl({ start: 1, end: 2, include_proxy_hops: false }).split("?")[1],
+      ).has("include_proxy_hops"),
+    ).toBe(false)
+  })
+})

--- a/console/src/lib/utils.test.ts
+++ b/console/src/lib/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test"
+import { cn } from "./utils"
+
+describe("cn", () => {
+  it("passes a single class through unchanged", () => {
+    expect(cn("px-2")).toBe("px-2")
+  })
+
+  it("concatenates multiple classes", () => {
+    expect(cn("px-2", "py-1")).toBe("px-2 py-1")
+  })
+
+  it("drops falsy values (undefined / null / false / empty string)", () => {
+    expect(cn("a", undefined, null, false, "", "b")).toBe("a b")
+  })
+
+  it("flattens nested arrays and objects (clsx conditional shapes)", () => {
+    expect(cn(["a", ["b", { c: true, d: false }]])).toBe("a b c")
+  })
+
+  it("resolves conflicting tailwind classes via tailwind-merge (last wins)", () => {
+    // px-2 then px-4 → tailwind-merge keeps the later one.
+    expect(cn("px-2", "px-4")).toBe("px-4")
+    expect(cn("text-red-500", "text-blue-500")).toBe("text-blue-500")
+  })
+
+  it("keeps non-conflicting classes and only merges the conflict", () => {
+    expect(cn("px-2 py-1", "px-4")).toBe("py-1 px-4")
+  })
+
+  it("returns an empty string for no/falsy input", () => {
+    expect(cn()).toBe("")
+    expect(cn(false, undefined, null, "")).toBe("")
+  })
+})

--- a/console/src/lib/wire-apis/dispatch.test.ts
+++ b/console/src/lib/wire-apis/dispatch.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test"
+import { classifyType } from "./dispatch"
+
+describe("classifyType — finalCallId short-circuit", () => {
+  it("returns 'final' when callId === finalCallId, before any wire-api logic", () => {
+    // Unknown wire_api + matching finalCallId → still 'final' (checked first).
+    expect(classifyType("unknown-api", null, "c1", "c1")).toBe("final")
+  })
+
+  it("does not return 'final' when finalCallId is null", () => {
+    expect(classifyType("anthropic", null, "c1", null)).toBe("text")
+  })
+})
+
+describe("classifyType — per-wire-api dispatch", () => {
+  it("routes 'anthropic' to the anthropic classifier (tool_use → tool_call)", () => {
+    const body = JSON.stringify({
+      content: [{ type: "tool_use", id: "t1", name: "read", input: {} }],
+    })
+    expect(classifyType("anthropic", body, "c1", null)).toBe("tool_call")
+  })
+
+  it("routes 'openai-chat' to the openai-chat classifier (tool_calls → tool_call)", () => {
+    const body = JSON.stringify({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [{ id: "x", type: "function", function: { name: "f", arguments: "{}" } }],
+          },
+        },
+      ],
+    })
+    expect(classifyType("openai-chat", body, "c1", null)).toBe("tool_call")
+  })
+
+  it("routes 'openai-responses' to the openai-responses classifier", () => {
+    // A plain text response → 'text'.
+    const body = JSON.stringify({
+      output: [{ type: "message", content: [{ type: "output_text", text: "hi" }] }],
+    })
+    expect(classifyType("openai-responses", body, "c1", null)).toBe("text")
+  })
+
+  it("routes 'gemini-aistudio' to the gemini classifier (functionCall part → tool_call)", () => {
+    const body = JSON.stringify({
+      candidates: [
+        {
+          content: {
+            parts: [{ functionCall: { name: "get_weather", args: {} } }],
+          },
+        },
+      ],
+    })
+    expect(classifyType("gemini-aistudio", body, "c1", null)).toBe("tool_call")
+  })
+})
+
+describe("classifyType — unknown wire_api fallback", () => {
+  it("falls back to 'text' for an unrecognised wire_api", () => {
+    // Conservative: not a tool_call if we can't prove it, not 'final' unless id matches.
+    expect(classifyType("some-new-api", null, "c1", null)).toBe("text")
+    // Even with a tool-shaped body under an unknown api, we can't classify → text.
+    const toolishBody = JSON.stringify({ tool_calls: [{ id: "x" }] })
+    expect(classifyType("some-new-api", toolishBody, "c1", null)).toBe("text")
+  })
+
+  it("falls back to 'text' for an empty wire_api string", () => {
+    expect(classifyType("", null, "c1", null)).toBe("text")
+  })
+})

--- a/console/src/lib/wire-apis/gemini-aistudio/classify.test.ts
+++ b/console/src/lib/wire-apis/gemini-aistudio/classify.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test"
+import { classifyGeminiAiStudioType } from "./classify"
+
+describe("classifyGeminiAiStudioType", () => {
+  it("returns 'final' when callId matches finalCallId (checked first)", () => {
+    expect(classifyGeminiAiStudioType(null, "c1", "c1")).toBe("final")
+  })
+
+  it("returns 'tool_call' when a candidate's finishReason is TOOL_USE", () => {
+    const body = JSON.stringify({
+      candidates: [{ finishReason: "TOOL_USE" }],
+    })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("tool_call")
+  })
+
+  it("returns 'tool_call' when a content part carries functionCall", () => {
+    const body = JSON.stringify({
+      candidates: [
+        {
+          finishReason: "STOP",
+          content: {
+            parts: [{ text: "ok" }, { functionCall: { name: "f", args: {} } }],
+          },
+        },
+      ],
+    })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("tool_call")
+  })
+
+  it("returns 'tool_call' when functionCall appears in a later candidate", () => {
+    const body = JSON.stringify({
+      candidates: [
+        { content: { parts: [{ text: "first" }] } },
+        { content: { parts: [{ functionCall: { name: "g" } }] } },
+      ],
+    })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("tool_call")
+  })
+
+  it("returns 'text' when candidates are present but none carry tool calls", () => {
+    const body = JSON.stringify({
+      candidates: [
+        { finishReason: "STOP", content: { parts: [{ text: "hello" }] } },
+      ],
+    })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("text")
+  })
+
+  it("returns 'text' when a candidate has no content / no parts", () => {
+    const body = JSON.stringify({ candidates: [{ finishReason: "STOP" }] })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("text")
+  })
+
+  it("returns 'text' for a plain-text (no candidates) body", () => {
+    expect(classifyGeminiAiStudioType("{}", "c1", null)).toBe("text")
+  })
+
+  it("returns 'text' for null / unparseable body", () => {
+    expect(classifyGeminiAiStudioType(null, "c1", null)).toBe("text")
+    expect(classifyGeminiAiStudioType("not-json", "c1", null)).toBe("text")
+  })
+
+  it("returns 'text' when candidates is not an array", () => {
+    const body = JSON.stringify({ candidates: "nope" })
+    expect(classifyGeminiAiStudioType(body, "c1", null)).toBe("text")
+  })
+})

--- a/console/src/lib/wire-apis/gemini-aistudio/index.test.ts
+++ b/console/src/lib/wire-apis/gemini-aistudio/index.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "bun:test"
+import { parseGeminiAiStudioCall } from "./index"
+
+describe("parseGeminiAiStudioCall — null/empty bodies", () => {
+  it("returns a default-shaped call for both bodies null", () => {
+    const call = parseGeminiAiStudioCall(null, null)
+    expect(call.request).toEqual({
+      model: null,
+      systemInstruction: null,
+      contents: [],
+      tools: [],
+      generationConfig: null,
+    })
+    expect(call.response).toEqual({
+      responseId: null,
+      modelVersion: null,
+      candidates: [],
+      usageMetadata: {
+        promptTokenCount: null,
+        candidatesTokenCount: null,
+        totalTokenCount: null,
+        cachedContentTokenCount: null,
+        thoughtsTokenCount: null,
+      },
+    })
+  })
+
+  it("returns defaults when bodies are unparseable garbage", () => {
+    const call = parseGeminiAiStudioCall("not-json", "also not json")
+    expect(call.request.contents).toEqual([])
+    expect(call.response.candidates).toEqual([])
+    expect(call.response.usageMetadata.totalTokenCount).toBeNull()
+  })
+})
+
+describe("parseGeminiAiStudioCall — request", () => {
+  it("parses model + contents (roles, text parts)", () => {
+    const body = JSON.stringify({
+      model: "gemini-2.0-flash",
+      contents: [
+        { role: "user", parts: [{ text: "hello" }] },
+        { role: "model", parts: [{ text: "hi there" }] },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.model).toBe("gemini-2.0-flash")
+    expect(call.request.contents).toHaveLength(2)
+    expect(call.request.contents[0]).toEqual({
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    })
+    expect(call.request.contents[1]).toEqual({
+      role: "model",
+      parts: [{ type: "text", text: "hi there" }],
+    })
+  })
+
+  it("maps any non-'model' role to 'user'", () => {
+    const body = JSON.stringify({
+      contents: [{ role: "system", parts: [{ text: "x" }] }],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.contents[0].role).toBe("user")
+  })
+
+  it("parses a thought part (thought:true + text)", () => {
+    const body = JSON.stringify({
+      contents: [{ role: "model", parts: [{ text: "thinking…", thought: true }] }],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.contents[0].parts[0]).toEqual({
+      type: "thought",
+      text: "thinking…",
+    })
+  })
+
+  it("parses a functionCall part (name + raw args)", () => {
+    const body = JSON.stringify({
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { name: "get_weather", args: { city: "SF" } } }],
+        },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    const part = call.request.contents[0].parts[0]
+    expect(part).toEqual({
+      type: "function_call",
+      name: "get_weather",
+      args: { city: "SF" },
+    })
+  })
+
+  it("parses a functionResponse part", () => {
+    const body = JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [{ functionResponse: { name: "get_weather", response: { temp: 72 } } }],
+        },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.contents[0].parts[0]).toEqual({
+      type: "function_response",
+      name: "get_weather",
+      response: { temp: 72 },
+    })
+  })
+
+  it("parses an inlineData (image/file) part", () => {
+    const body = JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [{ inlineData: { mimeType: "image/png", data: "iVBOR…" } }],
+        },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.contents[0].parts[0]).toEqual({
+      type: "inline_data",
+      mimeType: "image/png",
+      data: "iVBOR…",
+    })
+  })
+
+  it("falls back to an 'unknown' part for an unrecognised shape", () => {
+    const body = JSON.stringify({
+      contents: [{ role: "user", parts: [{ fileData: { fileUri: "x" } }] }],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    const part = call.request.contents[0].parts[0]
+    expect(part.type).toBe("unknown")
+    expect((part as { raw: unknown }).raw).toEqual({ fileData: { fileUri: "x" } })
+  })
+
+  it("parses systemInstruction as a content block", () => {
+    const body = JSON.stringify({
+      systemInstruction: { role: "system", parts: [{ text: "be helpful" }] },
+      contents: [],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.systemInstruction).toEqual({
+      role: "user",
+      parts: [{ type: "text", text: "be helpful" }],
+    })
+  })
+
+  it("parses functionDeclarations out of the tools array (skips built-in tools)", () => {
+    const body = JSON.stringify({
+      contents: [],
+      tools: [
+        { googleSearch: {} },
+        {
+          functionDeclarations: [
+            { name: "search", description: "search the web", parameters: { type: "object" } },
+            { name: "calc" },
+          ],
+        },
+        { codeExecution: {} },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.tools).toHaveLength(2)
+    expect(call.request.tools[0]).toEqual({
+      name: "search",
+      description: "search the web",
+      parametersJsonSchema: { type: "object" },
+    })
+    // No description → null; no parameters → undefined params land as parametersJsonSchema.
+    expect(call.request.tools[1].name).toBe("calc")
+    expect(call.request.tools[1].description).toBeNull()
+  })
+
+  it("prefers parametersJsonSchema over parameters when both present", () => {
+    const body = JSON.stringify({
+      contents: [],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "f",
+              parametersJsonSchema: { type: "object", x: 1 },
+              parameters: { type: "object", x: 2 },
+            },
+          ],
+        },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.tools[0].parametersJsonSchema).toEqual({ type: "object", x: 1 })
+  })
+
+  it("parses generationConfig (sampling + thinkingConfig)", () => {
+    const body = JSON.stringify({
+      contents: [],
+      generationConfig: {
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 40,
+        candidateCount: 1,
+        maxOutputTokens: 1024,
+        thinkingConfig: { thinkingLevel: "low", thinkingBudget: 0, includeThoughts: true },
+      },
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.generationConfig).toEqual({
+      temperature: 0.7,
+      topP: 0.9,
+      topK: 40,
+      candidateCount: 1,
+      maxOutputTokens: 1024,
+      thinkingConfig: {
+        thinkingLevel: "low",
+        thinkingBudget: 0,
+        includeThoughts: true,
+      },
+    })
+  })
+
+  it("treats generationConfig as null when absent or non-object", () => {
+    const call = parseGeminiAiStudioCall(JSON.stringify({ contents: [] }), null)
+    expect(call.request.generationConfig).toBeNull()
+    const call2 = parseGeminiAiStudioCall(
+      JSON.stringify({ contents: [], generationConfig: "x" }),
+      null,
+    )
+    expect(call2.request.generationConfig).toBeNull()
+  })
+
+  it("rejects non-uint sampling fields (negatives / fractions)", () => {
+    const body = JSON.stringify({
+      contents: [],
+      generationConfig: { topK: -1, candidateCount: 1.5, maxOutputTokens: 10 },
+    })
+    const call = parseGeminiAiStudioCall(body, null)
+    expect(call.request.generationConfig?.topK).toBeNull()
+    expect(call.request.generationConfig?.candidateCount).toBeNull()
+    expect(call.request.generationConfig?.maxOutputTokens).toBe(10)
+  })
+})
+
+describe("parseGeminiAiStudioCall — response", () => {
+  it("parses candidates (index, finishReason, content with parts)", () => {
+    const body = JSON.stringify({
+      responseId: "resp-1",
+      modelVersion: "gemini-2.0-flash",
+      candidates: [
+        {
+          index: 0,
+          finishReason: "STOP",
+          content: { role: "model", parts: [{ text: "answer" }] },
+        },
+      ],
+    })
+    const call = parseGeminiAiStudioCall(null, body)
+    expect(call.response.responseId).toBe("resp-1")
+    expect(call.response.modelVersion).toBe("gemini-2.0-flash")
+    expect(call.response.candidates).toHaveLength(1)
+    expect(call.response.candidates[0]).toEqual({
+      index: 0,
+      finishReason: "STOP",
+      content: { role: "model", parts: [{ type: "text", text: "answer" }] },
+    })
+  })
+
+  it("parses usageMetadata (uint counts)", () => {
+    const body = JSON.stringify({
+      candidates: [],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 20,
+        totalTokenCount: 120,
+        cachedContentTokenCount: 30,
+        thoughtsTokenCount: 5,
+      },
+    })
+    const call = parseGeminiAiStudioCall(null, body)
+    expect(call.response.usageMetadata).toEqual({
+      promptTokenCount: 100,
+      candidatesTokenCount: 20,
+      totalTokenCount: 120,
+      cachedContentTokenCount: 30,
+      thoughtsTokenCount: 5,
+    })
+  })
+
+  it("returns the EMPTY_USAGE default when usageMetadata is absent", () => {
+    const call = parseGeminiAiStudioCall(null, JSON.stringify({ candidates: [] }))
+    expect(call.response.usageMetadata).toEqual({
+      promptTokenCount: null,
+      candidatesTokenCount: null,
+      totalTokenCount: null,
+      cachedContentTokenCount: null,
+      thoughtsTokenCount: null,
+    })
+  })
+
+  it("rejects non-uint usage counts (fractional → null)", () => {
+    const body = JSON.stringify({
+      usageMetadata: { promptTokenCount: 1.5, totalTokenCount: -3, candidatesTokenCount: 10 },
+    })
+    const call = parseGeminiAiStudioCall(null, body)
+    expect(call.response.usageMetadata.promptTokenCount).toBeNull()
+    expect(call.response.usageMetadata.totalTokenCount).toBeNull()
+    expect(call.response.usageMetadata.candidatesTokenCount).toBe(10)
+  })
+})

--- a/console/src/lib/wire-apis/shared.test.ts
+++ b/console/src/lib/wire-apis/shared.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "bun:test"
+import {
+  asArray,
+  asBoolean,
+  asNumber,
+  asObject,
+  asString,
+  asUint,
+  get,
+  parseJsonOrNull,
+  stringOrJson,
+  toJsonString,
+} from "./shared"
+
+describe("asString", () => {
+  it("returns the string for strings", () => {
+    expect(asString("hi")).toBe("hi")
+  })
+  it("returns null for non-strings (incl. number, null, undefined, object, array)", () => {
+    expect(asString(3)).toBeNull()
+    expect(asString(null)).toBeNull()
+    expect(asString(undefined)).toBeNull()
+    expect(asString({})).toBeNull()
+    expect(asString([])).toBeNull()
+    expect(asString(true)).toBeNull()
+  })
+})
+
+describe("asArray", () => {
+  it("returns the array for arrays", () => {
+    expect(asArray([1, 2])).toEqual([1, 2])
+  })
+  it("returns null for non-arrays (object, null, string, number)", () => {
+    expect(asArray({})).toBeNull()
+    expect(asArray(null)).toBeNull()
+    expect(asArray("x")).toBeNull()
+    expect(asArray(1)).toBeNull()
+  })
+})
+
+describe("asObject", () => {
+  it("returns an object for plain objects", () => {
+    expect(asObject({ a: 1 })).toEqual({ a: 1 })
+  })
+  it("returns null for arrays (arrays are objects but excluded)", () => {
+    expect(asArray([1]) // sanity: arrays are arrays
+    ).toEqual([1])
+    expect(asObject([1])).toBeNull()
+  })
+  it("returns null for null and primitives", () => {
+    expect(asObject(null)).toBeNull()
+    expect(asObject("x")).toBeNull()
+    expect(asObject(1)).toBeNull()
+    expect(asObject(true)).toBeNull()
+  })
+})
+
+describe("asNumber", () => {
+  it("returns finite numbers", () => {
+    expect(asNumber(3)).toBe(3)
+    expect(asNumber(0)).toBe(0)
+    expect(asNumber(-1.5)).toBe(-1.5)
+  })
+  it("returns null for non-numbers, NaN, and Infinity", () => {
+    expect(asNumber("3")).toBeNull()
+    expect(asNumber(null)).toBeNull()
+    expect(asNumber(undefined)).toBeNull()
+    expect(asNumber(NaN)).toBeNull()
+    expect(asNumber(Infinity)).toBeNull()
+    expect(asNumber(-Infinity)).toBeNull()
+  })
+})
+
+describe("asBoolean", () => {
+  it("returns the boolean for booleans", () => {
+    expect(asBoolean(true)).toBe(true)
+    expect(asBoolean(false)).toBe(false)
+  })
+  it("returns null for truthy/falsy non-booleans", () => {
+    expect(asBoolean(0)).toBeNull()
+    expect(asBoolean(1)).toBeNull()
+    expect(asBoolean("")).toBeNull()
+    expect(asBoolean(null)).toBeNull()
+    expect(asBoolean(undefined)).toBeNull()
+  })
+})
+
+describe("asUint", () => {
+  it("returns non-negative integers", () => {
+    expect(asUint(0)).toBe(0)
+    expect(asUint(42)).toBe(42)
+  })
+  it("returns null for negatives, non-integers, and non-numbers", () => {
+    expect(asUint(-1)).toBeNull()
+    expect(asUint(1.5)).toBeNull()
+    expect(asUint("1")).toBeNull()
+    expect(asUint(null)).toBeNull()
+    expect(asUint(Infinity)).toBeNull() // asNumber rejects Infinity first
+  })
+})
+
+describe("get", () => {
+  it("returns the value at a key for an object", () => {
+    expect(get({ a: "x" }, "a")).toBe("x")
+    expect(get({ a: 1 }, "a")).toBe(1)
+  })
+  it("returns undefined for a missing key", () => {
+    expect(get({ a: 1 }, "b")).toBeUndefined()
+  })
+  it("returns undefined for a non-object target (not throw)", () => {
+    expect(get(null, "a")).toBeUndefined()
+    expect(get("x", "a")).toBeUndefined()
+    expect(get([1], "a")).toBeUndefined()
+    expect(get(3, "a")).toBeUndefined()
+  })
+})
+
+describe("toJsonString", () => {
+  it("serializes a value with no whitespace", () => {
+    expect(toJsonString({ a: 1, b: [2, 3] })).toBe('{"a":1,"b":[2,3]}')
+  })
+  it("returns empty string for values that fail to stringify (cycles)", () => {
+    const o: any = {}
+    o.self = o
+    expect(toJsonString(o)).toBe("")
+  })
+  it("returns the string for null input (JSON.stringify(null) → 'null')", () => {
+    expect(toJsonString(null)).toBe("null")
+  })
+})
+
+describe("parseJsonOrNull", () => {
+  it("parses valid JSON", () => {
+    expect(parseJsonOrNull('{"a":1}')).toEqual({ a: 1 })
+    expect(parseJsonOrNull("[1,2,3]")).toEqual([1, 2, 3])
+  })
+  it("returns null for null / undefined input", () => {
+    expect(parseJsonOrNull(null)).toBeNull()
+    expect(parseJsonOrNull(undefined)).toBeNull()
+  })
+  it("returns null for invalid JSON", () => {
+    expect(parseJsonOrNull("not json")).toBeNull()
+    expect(parseJsonOrNull("{a:1}")).toBeNull()
+  })
+})
+
+describe("stringOrJson", () => {
+  it("returns a string verbatim", () => {
+    expect(stringOrJson("hello")).toBe("hello")
+  })
+  it("returns empty string for null / undefined", () => {
+    expect(stringOrJson(null)).toBe("")
+    expect(stringOrJson(undefined)).toBe("")
+  })
+  it("JSON-stringifies any other value (no whitespace)", () => {
+    expect(stringOrJson({ a: 1 })).toBe('{"a":1}')
+    expect(stringOrJson([1, 2])).toBe("[1,2]")
+    expect(stringOrJson(3)).toBe("3")
+    expect(stringOrJson(true)).toBe("true")
+  })
+})

--- a/console/src/stores/page-filter-specs.test.ts
+++ b/console/src/stores/page-filter-specs.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test"
+import { ALL_DIMENSIONS, getSpecForPath } from "./page-filter-specs"
+
+describe("getSpecForPath", () => {
+  it("returns no dimensions for the agent-sessions routes", () => {
+    expect(getSpecForPath("/agent-sessions")).toEqual([])
+    expect(getSpecForPath("/agent-sessions/src-1/ses-1")).toEqual([])
+  })
+
+  it("returns only serverIp for http-exchanges", () => {
+    expect(getSpecForPath("/http-exchanges")).toEqual(["serverIp"])
+  })
+
+  it("returns all dimensions for the analytics routes", () => {
+    for (const p of ["/agent-turns", "/llm-calls", "/models", "/errors", "/traffic", "/performance"]) {
+      expect(getSpecForPath(p)).toEqual(["wireApi", "model", "serverIp"])
+    }
+  })
+
+  it("returns all dimensions for the root path", () => {
+    expect(getSpecForPath("/")).toEqual(["wireApi", "model", "serverIp"])
+  })
+
+  it("returns [] for an unknown route (conservative: no filters)", () => {
+    expect(getSpecForPath("/no-such-page")).toEqual([])
+    expect(getSpecForPath("/debug/pipeline-health")).toEqual([])
+  })
+
+  it("normalizes trailing slashes before matching", () => {
+    expect(getSpecForPath("/llm-calls/")).toEqual(["wireApi", "model", "serverIp"])
+    expect(getSpecForPath("/http-exchanges//")).toEqual(["serverIp"])
+    expect(getSpecForPath("/agent-sessions/")).toEqual([])
+  })
+
+  it("normalizes a bare trailing-slash URL to '/' (root)", () => {
+    // pathname.replace(/\/+$/,"") on "" → "/", and on "/" → "" → "/"
+    expect(getSpecForPath("/")).toEqual(["wireApi", "model", "serverIp"])
+  })
+
+  it("ALL_DIMENSIONS lists the three dimension keys", () => {
+    expect(ALL_DIMENSIONS).toEqual(["wireApi", "model", "serverIp"])
+  })
+
+  it("most-specific entry wins (session detail before the sessions list)", () => {
+    // /agent-sessions/:source_id/:session_id is listed above /agent-sessions
+    // and both map to [], so this asserts ordering doesn't accidentally upgrade.
+    expect(getSpecForPath("/agent-sessions/a/b")).toEqual([])
+  })
+
+  it("does not match a prefix when end:true (longer paths fall through)", () => {
+    // /llm-calls is an exact-match entry; a deeper path isn't /llm-calls.
+    expect(getSpecForPath("/llm-calls/123")).toEqual([])
+  })
+})

--- a/console/src/stores/pipeline-health.test.ts
+++ b/console/src/stores/pipeline-health.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { resetStore } from "../../test/mocks"
+import { usePipelineHealthStore } from "./pipeline-health"
+
+const INITIAL = {
+  intervalMs: 2000,
+  selectedPipeline: null,
+  tableGroupFilter: "all",
+  tableOnlyWarn: false,
+}
+
+afterEach(() => resetStore(usePipelineHealthStore, INITIAL))
+
+describe("usePipelineHealthStore", () => {
+  it("starts with the documented defaults", () => {
+    const s = usePipelineHealthStore.getState()
+    expect(s.intervalMs).toBe(2000)
+    expect(s.selectedPipeline).toBeNull()
+    expect(s.tableGroupFilter).toBe("all")
+    expect(s.tableOnlyWarn).toBe(false)
+  })
+
+  it("setIntervalMs sets a number or null (null = paused)", () => {
+    usePipelineHealthStore.getState().setIntervalMs(5000)
+    expect(usePipelineHealthStore.getState().intervalMs).toBe(5000)
+    usePipelineHealthStore.getState().setIntervalMs(null)
+    expect(usePipelineHealthStore.getState().intervalMs).toBeNull()
+  })
+
+  it("setSelectedPipeline sets / clears the selection", () => {
+    usePipelineHealthStore.getState().setSelectedPipeline("capture")
+    expect(usePipelineHealthStore.getState().selectedPipeline).toBe("capture")
+    usePipelineHealthStore.getState().setSelectedPipeline(null)
+    expect(usePipelineHealthStore.getState().selectedPipeline).toBeNull()
+  })
+
+  it("setTableGroupFilter updates the chip filter", () => {
+    usePipelineHealthStore.getState().setTableGroupFilter("errors")
+    expect(usePipelineHealthStore.getState().tableGroupFilter).toBe("errors")
+  })
+
+  it("setTableOnlyWarn toggles the warn-only flag", () => {
+    usePipelineHealthStore.getState().setTableOnlyWarn(true)
+    expect(usePipelineHealthStore.getState().tableOnlyWarn).toBe(true)
+    usePipelineHealthStore.getState().setTableOnlyWarn(false)
+    expect(usePipelineHealthStore.getState().tableOnlyWarn).toBe(false)
+  })
+})

--- a/console/src/stores/sidebar.test.ts
+++ b/console/src/stores/sidebar.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { resetStore } from "../../test/mocks"
+import { useSidebarStore } from "./sidebar"
+
+afterEach(() => resetStore(useSidebarStore, { expanded: false }))
+
+describe("useSidebarStore", () => {
+  it("starts collapsed", () => {
+    expect(useSidebarStore.getState().expanded).toBe(false)
+  })
+
+  it("toggle flips expanded", () => {
+    useSidebarStore.getState().toggle()
+    expect(useSidebarStore.getState().expanded).toBe(true)
+    useSidebarStore.getState().toggle()
+    expect(useSidebarStore.getState().expanded).toBe(false)
+  })
+
+  it("setExpanded sets an explicit value", () => {
+    useSidebarStore.getState().setExpanded(true)
+    expect(useSidebarStore.getState().expanded).toBe(true)
+    useSidebarStore.getState().setExpanded(false)
+    expect(useSidebarStore.getState().expanded).toBe(false)
+  })
+})

--- a/console/src/stores/theme.test.ts
+++ b/console/src/stores/theme.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { resetStore } from "../../test/mocks"
+import { initTheme, useThemeStore, type ThemeMode } from "./theme"
+
+const ALL_CLASSES: ThemeMode[] = ["dark", "light", "kami"]
+
+afterEach(() => {
+  resetStore(useThemeStore, { theme: "kami" })
+  // Clear any theme classes initTheme applied to <html> so the DOM is clean
+  // for the next test / file.
+  for (const c of ALL_CLASSES) document.documentElement.classList.remove(c)
+})
+
+describe("useThemeStore", () => {
+  it("defaults to 'kami'", () => {
+    expect(useThemeStore.getState().theme).toBe("kami")
+  })
+
+  it("setTheme sets an explicit theme", () => {
+    useThemeStore.getState().setTheme("dark")
+    expect(useThemeStore.getState().theme).toBe("dark")
+    useThemeStore.getState().setTheme("light")
+    expect(useThemeStore.getState().theme).toBe("light")
+  })
+
+  it("cycleTheme walks dark → light → kami → dark …", () => {
+    useThemeStore.getState().setTheme("dark")
+    useThemeStore.getState().cycleTheme()
+    expect(useThemeStore.getState().theme).toBe("light")
+    useThemeStore.getState().cycleTheme()
+    expect(useThemeStore.getState().theme).toBe("kami")
+    useThemeStore.getState().cycleTheme()
+    expect(useThemeStore.getState().theme).toBe("dark")
+  })
+})
+
+describe("initTheme", () => {
+  it("applies the current theme class to <html> immediately", () => {
+    useThemeStore.getState().setTheme("light")
+    initTheme()
+    expect(document.documentElement.classList.contains("light")).toBe(true)
+    expect(document.documentElement.classList.contains("kami")).toBe(false)
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  })
+
+  it("re-applies the class when the theme changes (subscribe)", () => {
+    useThemeStore.getState().setTheme("dark")
+    initTheme()
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+    useThemeStore.getState().setTheme("kami")
+    // The subscription re-applies on every change.
+    expect(document.documentElement.classList.contains("kami")).toBe(true)
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  })
+
+  it("replaces the prior class (no accumulation)", () => {
+    useThemeStore.getState().setTheme("dark")
+    initTheme()
+    useThemeStore.getState().setTheme("light")
+    useThemeStore.getState().setTheme("kami")
+    const html = document.documentElement
+    const present = ALL_CLASSES.filter((c) => html.classList.contains(c))
+    expect(present).toEqual(["kami"])
+  })
+})

--- a/console/src/stores/toolbar.test.ts
+++ b/console/src/stores/toolbar.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { resetStore } from "../../test/mocks"
+import {
+  PRESET_SECONDS,
+  TOOLBAR_DEFAULTS,
+  isValidPreset,
+  useToolbarStore,
+} from "./toolbar"
+
+// Pin the clock: the store derives start/end from Date.now() for presets and
+// at creation. A fixed "now" makes setPreset / initial-state assertions exact.
+const NOW_S = 1_780_000_000 // unix seconds (mid-2026)
+let restoreNow: () => void
+
+beforeEach(() => {
+  const orig = Date.now
+  // @ts-expect-error — narrowing the global getter is intentional in tests
+  Date.now = () => NOW_S * 1000
+  restoreNow = () => {
+    Date.now = orig
+  }
+})
+
+afterEach(() => {
+  // Reset to the default-preset window so the next test starts clean.
+  resetStore(useToolbarStore, {
+    preset: "1h",
+    start: NOW_S - PRESET_SECONDS["1h"],
+    end: NOW_S,
+    filters: { wireApi: "", model: "", serverIp: "" },
+    refreshInterval: 5000,
+  })
+  restoreNow()
+})
+
+describe("PRESET_SECONDS + isValidPreset", () => {
+  it("maps each named preset to its duration in seconds", () => {
+    expect(PRESET_SECONDS["5m"]).toBe(300)
+    expect(PRESET_SECONDS["15m"]).toBe(900)
+    expect(PRESET_SECONDS["1h"]).toBe(3600)
+    expect(PRESET_SECONDS["6h"]).toBe(6 * 3600)
+    expect(PRESET_SECONDS["24h"]).toBe(24 * 3600)
+    expect(PRESET_SECONDS["7d"]).toBe(7 * 24 * 3600)
+  })
+
+  it("isValidPreset is true for every named preset + 'custom', false otherwise", () => {
+    expect(isValidPreset("5m")).toBe(true)
+    expect(isValidPreset("custom")).toBe(true)
+    expect(isValidPreset("2m")).toBe(false)
+    expect(isValidPreset("")).toBe(false)
+    expect(isValidPreset("1h ")).toBe(false)
+  })
+
+  it("isValidPreset narrows to the type (assignment check)", () => {
+    const v: string = "15m"
+    if (isValidPreset(v)) {
+      // TS: v is now TimeRangePreset
+      const _t: "5m" | "15m" | "1h" | "6h" | "24h" | "7d" | "custom" = v
+      void _t
+    }
+  })
+})
+
+describe("TOOLBAR_DEFAULTS", () => {
+  it("lists the documented defaults", () => {
+    expect(TOOLBAR_DEFAULTS.preset).toBe("1h")
+    expect(TOOLBAR_DEFAULTS.wireApi).toBe("")
+    expect(TOOLBAR_DEFAULTS.model).toBe("")
+    expect(TOOLBAR_DEFAULTS.serverIp).toBe("")
+    expect(TOOLBAR_DEFAULTS.refreshInterval).toBe(5000)
+  })
+})
+
+describe("useToolbarStore — presets", () => {
+  it("setPreset slides the window to [now-duration, now] keeping the preset", () => {
+    useToolbarStore.getState().setPreset("15m")
+    const s = useToolbarStore.getState()
+    expect(s.preset).toBe("15m")
+    expect(s.start).toBe(NOW_S - 900)
+    expect(s.end).toBe(NOW_S)
+  })
+
+  it("setCustomRange switches to 'custom' with absolute start/end and pauses auto-refresh", () => {
+    useToolbarStore.getState().setCustomRange(NOW_S - 1000, NOW_S - 10)
+    const s = useToolbarStore.getState()
+    expect(s.preset).toBe("custom")
+    expect(s.start).toBe(NOW_S - 1000)
+    expect(s.end).toBe(NOW_S - 10)
+    // Custom disables auto-refresh (refreshInterval → 0).
+    expect(s.refreshInterval).toBe(0)
+  })
+})
+
+describe("useToolbarStore — filters", () => {
+  it("setFilter updates a single dimension filter, leaving others untouched", () => {
+    useToolbarStore.getState().setFilter("wireApi", "anthropic")
+    expect(useToolbarStore.getState().filters.wireApi).toBe("anthropic")
+    expect(useToolbarStore.getState().filters.model).toBe("")
+
+    useToolbarStore.getState().setFilter("model", "claude-3")
+    expect(useToolbarStore.getState().filters.model).toBe("claude-3")
+    expect(useToolbarStore.getState().filters.wireApi).toBe("anthropic")
+  })
+
+  it("setFilter can clear a filter back to empty", () => {
+    useToolbarStore.getState().setFilter("serverIp", "10.0.0.1")
+    useToolbarStore.getState().setFilter("serverIp", "")
+    expect(useToolbarStore.getState().filters.serverIp).toBe("")
+  })
+})
+
+describe("useToolbarStore — refresh interval", () => {
+  it("setRefreshInterval updates the interval (0 = off)", () => {
+    useToolbarStore.getState().setRefreshInterval(10000)
+    expect(useToolbarStore.getState().refreshInterval).toBe(10000)
+    useToolbarStore.getState().setRefreshInterval(0)
+    expect(useToolbarStore.getState().refreshInterval).toBe(0)
+  })
+})
+
+describe("useToolbarStore — _hydrate (URL batch-set)", () => {
+  it("patches only the provided fields (partial merge)", () => {
+    useToolbarStore.getState().setPreset("15m")
+    useToolbarStore.getState()._hydrate({ refreshInterval: 1000 })
+    const s = useToolbarStore.getState()
+    expect(s.refreshInterval).toBe(1000)
+    // Unmentioned fields preserved.
+    expect(s.preset).toBe("15m")
+  })
+
+  it("replaces only the named filter keys (filter merge)", () => {
+    useToolbarStore.getState().setFilter("wireApi", "anthropic")
+    useToolbarStore.getState().setFilter("model", "claude")
+    useToolbarStore.getState()._hydrate({ filters: { model: "" } })
+    const f = useToolbarStore.getState().filters
+    expect(f.wireApi).toBe("anthropic") // preserved (not in patch)
+    expect(f.model).toBe("") // merged-over
+    expect(f.serverIp).toBe("") // untouched
+  })
+
+  it("sets preset / start / end / refreshInterval when provided", () => {
+    useToolbarStore.getState()._hydrate({
+      preset: "custom",
+      start: 100,
+      end: 200,
+      refreshInterval: 2500,
+    })
+    const s = useToolbarStore.getState()
+    expect(s.preset).toBe("custom")
+    expect(s.start).toBe(100)
+    expect(s.end).toBe(200)
+    expect(s.refreshInterval).toBe(2500)
+  })
+
+  it("leaves all fields unchanged when the patch is empty", () => {
+    // An empty patch still calls set (zustand produces a new state object),
+    // but no observable field changes.
+    const before = useToolbarStore.getState()
+    useToolbarStore.getState()._hydrate({})
+    const after = useToolbarStore.getState()
+    expect(after.preset).toBe(before.preset)
+    expect(after.start).toBe(before.start)
+    expect(after.end).toBe(before.end)
+    expect(after.refreshInterval).toBe(before.refreshInterval)
+    expect(after.filters).toEqual(before.filters)
+  })
+})

--- a/console/test/mocks.ts
+++ b/console/test/mocks.ts
@@ -12,13 +12,14 @@
  * `QueryClient` per call, and `resetStore`/`mockFetch` restore originals in an
  * `afterEach` they register themselves (Bun provides `afterEach`).
  */
-import { afterEach } from "bun:test"
+import { afterEach, expect } from "bun:test"
 import {
   QueryClient,
   QueryClientProvider,
   type QueryClientConfig,
 } from "@tanstack/react-query"
-import { render, type RenderOptions, type RenderResult } from "@testing-library/react"
+import { render, renderHook, type RenderHookOptions, type RenderHookResult, type RenderOptions, type RenderResult } from "@testing-library/react"
+import { MemoryRouter, type MemoryRouterProps } from "react-router"
 import * as React from "react"
 import type { ReactNode } from "react"
 import type { UseBoundStore } from "zustand"
@@ -90,6 +91,52 @@ export function setQueryData(
   client.setQueryData(queryKey, data)
 }
 
+/**
+ * `renderHook` already wired with a fresh `QueryClientProvider` (and, when
+ * `router` is set, a `MemoryRouter`). The single shared helper for testing the
+ * console's `useQuery`/`useInfiniteQuery`/`useMutation` hooks — the ones that
+ * pull `start`/`end` off the toolbar store and server state via TanStack Query.
+ *
+ * Each call gets an isolated `QueryClient` (default) so cache state can't leak
+ * between tests; pass `queryClient` to reuse one when you've seeded it with
+ * `setQueryData`. Pass `initialEntries` for hooks that read `useLocation` /
+ * `useSearchParams` (via `useSupportedFilterParams` or directly).
+ *
+ *   const { result } = renderHookWithProviders(() => useServices())
+ *   const { result } = renderHookWithProviders(
+ *     () => useLlmCalls({ page: 1, pageSize: 50, sortBy: "ts", sortOrder: "desc" }),
+ *     { initialEntries: ["/llm-calls?wire_api=anthropic"] },
+ *   )
+ *
+ * Returns the full `renderHook` result (`result.current`, `rerender`,
+ * `unmount`); RTL's self-registered `afterEach` unmounts between tests.
+ */
+export function renderHookWithProviders<Result>(
+  hook: () => Result,
+  opts: {
+    queryClient?: QueryClient
+    /** MemoryRouter initial entries — enables useLocation/useSearchParams. */
+    initialEntries?: MemoryRouterProps["initialEntries"]
+  } = {},
+): RenderHookResult<Result, unknown> {
+  const queryClient = opts.queryClient ?? createTestQueryClient()
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const inner = React.createElement(QueryClientProvider, { client: queryClient }, children)
+    if (opts.initialEntries) {
+      return React.createElement(MemoryRouter, { initialEntries: opts.initialEntries }, inner)
+    }
+    return inner
+  }
+  // renderHook expects a render fn taking initialProps; ours ignores them.
+  return renderHook((() => hook()) as () => Result, { wrapper } as RenderHookOptions)
+}
+
+/** Await the microtask queue (for `queueMicrotask`-batched URL updates). */
+export function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => Promise.resolve().then(() => resolve()))
+}
+
+
 // ── fetch stubbing ───────────────────────────────────────────────────────────
 
 type FetchImpl = typeof globalThis.fetch
@@ -113,6 +160,76 @@ export function mockFetch(handler: (req: RequestInfo | URL, init?: RequestInit) 
   })
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     Promise.resolve(handler(input, init))) as FetchImpl
+}
+
+/**
+ * Record every request URL the stubbed `fetch` receives into a fresh array,
+ * responding with the given `data` (wrapped in the `{code,message,data}`
+ * `ApiResponse` envelope `apiFetch` unwraps). Use this (over a single mutable
+ * `cell`) when a hook may refetch under parallel-test contention — assert on
+ * the request via `findRequest(urls, expected, endpoint)` so a stray refetch
+ * from another query (often a different endpoint / params) can't clobber the
+ * one you care about.
+ *
+ *   const urls = captureRequests({ services: [] })
+ *   const req = qsOf(findRequest(urls, { start: "1000" }, "/api/services"))
+ *   expect(req.get("end")).toBe("2000")
+ *   expect(result.current.data).toEqual({ services: [] })
+ *
+ * The array is per-call; the underlying `mockFetch` self-restores afterEach.
+ */
+export function captureRequests(data: unknown = {}): string[] {
+  const urls: string[] = []
+  mockFetch((input) => {
+    urls.push(String(input))
+    return jsonResponse({ code: 0, message: "ok", data })
+  })
+  return urls
+}
+
+/** Parse the query string of a captured request URL into URLSearchParams. */
+export function qsOf(url: string): URLSearchParams {
+  return new URLSearchParams(url.split("?")[1] ?? "")
+}
+
+/**
+ * Find a captured request whose path starts with `endpoint` (when given) and
+ * whose query params match `expected`. For each key in `expected`:
+ *   - `undefined` (or absent) → param is ignored (may be present or absent);
+ *   - `null` → the param must be ABSENT (asserts "this filter is omitted");
+ *   - a string → the param must be present with that value.
+ *
+ * Asserting on the returned request's `qsOf` (rather than a single mutable
+ * `cell.url`) is robust to parallel-test contention: a stray refetch from
+ * another query can't masquerade as this one unless it carries the exact same
+ * endpoint + params, so a real "the hook sent the wrong params" bug still
+ * fails.
+ *
+ *   const req = qsOf(findRequest(urls, { start: "1000", end: "2000", model: null }, "/api/services"))
+ *   expect(req.get("wire_api")).toBe("anthropic")
+ *
+ * Throws (via expect) when no request matches, so failures name the missing
+ * combination rather than silently passing.
+ */
+export function findRequest(
+  urls: string[],
+  expected: Record<string, string | null | undefined>,
+  endpoint?: string,
+): string {
+  const match = urls.find((u) => {
+    if (endpoint !== undefined && !u.startsWith(endpoint)) return false
+    const qs = qsOf(u)
+    return Object.entries(expected).every(([k, v]) => {
+      if (v === undefined) return true
+      if (v === null) return !qs.has(k)
+      return qs.get(k) === v
+    })
+  })
+  expect(
+    match,
+    `no captured request to ${endpoint ?? "(any)"} matched ${JSON.stringify(expected)} (got: ${JSON.stringify(urls)})`,
+  ).toBeDefined()
+  return match as string
 }
 
 /** Build a `Response` whose body is `JSON.stringify(body)` (default 200). */
@@ -143,6 +260,40 @@ export function resetStore<S extends object>(
 ): void {
   store.setState(initialState as Partial<S>, false)
 }
+
+// ── hook-test environment ────────────────────────────────────────────────────
+
+/**
+ * Pin `Date.now()` to a fixed value for the duration of a test, returning a
+ * restore fn. Many console hooks derive their window (start/end) from
+ * `Date.now()` at call time; a fixed clock makes param assertions exact.
+ *
+ *   const restore = pinClock(1_780_000_000 * 1000)
+ *   afterEach(restore)
+ */
+export function pinClock(fixedMs: number): () => void {
+  const orig = Date.now
+  // @ts-expect-error — narrowing the global getter is intentional in tests
+  Date.now = () => fixedMs
+  return () => {
+    Date.now = orig
+  }
+}
+
+/**
+ * Point the happy-dom window at a real origin. `apiFetch` builds request URLs
+ * with `new URL(path, window.location.origin)`, but happy-dom loads the page
+ * as `about:blank` → origin is the string `"null"` → `new URL(path, "null")`
+ * throws. Call once in a hook test file's `beforeAll` so every fetch-bearing
+ * hook resolves its URL. Each test file gets its own `Window` from the preload,
+ * so this is file-scoped (it doesn't leak into other files' DOMs).
+ *
+ *   beforeAll(() => setWindowOrigin("http://localhost:8080/"))
+ */
+export function setWindowOrigin(href: string): void {
+  window.location.href = href
+}
+
 
 // ── shared teardown ──────────────────────────────────────────────────────────
 

--- a/console/test/setup.ts
+++ b/console/test/setup.ts
@@ -61,3 +61,13 @@ g.IS_REACT_ACT_ENVIRONMENT = true
 // Top-level await (supported in Bun ESM) guarantees `screen` is built against
 // the live `document` rather than its throwing stub.
 await import("@testing-library/jest-dom")
+
+// ── 3. generous async wait timeout ──────────────────────────────────────────
+// `bun test` runs many files concurrently (one process per worker). Under
+// heavy parallel CPU contention a react-query fetch + React re-render can
+// take longer than RTL's 1000ms `waitFor` default to settle, producing flaky
+// timeouts that aren't real failures. Bump the shared async-utility timeout
+// so hook/component tests stay green regardless of worker load.
+const { configure } = await import("@testing-library/react")
+configure({ asyncUtilTimeout: 5000 })
+


### PR DESCRIPTION
Automated pull request for Hera task `b3d55f1b-6058-4755-8ee4-b01df5d9f55b`.

INPUT: harness from t7; gap list for `console/src/lib`, `hooks`, `stores`.
WORK: Expand `bun:test` coverage for uncovered pure modules, hook helpers, and zustand stores (reset between tests, fixed clocks where needed); mock network at boundaries.