### PR TITLE
ci(prod): record deployments again, and the sglake flag that starves the small indexes

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,6 +54,21 @@ jobs:
   deploy:
     runs-on: [self-hosted, prod-deploy]
     timeout-minutes: 20
+    # For the RECORD, not for an approval. Naming an environment is the only
+    # thing that makes GitHub log a deployment, so this is what keeps the repo's
+    # Environments panel showing which release prod is actually on. #192 dropped
+    # this line along with the approval it used to carry, and the panel has been
+    # frozen on a stale entry ever since.
+    #
+    # The `production` environment therefore carries NO protection rules. It
+    # required a reviewer back when approving here WAS the gate; #192 moved the
+    # gate to the tag — release.yml refuses to build a commit that is not both
+    # `staging-soaked` and `ebpf-soaked` — so a rule left here gates nothing and
+    # only parks the run. Parking is not free: GitHub fails a deployment left
+    # waiting 30 days, so an un-approved run turns red a month after prod
+    # already shipped, and the panel reports a failure that never ran a step.
+    # That is precisely what the 2026-06-23 run did. Do not re-add reviewers.
+    environment: production
     permissions:
       contents: read
     # A workflow_run fires for EVERY release.yml run, including the

--- a/docs/design/10-sglake.md
+++ b/docs/design/10-sglake.md
@@ -302,12 +302,51 @@ magnitude below this, and this guard is what stands in when it is disabled.
 
 ## Deployment
 
-Two daemon flags Heron cannot set:
+Three daemon flags Heron cannot set:
 
 * **`--max-hot-raw-mib 2048` or more.** The 64 MiB default seals a bucket every
   few hundred spans, and search cost scales with how many buckets a query must
   open. At 2048 MiB, 124k spans produced 12 warm buckets.
+* **`--max-hot-span-hours 6`** (default 2160 h = 90 days). Set this, or the size
+  knob above will starve the small indexes. See below — it is the one flag whose
+  omission produces a slow console rather than a large one.
 * **`--splunk-web-dir <assets>`**, only if you want Heron to manage retention.
+
+### The size knob is global, and Heron's indexes are not the same size
+
+`--max-hot-raw-mib` is per daemon, and it decides when a *hot* bucket seals.
+An inverted index (`index.tsidx`), bloom filter and time index are written when
+that seal happens — a hot bucket has none of them, only `journal.sgj` and its
+WAL. To serve a search over a hot bucket, sglogd builds an index for it in
+memory, and Heron appends every `flush_interval_ms`, so that structure is
+invalidated about as fast as it is built.
+
+`heron_bodies` carries ~200 KB events and seals every few hours on size alone,
+so nearly all of it is warm and indexed. `heron_spans` carries scalars — a
+production instance accumulated 135 MB of raw spans in three days, which reaches
+2048 MiB in about seven weeks, and 90 days of span is further still. **The
+metadata index is the one that never gets an on-disk index**, which is the
+opposite of what the bucket-count analysis above would lead you to expect.
+
+Measured against that instance, both indexes hot and unsealed, under live
+ingest:
+
+| index | hot `journal.sgj` | point lookup | `stats count` |
+|---|---|---|---|
+| `heron_traces` | 3.4 MB | 65 ms, no outliers | 82 ms |
+| `heron_spans` | 22 MB | 12 ms, **spiking to 2.2 s** | 4.2 s |
+
+Same code path and the same absent tsidx in both rows; the only variable is how
+much journal the in-memory build has to cover. At 3.4 MB the rebuild is invisible
+and at 22 MB it is the dominant cost of opening an agent turn — polling once a
+second, ~40% of lookups paid it. It is invariant in the ways that mislead: the
+same for a 1-call turn as an 85-call one, and the same whether the search window
+is the turn's own span, ±24 h, or unbounded.
+
+Keeping the hot bucket small is the fix, and only `--max-hot-span-hours` does
+that for an index whose events are small. At 6 h, `heron_spans` seals four
+buckets a day — 120 over a 30-day retention, against the hundreds of thousands
+the bucket-count guidance is about.
 
 And one property to check: sglake's `/api/v1/*` search endpoints have **no
 authentication**. Where sglogd listens is the entire access-control story for


### PR DESCRIPTION
Two unrelated fixes, both fallout from chasing why opening an agent turn felt
slow.

## 1. `deploy-prod` records a deployment again

The Environments panel has read `production — failure` since 2026-06-23, and
nothing failed. The deploy-prod run on `57ba003` named the `production`
environment, that environment required a reviewer, nobody approved, and GitHub
fails a deployment left waiting for 30 days — so it turned red on 2026-07-23, a
month after the release it was for had come and gone. No step ever ran.

\#192 then dropped `environment: production` along with the approval it carried,
on the reasoning that cutting a tag **is** the approval and `release.yml`
already refuses to build a commit that is not both `staging-soaked` and
`ebpf-soaked`. That reasoning holds. What it missed is that naming an
environment is also the only thing that makes GitHub log a deployment at all —
so prod has deployed twice since (v0.7.2, v0.7.3) without recording either, and
the panel stayed frozen on the June entry, reporting a failure for a commit that
predates both.

This names the environment again, **for the record and not for a gate**.

**Prerequisite, already applied:** the `production` environment's
required-reviewers rule has been removed — `protection_rules: []`. It had to go
*before* this merges, not after: with the rule still on, the next release parks
for 30 days and then goes red exactly as before. The comment on the new line
says so, so nobody re-adds it.

Verification is the next release — deploy-prod should leave a `success`
deployment behind and the panel should move off the June entry. Until then it
stays red, which is expected.

## 2. `--max-hot-span-hours` — the size knob is global, the indexes are not

`10-sglake.md` said to raise `--max-hot-raw-mib` to 2048 and stopped there.
That is right for `heron_bodies`, which carries ~200 KB events and seals every
few hours on size alone. It is wrong for `heron_spans`, which carries scalars:
135 MB of raw spans in three days reaches 2048 MiB in about seven weeks, and the
`--max-hot-span-hours` default is 90 days. So the **metadata** index is the one
running with no on-disk `index.tsidx` — the opposite of what the bucket-count
analysis in that same section leads you to expect.

A hot bucket has no inverted index, so sglogd builds one in memory per search,
and Heron appends every `flush_interval_ms`, invalidating it about as fast as it
is built. Measured with both indexes hot, under live ingest:

| index | hot `journal.sgj` | point lookup | `stats count` |
|---|---|---|---|
| `heron_traces` | 3.4 MB | 65 ms, no outliers | 82 ms |
| `heron_spans` | 22 MB | 12 ms, **spiking to 2.2 s** | 4.2 s |

Same code path and the same absent tsidx in both rows; the only variable is how
much journal the in-memory build has to cover. Polling once a second, ~40% of
lookups paid it, and at that point it is the dominant cost of opening an agent
turn.

The doc now names `--max-hot-span-hours 6` as a third required flag, explains
why the size knob alone cannot cover an index whose events are small, and
records what makes this easy to misdiagnose: the cost is invariant in every way
that suggests the query is fine — the same for a 1-call turn as an 85-call one,
and the same whether the search window is the turn's own span, ±24 h, or
unbounded.

---

Docs and CI only; no Rust or console code changes.