### PR TITLE
ci(prod): chain deploy-prod off release.yml — the release trigger never fires

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,11 +12,28 @@ name: deploy-prod
 #   release.yml (gate + build + publish) → deploy-prod (this) → prod on the release
 #
 # Security: runs ONLY on the `prod-deploy` self-hosted runner ON the prod host,
-# and only on `release: published` / manual dispatch — neither of which a fork
-# or PR can raise. The label is not shared with PR CI, so untrusted code never
-# reaches the prod host. The deploy installs the published, checksummed artifact
-# rather than building on the host.
+# and only on the triggers below — none of which a fork or PR can raise. The
+# label is not shared with PR CI, so untrusted code never reaches the prod host.
+# The deploy installs the published, checksummed artifact rather than building
+# on the host.
+#
+# WHY `workflow_run` AND NOT JUST `release: published`. release.yml publishes
+# with the default GITHUB_TOKEN, and GitHub does not start workflow runs from
+# events raised by that token — a deliberate anti-recursion rule. So a release
+# cut by our own pipeline raises `release: published` that nothing receives:
+# the release appeared, prod never moved, and no run failed to say so. Found by
+# cutting v0.7.2 and watching deploy-prod not exist. Chaining off release.yml's
+# completion is not subject to the rule, because the run being observed was
+# started by a human's tag push.
+#
+# `release: published` is KEPT for the other path: a release published by hand
+# in the UI (or by a PAT) does fire it, and should deploy. When both could fire
+# for one release, the concurrency group below serialises them and the second
+# installs the same checksummed bytes — idempotent, not a double-deploy hazard.
 on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
   release:
     types: [published]
   # Manual lever: redeploy, or pin prod to a specific (e.g. earlier) release.
@@ -39,21 +56,35 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+    # A workflow_run fires for EVERY release.yml run, including the
+    # artifacts-only workflow_dispatch one that publishes nothing, and
+    # including failed ones. Only a successful tag-push run produced a release.
+    if: >-
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')
+      )
     steps:
-      # For `release: published` this checks out the tagged tree, so the deploy
-      # script that runs is the one that shipped with the release.
-      - uses: actions/checkout@v4
-
       - name: resolve release tag
         id: pick
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            tag="${{ github.event.release.tag_name }}"
-          else
-            tag="${{ github.event.inputs.tag }}"
-          fi
+          case "${{ github.event_name }}" in
+            release)      tag="${{ github.event.release.tag_name }}" ;;
+            # For a tag push, workflow_run's head_branch IS the tag name.
+            workflow_run) tag="${{ github.event.workflow_run.head_branch }}" ;;
+            *)            tag="${{ github.event.inputs.tag }}" ;;
+          esac
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "deploying release: ${tag:-<latest>}"
+
+      # Check out the TAGGED tree, so the deploy script that runs is the one
+      # that shipped with the release. `release` sets GITHUB_SHA to the tag
+      # commit, but `workflow_run` points at the default branch — hence the
+      # explicit ref rather than a bare checkout.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pick.outputs.tag }}
 
       - name: install the release on prod + gate on health (rollback on failure)
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ the chain rather than merely reporting.
   in the workflow — but `deploy-prod.sh` refuses to install a binary whose
   `--version` disagrees with the tag, so a mismatch stops before prod.)
 
-**Production tracks releases** — `release: published` → `deploy-prod`:
+**Production tracks releases** — `release.yml` succeeds → `deploy-prod`:
 - Publishing the tag is the approval; there is no second one. deploy-prod
   downloads the release asset for the host's arch, **verifies its SHA256**,
   installs it, restarts, and gates on `/api/health` **plus a read-path smoke
@@ -158,6 +158,11 @@ the chain rather than merely reporting.
   release gate validated, at the cost of running only what the release matrix
   builds (`console`, i.e. pcap capture, not eBPF). Backing prod out of a bad
   release is `gh workflow run deploy-prod.yml -f tag=<older>`.
+- The trigger chains off release.yml's **completion**, not `release: published`.
+  A release cut by the pipeline is published with the default `GITHUB_TOKEN`,
+  and GitHub raises no workflow runs from that token's events — so the
+  `release` trigger alone leaves prod silently un-deployed. It is kept for
+  releases published by hand.
 
 **Out of band** — a **nightly longevity soak** (a timer on the staging VM) runs
 the load soak for hours, tracking RSS + on-disk DB size to catch slow leaks /

--- a/scripts/prod/README.md
+++ b/scripts/prod/README.md
@@ -1,8 +1,9 @@
 # Production deploy
 
 Production runs **releases**. Publishing a tag is what ships it: `deploy-prod`
-fires on `release: published`, installs the published artifact on the prod host,
-and gates on health plus a read-path smoke, rolling back on failure.
+fires when `release.yml` finishes a tag build, installs the published artifact
+on the prod host, and gates on health plus a read-path smoke, rolling back on
+failure.
 
 ## Chain
 
@@ -15,7 +16,7 @@ tag v* → release.yml
    │        `staging-soaked` ✅ AND `ebpf-soaked` ✅
    └─ builds + publishes the multi-arch binaries
         │
-        ▼  release: published
+        ▼  release.yml completed (success, tag push)
 deploy-prod.yml
    ├─ runs on the `prod-deploy` self-hosted runner ON the prod host
    └─ deploy-prod.sh <tag>


### PR DESCRIPTION
`deploy-prod` listened for `release: published`. It could never fire.

release.yml publishes with the default `GITHUB_TOKEN`, and GitHub deliberately
raises no workflow runs from that token's events. So for every release this
pipeline cuts, the trigger has no receiver: the release appears with its
assets, production does not move, and **nothing goes red to say so**. The
evidence of a broken deploy is the absence of a run.

Found by cutting v0.7.2 and going to look at the deploy that was not there.

## This could not have been caught before a real release

The previous change's premise — "publishing the tag is the approval, prod
tracks releases" — was not in effect as merged. Nothing in the repo could have
shown that: there was no release to raise the event, and the workflow file
itself is correct in isolation. It took a release existing.

## The fix

Chain off release.yml's **completion**. That run was started by a human's tag
push, so observing it is not subject to the rule. Same act, same meaning —
release.yml still refuses to build a tag whose commit lacks both soak statuses,
so a release still cannot exist without the evidence.

Guarded, because a `workflow_run` fires for *every* release.yml run:

| condition | rules out |
|---|---|
| `conclusion == 'success'` | a build that failed or was cancelled |
| `event == 'push'` | the artifacts-only `workflow_dispatch` run, which publishes nothing |
| `head_branch` starts with `v` | anything that is not a version tag |

`release: published` is **kept** — a release published by hand in the UI does
raise it, and should deploy. If both ever fire for one release, the existing
concurrency group serialises them and the second installs the same
checksum-verified bytes.

Checkout now needs an explicit `ref`. `release` set `GITHUB_SHA` to the tag
commit so a bare checkout was right; `workflow_run` points at the default
branch, and the deploy must run the script that shipped with the release, not
whatever is on main today.

## Verification

The negative case is testable once this is on the default branch (that is where
`workflow_run` reads the workflow from): run release.yml's artifacts-only
dispatch and confirm `deploy-prod` does **not** appear — which distinguishes
three working guards from a condition that is accidentally always true. The
positive case is the next release.

v0.7.2 itself is already on production, installed via the manual dispatch lever
this PR leaves in place: 24/24 read endpoints 200, capture clean, every drop
and error counter zero.
