### PR TITLE
soak: say whether the load gate is enforcing, because the log said it wasn't

### DIFF
--- a/scripts/staging/soak-staging.sh
+++ b/scripts/staging/soak-staging.sh
@@ -39,8 +39,8 @@
 #                          still flags relative regressions meanwhile)
 #
 # After the correctness soak passes, a deeper sustained-LOAD soak runs (steady
-# rate_pps replay; perf + reliability invariants). It is informational by
-# default — see HERON_STAGE_LOAD_ENFORCE.
+# rate_pps replay; perf + reliability invariants). Informational by default;
+# staging-soak.yml passes HERON_STAGE_LOAD_ENFORCE=1, so in CI it gates.
 #
 # Exit: 0 pass · 1 candidate regressed · 2 setup error. A tara `harness_broken`
 # (baseline itself failed → corpus/env problem, never the candidate) is logged
@@ -106,12 +106,19 @@ case "$rc" in
     # Deeper check: a sustained-load soak (steady rate_pps replay for a window),
     # asserting perf + reliability invariants — queue depth bounded, zero
     # backpressure drops, RSS growth bounded, no flush errors. Runs only after
-    # the correctness soak is green. INFORMATIONAL by default: the absolute
-    # queue/RSS thresholds still need one calibration pass on this VM's CPU, so
-    # a load regression is logged + warned but does NOT fail the deploy yet (the
-    # dual-binary baseline still flags a *relative* regression). Flip to a hard
-    # gate with HERON_STAGE_LOAD_ENFORCE=1 once calibrated.
-    echo "==> running tara LOAD soak inside the VM (informational)"
+    # the correctness soak is green. Informational until the absolute queue/RSS
+    # thresholds get a calibration pass on a given VM's CPU; the dual-binary
+    # baseline flags *relative* regressions meanwhile. HERON_STAGE_LOAD_ENFORCE=1
+    # makes it a hard gate — which is what staging-soak.yml passes.
+    #
+    # Say which of the two this run is. The line used to read "(informational)"
+    # unconditionally, so an operator reading a log from an enforcing run was
+    # told a load failure would not have blocked the deploy, when it would have.
+    if [ "${HERON_STAGE_LOAD_ENFORCE:-0}" = 1 ]; then
+      echo "==> running tara LOAD soak inside the VM (ENFORCING — a regression fails the deploy)"
+    else
+      echo "==> running tara LOAD soak inside the VM (informational — set HERON_STAGE_LOAD_ENFORCE=1 to gate)"
+    fi
     set +e
     remote "cd $RD && bash tara.sh --binary '$STAGE_BIN' --corpus '$CORPUS_VM' $base_arg --load --duration ${HERON_STAGE_LOAD_SECS:-45} --rate-pps ${HERON_STAGE_LOAD_PPS:-500} --json-out $RD/load.json"
     lrc=$?


### PR DESCRIPTION
`staging-soak.yml` passes `HERON_STAGE_LOAD_ENFORCE=1`, so a load-soak
regression on main exits 1 and fails the deploy. The banner printed directly
above it was a fixed string reading `(informational)` — written when that was
true of the default, and never revisited when CI started gating on it.

So **every enforcing run logged the opposite of what it does.**

That is worse than a stale comment. Someone reading the log of a failed deploy
would conclude the load soak could not have been the cause and go looking
elsewhere; someone auditing the gate would read the banner as evidence that the
pipeline documentation in `CLAUDE.md` overstates it.

Branch the banner on the variable, and fix the two header comments that
likewise described the default as if it were the CI behaviour.

Noticed while reading a real soak log end to end, checking the v0.7.2 gate was
not passing vacuously.
