### PR TITLE
hera: Close remaining Rust gaps until overall line coverage > 90%

### DIFF
--- a/server/h-metrics/src/model.rs
+++ b/server/h-metrics/src/model.rs
@@ -253,3 +253,187 @@ impl fmt::Display for LlmMetric {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A metric with every field zeroed — the baseline the avg methods are
+    /// exercised against by mutating the relevant `*_sum`/`*_count` pairs.
+    fn zero_metric() -> LlmMetric {
+        LlmMetric {
+            timestamp_us: 0,
+            source_id: String::new(),
+            granularity: "10s",
+            wire_api: "openai-chat".to_string(),
+            model: "gpt-4".to_string(),
+            server_ip: "10.0.0.2".to_string(),
+            call_count: 0,
+            stream_count: 0,
+            non_stream_count: 0,
+            active_calls_sum: 0,
+            active_calls_sample_count: 0,
+            active_calls_max: 0,
+            total_input_tokens: 0,
+            input_token_count: 0,
+            total_output_tokens: 0,
+            output_token_count: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            error_count: 0,
+            error_4xx_count: 0,
+            error_429_count: 0,
+            error_5xx_count: 0,
+            ttft_sum: 0.0,
+            ttft_count: 0,
+            ttft_p50: None,
+            ttft_p95: None,
+            ttft_p99: None,
+            ttft_stream_sum: 0.0,
+            ttft_stream_count: 0,
+            ttft_stream_p50: None,
+            ttft_stream_p95: None,
+            ttft_stream_p99: None,
+            ttft_nonstream_sum: 0.0,
+            ttft_nonstream_count: 0,
+            ttft_nonstream_p50: None,
+            ttft_nonstream_p95: None,
+            ttft_nonstream_p99: None,
+            e2e_sum: 0.0,
+            e2e_count: 0,
+            e2e_p50: None,
+            e2e_p95: None,
+            e2e_p99: None,
+            tpot_sum: 0.0,
+            tpot_count: 0,
+            tpot_p50: None,
+            tpot_p95: None,
+            tpot_p99: None,
+            tool_surface: None,
+        }
+    }
+
+    #[test]
+    fn active_calls_avg_zero_when_no_samples() {
+        let mut m = zero_metric();
+        assert_eq!(m.active_calls_avg(), 0.0);
+        m.active_calls_sum = 30;
+        // still zero — sampled against a zero denominator
+        assert_eq!(m.active_calls_avg(), 0.0);
+        m.active_calls_sample_count = 4;
+        assert_eq!(m.active_calls_avg(), 7.5);
+    }
+
+    #[test]
+    fn token_avgs_are_none_when_no_samples() {
+        let m = zero_metric();
+        assert_eq!(m.input_tokens_avg(), None);
+        assert_eq!(m.output_tokens_avg(), None);
+
+        let mut m = zero_metric();
+        m.total_input_tokens = 300;
+        m.input_token_count = 3;
+        assert_eq!(m.input_tokens_avg(), Some(100.0));
+        m.total_output_tokens = 50;
+        m.output_token_count = 0;
+        assert_eq!(m.output_tokens_avg(), None);
+    }
+
+    #[test]
+    fn latency_avgs_are_none_when_no_samples() {
+        assert_eq!(zero_metric().ttft_avg(), None);
+        assert_eq!(zero_metric().ttft_stream_avg(), None);
+        assert_eq!(zero_metric().ttft_nonstream_avg(), None);
+        assert_eq!(zero_metric().e2e_avg(), None);
+        assert_eq!(zero_metric().tpot_avg(), None);
+
+        let mut m = zero_metric();
+        m.ttft_sum = 150.0;
+        m.ttft_count = 3;
+        assert_eq!(m.ttft_avg(), Some(50.0));
+
+        m.ttft_stream_sum = 90.0;
+        m.ttft_stream_count = 3;
+        assert_eq!(m.ttft_stream_avg(), Some(30.0));
+
+        m.ttft_nonstream_sum = 40.0;
+        m.ttft_nonstream_count = 2;
+        assert_eq!(m.ttft_nonstream_avg(), Some(20.0));
+
+        m.e2e_sum = 800.0;
+        m.e2e_count = 4;
+        assert_eq!(m.e2e_avg(), Some(200.0));
+
+        m.tpot_sum = 12.0;
+        m.tpot_count = 4;
+        assert_eq!(m.tpot_avg(), Some(3.0));
+    }
+
+    #[test]
+    fn display_renders_header_traffic_tokens_and_latency_lines() {
+        let mut m = zero_metric();
+        // timestamp_us = 3,661,000,000 µs → 3,661 s → 01:01:01
+        // (h=(3661/3600)%24=1, m=(3661/60)%60=1, s=3661%60=1). Exercises
+        // the private format_ts helper end-to-end.
+        m.timestamp_us = 3_661_000_000;
+        m.granularity = "1m";
+        m.source_id = "src-1".to_string();
+        m.wire_api = "anthropic".to_string();
+        m.model = "claude-3".to_string();
+        m.server_ip = "10.0.0.9".to_string();
+        m.call_count = 5;
+        m.stream_count = 2;
+        m.non_stream_count = 3;
+        m.error_count = 1;
+        m.error_4xx_count = 1;
+        m.error_429_count = 0;
+        m.error_5xx_count = 0;
+        m.active_calls_sum = 10;
+        m.active_calls_sample_count = 2;
+        m.active_calls_max = 7;
+        m.total_input_tokens = 1000;
+        m.total_output_tokens = 500;
+        m.total_cache_read_input_tokens = 250;
+        m.total_cache_creation_input_tokens = 50;
+        m.ttft_sum = 200.0;
+        m.ttft_count = 2;
+        m.ttft_p50 = Some(90.0);
+        m.ttft_p95 = Some(110.0);
+        m.ttft_p99 = Some(120.0);
+        m.e2e_sum = 1000.0;
+        m.e2e_count = 2;
+        m.e2e_p50 = Some(450.0);
+        m.tpot_sum = 8.0;
+        m.tpot_count = 2;
+        m.tpot_p99 = Some(5.0);
+
+        let s = m.to_string();
+        assert!(s.contains("[Metric] 1m | 01:01:01"), "header/ts line: {s}");
+        assert!(s.contains("source=src-1"), "{s}");
+        assert!(s.contains("anthropic / claude-3 / 10.0.0.9"), "{s}");
+        assert!(s.contains("calls=5 (stream=2 non_stream=3)"), "{s}");
+        assert!(
+            s.contains("errors=1 (4xx=1 429=0 5xx=0)"),
+            "{s}"
+        );
+        assert!(s.contains("active_calls avg=5.0 max=7"), "{s}");
+        assert!(s.contains("tokens: in=1000 out=500"), "{s}");
+        assert!(s.contains("cache_read=250 cache_create=50"), "{s}");
+        // ttft avg = 100.0 → "100.0ms"; p50 from the field → "90.0ms"
+        assert!(s.contains("ttft: avg=100.0ms p50=90.0ms"), "{s}");
+        assert!(s.contains("e2e:  avg=500.0ms p50=450.0ms"), "{s}");
+        assert!(s.contains("tpot: avg=4.0ms/t"), "{s}");
+        assert!(s.contains("p99=5.0ms/t"), "{s}");
+    }
+
+    #[test]
+    fn display_emits_dashes_for_unsampled_latency_percentiles() {
+        // With all counts at zero, every avg is None and every percentile is
+        // None — the Display must render "-" placeholders (exercises the
+        // private fmt_opt's None arm).
+        let s = zero_metric().to_string();
+        assert!(s.contains("ttft: avg=- p50=- p95=- p99=-"), "{s}");
+        assert!(s.contains("e2e:  avg=- p50=- p95=- p99=-"), "{s}");
+        assert!(s.contains("tpot: avg=- p50=- p95=- p99=-"), "{s}");
+    }
+}

--- a/server/h-protocol/src/de/headers.rs
+++ b/server/h-protocol/src/de/headers.rs
@@ -277,3 +277,163 @@ impl TcpHeader {
         self.data_offset_flags[1]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    /// Cast a sized byte buffer to a `Pod` header. Mirrors the `PacketBuf::peek`
+    /// / `consume` idiom (`bytemuck::from_bytes`) used by the L2/L3/L4 decoders.
+    fn hdr<H: Pod + Copy>(bytes: &[u8]) -> H {
+        assert_eq!(bytes.len(), std::mem::size_of::<H>(), "buffer size mismatch");
+        *bytemuck::from_bytes::<H>(bytes)
+    }
+
+    #[test]
+    fn ethernet_ether_type_is_big_endian() {
+        // src/dst MACs are 6 bytes each; ethertype 0x0800 (IPv4) in big-endian.
+        let mut b = [0u8; 14];
+        b[12] = 0x08;
+        b[13] = 0x00;
+        let h = hdr::<EthernetHeader>(&b);
+        assert_eq!(h.ether_type(), ETHERTYPE_IPV4);
+        // 0x86DD → IPv6.
+        b[12] = 0x86;
+        b[13] = 0xDD;
+        assert_eq!(hdr::<EthernetHeader>(&b).ether_type(), ETHERTYPE_IPV6);
+    }
+
+    #[test]
+    fn vlan_ether_type_is_big_endian() {
+        let mut b = [0u8; 4];
+        b[2] = 0x81;
+        b[3] = 0x00;
+        assert_eq!(hdr::<VlanHeader>(&b).ether_type(), ETHERTYPE_VLAN);
+    }
+
+    #[test]
+    fn linux_sll_protocol_is_big_endian() {
+        let mut b = [0u8; 16];
+        b[14] = 0x08;
+        b[15] = 0x00;
+        assert_eq!(hdr::<LinuxSllHeader>(&b).protocol(), ETHERTYPE_IPV4);
+    }
+
+    #[test]
+    fn linux_sll2_protocol_is_big_endian() {
+        let mut b = [0u8; 20];
+        b[0] = 0x86;
+        b[1] = 0xDD;
+        assert_eq!(hdr::<LinuxSll2Header>(&b).protocol(), ETHERTYPE_IPV6);
+    }
+
+    #[test]
+    fn null_header_af_family_is_native_endian() {
+        // AF_INET = 2 in host byte order (the `from_ne_bytes` accessor).
+        let b: [u8; 4] = (AF_INET as u32).to_ne_bytes();
+        assert_eq!(hdr::<NullHeader>(&b).af_family(), AF_INET);
+    }
+
+    #[test]
+    fn mpls_bottom_of_stack_detects_s_bit() {
+        // S bit is the LSB of the third byte.
+        let mut b = [0u8; 4];
+        // bottom-of-stack clear
+        assert!(!hdr::<MplsHeader>(&b).bottom_of_stack());
+        // set the S bit
+        b[2] = 0x01;
+        assert!(hdr::<MplsHeader>(&b).bottom_of_stack());
+        // other bits in byte 2 do not flip the S bit
+        b[2] = 0xFE;
+        assert!(!hdr::<MplsHeader>(&b).bottom_of_stack());
+        b[2] = 0xFF;
+        assert!(hdr::<MplsHeader>(&b).bottom_of_stack());
+    }
+
+    #[test]
+    fn ipv4_accessors() {
+        // ver_ihl = 0x45 (version 4, IHL 5 → 20 bytes), proto TCP (6),
+        // total_length = 0x0040 (big-endian), src/dst 10.0.0.1 / 10.0.0.2.
+        let mut b = [0u8; 20];
+        b[0] = 0x45; // ver=4, ihl=5
+        b[9] = IP_PROTO_TCP;
+        b[2] = 0x00;
+        b[3] = 0x40; // total_length = 64
+        b[12] = 10;
+        b[13] = 0;
+        b[14] = 0;
+        b[15] = 1;
+        b[16] = 10;
+        b[17] = 0;
+        b[18] = 0;
+        b[19] = 2;
+        let h = hdr::<Ipv4Header>(&b);
+        assert_eq!(h.ihl(), 20);
+        assert_eq!(h.total_length(), 64);
+        assert_eq!(h.protocol(), IP_PROTO_TCP);
+        assert_eq!(h.src_ip(), Ipv4Addr::new(10, 0, 0, 1));
+        assert_eq!(h.dst_ip(), Ipv4Addr::new(10, 0, 0, 2));
+
+        // IHL with options (IHL=6 → 24 bytes) and a non-TCP protocol (17=UDP).
+        let mut b2 = b;
+        b2[0] = 0x46; // ver=4, ihl=6
+        b2[9] = 17;
+        let h2 = hdr::<Ipv4Header>(&b2);
+        assert_eq!(h2.ihl(), 24);
+        assert_eq!(h2.protocol(), 17);
+    }
+
+    #[test]
+    fn ipv6_accessors() {
+        let mut b = [0u8; 40];
+        // payload_length = 0x0100 (256) big-endian, next_header = 6 (TCP).
+        b[4] = 0x01;
+        b[5] = 0x00;
+        b[6] = IP_PROTO_TCP;
+        // src = ::1 (src[15] is the last byte of the 16-byte src field, at
+        // buffer index 8+15=23), dst = ::2 (dst[15] at index 24+15=39).
+        b[23] = 1;
+        b[39] = 2;
+        let h = hdr::<Ipv6Header>(&b);
+        assert_eq!(h.payload_length(), 256);
+        assert_eq!(h.next_header(), IP_PROTO_TCP);
+        assert_eq!(h.src_ip(), Ipv6Addr::LOCALHOST);
+        assert_eq!(h.dst_ip(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2));
+    }
+
+    #[test]
+    fn tcp_accessors() {
+        // src_port=0x1234, dst_port=0x0050 (80), seq=0x00000007,
+        // ack=0x00000008, data_offset=5 (→20B), flags=0x18 (PSH|ACK).
+        let mut b = [0u8; 20];
+        b[0] = 0x12;
+        b[1] = 0x34; // src_port
+        b[2] = 0x00;
+        b[3] = 0x50; // dst_port = 80
+        b[4] = 0x00;
+        b[5] = 0x00;
+        b[6] = 0x00;
+        b[7] = 0x07; // seq = 7
+        b[8] = 0x00;
+        b[9] = 0x00;
+        b[10] = 0x00;
+        b[11] = 0x08; // ack = 8
+        b[12] = 0x50; // data offset = 5 (high nibble), reserved low
+        b[13] = 0x18; // flags = PSH|ACK
+        let h = hdr::<TcpHeader>(&b);
+        assert_eq!(h.src_port(), 0x1234);
+        assert_eq!(h.dst_port(), 80);
+        assert_eq!(h.seq(), 7);
+        assert_eq!(h.ack(), 8);
+        assert_eq!(h.data_offset(), 20);
+        assert_eq!(h.flags(), 0x18);
+
+        // Data offset with options: high nibble = 8 → 32-byte header.
+        let mut b2 = b;
+        b2[12] = 0x80;
+        let h2 = hdr::<TcpHeader>(&b2);
+        assert_eq!(h2.data_offset(), 32);
+        assert_eq!(h2.flags(), 0x18); // flags byte is unchanged
+    }
+}

--- a/server/h-protocol/src/model.rs
+++ b/server/h-protocol/src/model.rs
@@ -167,3 +167,205 @@ impl std::fmt::Display for HttpParseEvent {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn fk() -> FlowKey {
+        FlowKey::new(
+            String::new(),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            1234,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            80,
+        )
+    }
+
+    fn req(headers: Vec<(&str, &str)>) -> HttpRequestData {
+        HttpRequestData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            method: "POST".to_string(),
+            uri: "/v1/chat".to_string(),
+            version: 1,
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: Bytes::new(),
+            timestamp_us: 0,
+            process: None,
+        }
+    }
+
+    fn resp(headers: Vec<(&str, &str)>) -> HttpResponseData {
+        HttpResponseData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            status: 200,
+            version: 1,
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: Bytes::new(),
+            first_byte_timestamp_us: 0,
+            complete_timestamp_us: 0,
+            process: None,
+        }
+    }
+
+    #[test]
+    fn request_header_lookup_is_case_insensitive() {
+        let r = req(vec![("Content-Type", "application/json"), ("X-Foo", "bar")]);
+        assert_eq!(r.header("content-type"), Some("application/json"));
+        assert_eq!(r.header("CONTENT-TYPE"), Some("application/json"));
+        assert_eq!(r.header("x-foo"), Some("bar"));
+        assert_eq!(r.header("missing"), None);
+        assert_eq!(r.content_type(), Some("application/json"));
+    }
+
+    #[test]
+    fn response_header_lookup_is_case_insensitive() {
+        let r = resp(vec![("Content-Type", "text/event-stream")]);
+        assert_eq!(r.header("CONTENT-TYPE"), Some("text/event-stream"));
+        assert_eq!(r.content_type(), Some("text/event-stream"));
+        assert_eq!(resp(vec![]).content_type(), None);
+    }
+
+    #[test]
+    fn set_process_stamps_content_events_and_noops_heartbeat() {
+        let proc = ProcessInfo::new(42, "node");
+
+        let mut req_ev = HttpParseEvent::HttpRequest(req(vec![]));
+        req_ev.set_process(Some(proc.clone()));
+        match &req_ev {
+            HttpParseEvent::HttpRequest(r) => assert_eq!(r.process.as_ref(), Some(&proc)),
+            _ => unreachable!(),
+        }
+
+        let mut resp_ev = HttpParseEvent::HttpResponse(resp(vec![]));
+        resp_ev.set_process(Some(proc.clone()));
+        match &resp_ev {
+            HttpParseEvent::HttpResponse(r) => assert_eq!(r.process.as_ref(), Some(&proc)),
+            _ => unreachable!(),
+        }
+
+        let mut sse_ev = HttpParseEvent::SseEvent(SseEventData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            event_type: "delta".to_string(),
+            data: "{}".to_string(),
+            timestamp_us: 0,
+            process: None,
+        });
+        sse_ev.set_process(Some(proc.clone()));
+        match &sse_ev {
+            HttpParseEvent::SseEvent(s) => assert_eq!(s.process.as_ref(), Some(&proc)),
+            _ => unreachable!(),
+        }
+
+        // Heartbeat carries no process slot — a no-op that must not panic and
+        // must leave the variant untouched.
+        let mut hb = HttpParseEvent::Heartbeat {
+            ts: 7,
+            source_id: "src".to_string(),
+        };
+        hb.set_process(Some(proc));
+        match hb {
+            HttpParseEvent::Heartbeat { ts, source_id } => {
+                assert_eq!(ts, 7);
+                assert_eq!(source_id, "src");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn set_process_clears_existing_attribution() {
+        let proc = ProcessInfo::new(1, "a");
+        let mut r = req(vec![]);
+        r.process = Some(ProcessInfo::new(99, "old"));
+        r.set_process(Some(proc.clone()));
+        assert_eq!(r.process.as_ref(), Some(&proc));
+        // Passing None clears it.
+        r.set_process(None);
+        assert!(r.process.is_none());
+    }
+
+    #[test]
+    fn display_formats_each_variant() {
+        let req_ev = HttpParseEvent::HttpRequest(req(vec![]));
+        let s = req_ev.to_string();
+        assert!(s.contains("[REQ]"), "{s}");
+        assert!(s.contains("POST"), "{s}");
+        assert!(s.contains("/v1/chat"), "{s}");
+
+        let resp_ev = HttpParseEvent::HttpResponse(resp(vec![("content-type", "text/plain")]));
+        let s = resp_ev.to_string();
+        assert!(s.contains("[RESP]"), "{s}");
+        assert!(s.contains("200"), "{s}");
+        assert!(s.contains("text/plain"), "{s}");
+        // A response with no content-type falls back to "-".
+        let s_no_ct = HttpParseEvent::HttpResponse(resp(vec![])).to_string();
+        assert!(s_no_ct.contains("[RESP]"), "{s_no_ct}");
+        assert!(s_no_ct.contains(" | -"), "{s_no_ct}");
+
+        let sse_ev = HttpParseEvent::SseEvent(SseEventData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            event_type: "content_block_delta".to_string(),
+            data: "{\"x\":1}".to_string(),
+            timestamp_us: 0,
+            process: None,
+        });
+        let s = sse_ev.to_string();
+        assert!(s.contains("[SSE]"), "{s}");
+        assert!(s.contains("content_block_delta"), "{s}");
+        assert!(s.contains("{\"x\":1}"), "{s}");
+
+        let hb = HttpParseEvent::Heartbeat {
+            ts: 1_700_000_000_000_000,
+            source_id: "src1".to_string(),
+        };
+        let s = hb.to_string();
+        assert!(s.contains("[HB]"), "{s}");
+        assert!(s.contains("wall_ts_us=1700000000000000"), "{s}");
+        assert!(s.contains("source=src1"), "{s}");
+    }
+
+    #[test]
+    fn sse_display_truncates_long_data_to_80_chars() {
+        let long = "a".repeat(200);
+        let sse_ev = HttpParseEvent::SseEvent(SseEventData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            event_type: "e".to_string(),
+            data: long,
+            timestamp_us: 0,
+            process: None,
+        });
+        let s = sse_ev.to_string();
+        let preview_len = s.split('|').last().unwrap().trim().len();
+        assert_eq!(preview_len, 80, "preview must be capped at 80 chars: {s}");
+        // And a short payload is rendered in full.
+        let short_s = HttpParseEvent::SseEvent(SseEventData {
+            flow_key: fk(),
+            client_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1234),
+            server_addr: (IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 80),
+            event_type: "e".to_string(),
+            data: "hi".to_string(),
+            timestamp_us: 0,
+            process: None,
+        })
+        .to_string();
+        assert!(short_s.contains(" | hi"), "{short_s}");
+    }
+}

--- a/server/h-storage-duckdb/src/pool.rs
+++ b/server/h-storage-duckdb/src/pool.rs
@@ -130,3 +130,150 @@ impl std::ops::Deref for PooledConn {
         self.conn.as_ref().expect("conn present until drop")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `ReadPool` over `conns`, threading a fresh `FaultSet` only when
+    /// the `fault-injection` feature is on (the param is `#[cfg]`-gated on
+    /// `ReadPool::new`, so the call site must match).
+    fn pool(conns: Vec<Connection>) -> ReadPool {
+        #[cfg(feature = "fault-injection")]
+        {
+            ReadPool::new(conns, crate::fault_injection::FaultSet::new())
+        }
+        #[cfg(not(feature = "fault-injection"))]
+        {
+            ReadPool::new(conns)
+        }
+    }
+
+    /// Open an isolated in-memory DuckDB connection and stamp a single-row
+    /// sentinel table into it so the pool can tell connections apart.
+    fn conn_with_sentinel(label: &str) -> Connection {
+        let conn = Connection::open(":memory:").expect("open in-memory");
+        conn.execute(
+            &format!("CREATE TABLE sentinel AS SELECT '{label}' AS who"),
+            [],
+        )
+        .expect("create sentinel");
+        conn
+    }
+
+    /// Read the `who` column from a pooled connection's sentinel table.
+    fn who(conn: &PooledConn) -> String {
+        let mut stmt = conn.prepare("SELECT who FROM sentinel").expect("prepare");
+        let s: String = stmt.query_row([], |row| row.get(0)).expect("query_row");
+        s
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_a_usable_connection() {
+        let p = pool(vec![conn_with_sentinel("A")]);
+        let conn = p.acquire().await.expect("acquire");
+        assert_eq!(who(&conn), "A");
+    }
+
+    #[tokio::test]
+    async fn dropping_a_handle_returns_the_connection_to_the_pool() {
+        // One connection, one permit. After dropping the first acquire, the
+        // same connection must re-enter the pool and be re-acquirable.
+        let p = pool(vec![conn_with_sentinel("A")]);
+
+        let first = p.acquire().await.expect("first acquire");
+        assert_eq!(who(&first), "A");
+        drop(first);
+
+        let second = p.acquire().await.expect("second acquire (post-drop)");
+        assert_eq!(who(&second), "A");
+    }
+
+    #[tokio::test]
+    async fn acquire_round_robin_across_pool_size() {
+        // A pool of two distinct connections hands them out one at a time;
+        // after both are dropped they're available again.
+        let p = pool(vec![conn_with_sentinel("A"), conn_with_sentinel("B")]);
+
+        let h1 = p.acquire().await.expect("acquire 1");
+        let h2 = p.acquire().await.expect("acquire 2");
+        let labels = std::collections::HashSet::from([who(&h1), who(&h2)]);
+        assert_eq!(labels.len(), 2, "both distinct connections served");
+        assert!(labels.contains("A"));
+        assert!(labels.contains("B"));
+        drop(h1);
+        drop(h2);
+
+        // After releasing both, two more acquires must succeed again.
+        let _ = p.acquire().await.expect("re-acquire 1");
+        let _ = p.acquire().await.expect("re-acquire 2");
+    }
+
+    #[tokio::test]
+    async fn replace_all_swaps_in_a_new_working_set() {
+        // Start with one connection (sentinel A). replace_all swaps in a
+        // different connection (sentinel B); the next acquire must see B.
+        let p = pool(vec![conn_with_sentinel("A")]);
+
+        let pre = p.acquire().await.expect("pre-swap acquire");
+        assert_eq!(who(&pre), "A");
+        drop(pre);
+
+        p.replace_all(vec![conn_with_sentinel("B")]).expect("replace_all");
+
+        let post = p.acquire().await.expect("post-swap acquire");
+        assert_eq!(who(&post), "B");
+    }
+
+    #[tokio::test]
+    async fn in_flight_handle_drops_into_old_inner_not_new_pool() {
+        // The core `reopen_all_connections` contract: a handle taken before
+        // replace_all holds a private Arc snapshot of the *old* inner, so on
+        // drop it returns its connection to the orphaned old inner — never to
+        // the new pool. Use a size-2 pool so a fresh acquire can proceed while
+        // the stale handle still holds one permit.
+        let p = pool(vec![conn_with_sentinel("A"), conn_with_sentinel("A")]);
+
+        // Hold a handle across the swap — it still reads the old connection.
+        let in_flight = p.acquire().await.expect("in-flight acquire");
+        assert_eq!(who(&in_flight), "A");
+
+        p.replace_all(vec![conn_with_sentinel("B"), conn_with_sentinel("B")])
+            .expect("replace_all");
+
+        // One permit is still held by the stale handle, but the pool has two,
+        // so a fresh acquire proceeds and must see a *new* (B) connection.
+        let fresh = p.acquire().await.expect("fresh acquire post-swap");
+        assert_eq!(who(&fresh), "B");
+        drop(fresh);
+
+        // Dropping the stale handle returns its A connection to the orphaned
+        // old inner (freed with it) — NOT to the new pool. A subsequent
+        // acquire must still see only B, proving no stale connection re-enters
+        // circulation.
+        drop(in_flight);
+        let after = p.acquire().await.expect("acquire after stale drop");
+        assert_eq!(who(&after), "B");
+    }
+
+    #[tokio::test]
+    async fn acquire_blocks_when_pool_is_exhausted_then_resumes_on_drop() {
+        // One connection / one permit: a second concurrent acquire must wait
+        // until the first handle is dropped, then complete.
+        let p = pool(vec![conn_with_sentinel("A")]);
+        let p2 = p.clone(); // ReadPool is Clone (shares inner + semaphore)
+        let h1 = p.acquire().await.expect("first acquire");
+
+        let join = tokio::spawn(async move {
+            // Will block until h1 is dropped below.
+            let h2 = p2.acquire().await.expect("second acquire after drop");
+            who(&h2)
+        });
+        // Give the spawned task a moment to park on the semaphore.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!join.is_finished(), "second acquire must be parked");
+        drop(h1);
+        let label = join.await.expect("join");
+        assert_eq!(label, "A");
+    }
+}

--- a/server/h-storage/src/query.rs
+++ b/server/h-storage/src/query.rs
@@ -952,3 +952,72 @@ mod session_turns_cursor_tests {
         assert!(decode_session_turns_cursor("00").is_none()); // valid hex, invalid JSON
     }
 }
+
+#[cfg(test)]
+mod session_list_cursor_tests {
+    use super::*;
+
+    #[test]
+    fn session_list_cursor_roundtrip() {
+        let c = SessionListCursor {
+            last_turn_at_ms: 1_729_000_000_000,
+            source_id: "src-7".to_string(),
+            session_id: "sess-42".to_string(),
+        };
+        let encoded = encode_session_cursor(&c);
+        // Opaque hex — no base64, so every char is a hex digit.
+        assert!(
+            encoded.chars().all(|c| c.is_ascii_hexdigit()),
+            "cursor must be hex, got {encoded}",
+        );
+        let decoded = decode_session_cursor(&encoded).expect("decode");
+        assert_eq!(decoded.last_turn_at_ms, c.last_turn_at_ms);
+        assert_eq!(decoded.source_id, c.source_id);
+        assert_eq!(decoded.session_id, c.session_id);
+    }
+
+    #[test]
+    fn session_list_cursor_roundtrip_preserves_negative_timestamp_and_empty_ids() {
+        let c = SessionListCursor {
+            last_turn_at_ms: -1,
+            source_id: String::new(),
+            session_id: String::new(),
+        };
+        let encoded = encode_session_cursor(&c);
+        let decoded = decode_session_cursor(&encoded).expect("decode");
+        assert_eq!(decoded.last_turn_at_ms, -1);
+        assert!(decoded.source_id.is_empty());
+        assert!(decoded.session_id.is_empty());
+    }
+
+    #[test]
+    fn session_list_cursor_rejects_garbage() {
+        // odd length
+        assert!(decode_session_cursor("abc").is_none());
+        // non-hex digit
+        assert!(decode_session_cursor("zz").is_none());
+        // valid hex, invalid JSON
+        assert!(decode_session_cursor("00").is_none());
+        // valid hex, valid JSON, but not the expected object shape (missing keys)
+        let empty_obj_hex = hex_encode_str("{}");
+        assert!(decode_session_cursor(&empty_obj_hex).is_none());
+    }
+
+    #[test]
+    fn session_list_cursor_rejects_wrong_typed_fields() {
+        // t must be an i64 and s/k must be strings; a JSON object that has the
+        // right keys but wrong types decodes to None.
+        let bad = hex_encode_str(r#"{"t":"not-a-number","s":1,"k":true}"#);
+        assert!(decode_session_cursor(&bad).is_none());
+    }
+
+    /// Tiny local hex-encoder so the test doesn't depend on a hex crate.
+    fn hex_encode_str(s: &str) -> String {
+        let mut out = String::with_capacity(s.len() * 2);
+        for b in s.as_bytes() {
+            use std::fmt::Write;
+            let _ = write!(out, "{b:02x}");
+        }
+        out
+    }
+}


### PR DESCRIPTION
Automated pull request for Hera task `250f5eeb-1248-4b63-a52d-e475e218f8d7`.

INPUT: post-t2–t5 coverage report; residual dark files in `h-export`, `h-capture` (live/cloud-probe edges), `h-storage-duckdb`/`h-storage`, `h-metrics`, `h-pcap-extract`, and any leftover holes in strong crates.
WORK: Behavior-first unit/integration tests following existing fixture styles; remeasure after each meaningful slice; stop when **merged workspace Rust line coverage > 90%**; do not delete product code to game %; keep tests hermetic.